### PR TITLE
Add argument input mode

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/CliArgHelper.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/CliArgHelper.java
@@ -57,8 +57,9 @@ public class CliArgHelper {
                 .action(new StoreConstArgumentAction());
         parser.setDefault("fail-behavior", FAIL_FAST);
 
-        parser.addArgument("-c", "--cypher")
-                .help("specify a single string of cypher to execute and then exit");
+        parser.addArgument("cypher")
+                .nargs("?")
+                .help("an optional string of cypher to execute and then exit");
 
         Namespace ns = null;
         try {

--- a/cypher-shell/src/main/java/org/neo4j/shell/CliArgHelper.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/CliArgHelper.java
@@ -115,7 +115,7 @@ public class CliArgHelper {
         private String username = "";
         private String password = "";
         private FailBehavior failBehavior = FailBehavior.FAIL_FAST;
-        private String cypher = null;
+        private Optional<String> cypher = Optional.empty();
 
         public boolean getSuppressColor() {
             return suppressColor;
@@ -160,7 +160,7 @@ public class CliArgHelper {
          * Set the specified cypher string to execute
          */
         public void setCypher(@Nullable String cypher) {
-            this.cypher = cypher;
+            this.cypher = Optional.ofNullable(cypher);
         }
 
         @Nonnull
@@ -190,7 +190,7 @@ public class CliArgHelper {
 
         @Nonnull
         public Optional<String> getCypher() {
-            return Optional.ofNullable(cypher);
+            return cypher;
         }
     }
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/CliArgHelper.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/CliArgHelper.java
@@ -45,12 +45,12 @@ public class CliArgHelper {
                 .help("password to connect with");
 
         MutuallyExclusiveGroup failGroup = parser.addMutuallyExclusiveGroup();
-        failGroup.addArgument("-ff", "--fail-fast")
-                .help("exit and report failure on first error when reading from file")
+        failGroup.addArgument("--fail-fast")
+                .help("exit and report failure on first error when reading from file (this is the default behavior)")
                 .dest("fail-behavior")
                 .setConst(FAIL_FAST)
                 .action(new StoreConstArgumentAction());
-        failGroup.addArgument("-fae", "--fail-at-end")
+        failGroup.addArgument("--fail-at-end")
                 .help("exit and report failures at end of input when reading from file")
                 .dest("fail-behavior")
                 .setConst(FAIL_AT_END)

--- a/cypher-shell/src/main/java/org/neo4j/shell/CliArgHelper.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/CliArgHelper.java
@@ -6,6 +6,7 @@ import net.sourceforge.argparse4j.inf.*;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -27,7 +28,7 @@ public class CliArgHelper {
             Pattern.compile("\\s*((?<username>\\w+):(?<password>[^\\s]+)@)?(?<host>[\\d\\.\\w]+)?(:(?<port>\\d+))?\\s*");
 
     @Nonnull
-    public static CliArgs parse(@Nonnull final String[] args) {
+    public static CliArgs parse(@Nonnull String... args) {
         ArgumentParser parser = ArgumentParsers.newArgumentParser("neo4j-shell")
                 .defaultHelp(true)
                 .description("A command line shell where you can execute Cypher against an instance of Neo4j");
@@ -55,6 +56,9 @@ public class CliArgHelper {
                 .setConst(FAIL_AT_END)
                 .action(new StoreConstArgumentAction());
         parser.setDefault("fail-behavior", FAIL_FAST);
+
+        parser.addArgument("-c", "--cypher")
+                .help("specify a single string of cypher to execute and then exit");
 
         Namespace ns = null;
         try {
@@ -95,6 +99,8 @@ public class CliArgHelper {
         }
 
         // Other arguments
+        // cypher string might not be given, represented by null
+        cliArgs.setCypher(ns.getString("cypher"));
         // Fail behavior as sensible default and returns a proper type
         cliArgs.setFailBehavior(ns.get("fail-behavior"));
 
@@ -109,6 +115,7 @@ public class CliArgHelper {
         private String username = "";
         private String password = "";
         private FailBehavior failBehavior = FailBehavior.FAIL_FAST;
+        private String cypher = null;
 
         public boolean getSuppressColor() {
             return suppressColor;
@@ -149,6 +156,12 @@ public class CliArgHelper {
             this.failBehavior = failBehavior;
         }
 
+        /**
+         * Set the specified cypher string to execute
+         */
+        public void setCypher(@Nullable String cypher) {
+            this.cypher = cypher;
+        }
 
         @Nonnull
         public String getHost() {

--- a/cypher-shell/src/main/java/org/neo4j/shell/CliArgHelper.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/CliArgHelper.java
@@ -29,28 +29,28 @@ public class CliArgHelper {
     @Nonnull
     public static CliArgs parse(@Nonnull final String[] args) {
         ArgumentParser parser = ArgumentParsers.newArgumentParser("neo4j-shell")
-                                               .defaultHelp(true)
-                                               .description("A command line shell where you can execute Cypher against an instance of Neo4j");
+                .defaultHelp(true)
+                .description("A command line shell where you can execute Cypher against an instance of Neo4j");
 
         ArgumentGroup connGroup = parser.addArgumentGroup("connection arguments");
         connGroup.addArgument("-a", "--address")
-                .help("Address and port to connect to")
+                .help("address and port to connect to")
                 .setDefault("localhost:7687");
         connGroup.addArgument("-u", "--username")
                 .setDefault("")
-                .help("Username to connect as");
+                .help("username to connect as");
         connGroup.addArgument("-p", "--password")
                 .setDefault("")
-                .help("Password to connect with");
+                .help("password to connect with");
 
         MutuallyExclusiveGroup failGroup = parser.addMutuallyExclusiveGroup();
         failGroup.addArgument("-ff", "--fail-fast")
-                .help("Exit and report failure on first error when reading from file")
+                .help("exit and report failure on first error when reading from file")
                 .dest("fail-behavior")
                 .setConst(FAIL_FAST)
                 .action(new StoreConstArgumentAction());
         failGroup.addArgument("-fae", "--fail-at-end")
-                .help("Exit and report failures at end of input when reading from file")
+                .help("exit and report failures at end of input when reading from file")
                 .dest("fail-behavior")
                 .setConst(FAIL_AT_END)
                 .action(new StoreConstArgumentAction());

--- a/cypher-shell/src/main/java/org/neo4j/shell/CliArgHelper.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/CliArgHelper.java
@@ -142,26 +142,35 @@ public class CliArgHelper {
             password = primary == null ? fallback : primary;
         }
 
-        void setFailBehavior(FailBehavior failBehavior) {
+        /**
+         * Set the desired fail behavior
+         */
+        void setFailBehavior(@Nonnull FailBehavior failBehavior) {
             this.failBehavior = failBehavior;
         }
 
+
+        @Nonnull
         public String getHost() {
             return host;
         }
 
+        @Nonnull
         public int getPort() {
             return port;
         }
 
+        @Nonnull
         public String getUsername() {
             return username;
         }
 
+        @Nonnull
         public String getPassword() {
             return password;
         }
 
+        @Nonnull
         public FailBehavior getFailBehavior() {
             return failBehavior;
         }

--- a/cypher-shell/src/main/java/org/neo4j/shell/CliArgHelper.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/CliArgHelper.java
@@ -174,11 +174,10 @@ public class CliArgHelper {
         public FailBehavior getFailBehavior() {
             return failBehavior;
         }
-    }
 
-    public static class CliArgParsingException extends Exception {
-        public CliArgParsingException(String msg) {
-            super(msg);
+        @Nonnull
+        public Optional<String> getCypher() {
+            return Optional.ofNullable(cypher);
         }
     }
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/Shell.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/Shell.java
@@ -53,8 +53,16 @@ abstract public class Shell {
         return 1 == isatty(STDIN_FILENO);
     }
 
+    /**
+     * Get an appropriate shellrunner depending on the given arguments and if we are running in a TTY.
+     * @param cliArgs
+     * @return a ShellRunner
+     * @throws IOException
+     */
     ShellRunner getShellRunner(@Nonnull CliArgHelper.CliArgs cliArgs) throws IOException {
-        if (isInteractive()) {
+        if (cliArgs.getCypher().isPresent()) {
+            return new StringShellRunner(this, cliArgs);
+        } else if (isInteractive()) {
             return new InteractiveShellRunner(this);
         } else {
             return new NonInteractiveShellRunner(this, cliArgs);

--- a/cypher-shell/src/main/java/org/neo4j/shell/StringShellRunner.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/StringShellRunner.java
@@ -1,0 +1,40 @@
+package org.neo4j.shell;
+
+import jline.console.history.History;
+import org.neo4j.driver.v1.exceptions.ClientException;
+import org.neo4j.shell.commands.Exit;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.Optional;
+
+/**
+ * A shell runner which executes a single String and exits afterward. Any errors will throw immediately.
+ */
+public class StringShellRunner extends ShellRunner {
+    private final Shell shell;
+    private final String cypher;
+
+    public StringShellRunner(@Nonnull Shell shell, @Nonnull CliArgHelper.CliArgs cliArgs) throws IOException {
+        super();
+        this.shell = shell;
+        Optional<String> cypherString = cliArgs.getCypher();
+        if (cypherString.isPresent()) {
+            this.cypher = cypherString.get();
+        } else {
+            throw new NullPointerException("No cypher string specified");
+        }
+    }
+
+    @Override
+    public void run() throws IOException, Exit.ExitException, ClientException, CommandException {
+        shell.executeLine(cypher.trim());
+    }
+
+    @Nullable
+    @Override
+    public History getHistory() {
+        return null;
+    }
+}

--- a/cypher-shell/src/test/java/org/neo4j/shell/CliArgHelperTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/CliArgHelperTest.java
@@ -24,4 +24,11 @@ public class CliArgHelperTest {
         assertEquals("Unexpected fail-behavior", CliArgHelper.FailBehavior.FAIL_AT_END,
                 CliArgHelper.parse(asArray("--fail-at-end")).getFailBehavior());
     }
+
+    @Test
+    public void singlePositionalArgumentIsFine() {
+        String text = "Single string";
+        assertEquals("Did not parse cypher string", text,
+                CliArgHelper.parse(asArray(text)).getCypher().get());
+    }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/CliArgHelperTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/CliArgHelperTest.java
@@ -16,15 +16,11 @@ public class CliArgHelperTest {
     @Test
     public void testFailFastIsParsed() {
         assertEquals("Unexpected fail-behavior", CliArgHelper.FailBehavior.FAIL_FAST,
-                CliArgHelper.parse(asArray("-ff")).getFailBehavior());
-        assertEquals("Unexpected fail-behavior", CliArgHelper.FailBehavior.FAIL_FAST,
                 CliArgHelper.parse(asArray("--fail-fast")).getFailBehavior());
     }
 
     @Test
     public void testFailAtEndIsParsed() {
-        assertEquals("Unexpected fail-behavior", CliArgHelper.FailBehavior.FAIL_AT_END,
-                CliArgHelper.parse(asArray("-fae")).getFailBehavior());
         assertEquals("Unexpected fail-behavior", CliArgHelper.FailBehavior.FAIL_AT_END,
                 CliArgHelper.parse(asArray("--fail-at-end")).getFailBehavior());
     }

--- a/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
@@ -32,7 +32,7 @@ public class CypherShellTest {
 
     @Test
     public void specifyingACypherStringShouldGiveAStringRunner() throws IOException {
-        CliArgHelper.CliArgs cliArgs = CliArgHelper.parse("--cypher", "MATCH (n) RETURN n");
+        CliArgHelper.CliArgs cliArgs = CliArgHelper.parse("MATCH (n) RETURN n");
 
         ShellRunner shellRunner = shell.getShellRunner(cliArgs);
 

--- a/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
@@ -5,13 +5,17 @@ import org.junit.Test;
 
 import javax.annotation.Nonnull;
 
+import java.io.IOException;
+
+import static junit.framework.TestCase.fail;
+
 
 public class CypherShellTest {
-    private CypherTestShell shell;
+    private ThrowingShell shell;
 
     @Before
     public void setup() {
-        shell = new CypherTestShell();
+        shell = new ThrowingShell();
     }
 
     @Test
@@ -26,31 +30,21 @@ public class CypherShellTest {
         // If no exception was thrown, we have success
     }
 
-    class CypherTestShell extends CypherShell {
+    @Test
+    public void specifyingACypherStringShouldGiveAStringRunner() throws IOException {
+        CliArgHelper.CliArgs cliArgs = CliArgHelper.parse("--cypher", "MATCH (n) RETURN n");
 
-        CypherTestShell() {
-            super("", 1, "", "");
+        ShellRunner shellRunner = shell.getShellRunner(cliArgs);
+
+        if (!(shellRunner instanceof StringShellRunner)) {
+            fail("Expected a different runner than: " + shellRunner.getClass().getSimpleName());
         }
+    }
 
+    class ThrowingShell extends TestShell {
         @Override
         void executeCypher(@Nonnull String line) {
             throw new RuntimeException("Unexpected cypher execution");
-        }
-
-        @Override
-        public void connect(@Nonnull String host, int port,
-                            @Nonnull String username, @Nonnull String password) throws CommandException {
-            throw new RuntimeException("Test shell can't connect");
-        }
-
-        @Override
-        public void disconnect() throws CommandException {
-            throw new RuntimeException("Test shell can't disconnect");
-        }
-
-        @Override
-        boolean isConnected() {
-            return true;
         }
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/NonInteractiveShellRunnerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/NonInteractiveShellRunnerTest.java
@@ -21,7 +21,8 @@ public class NonInteractiveShellRunnerTest {
         TestShell shell = new TestShell(
                 "good1\n" +
                         "good2\n");
-        NonInteractiveShellRunner runner = new NonInteractiveShellRunner(shell, CliArgHelper.parse(asArray("-ff")));
+        NonInteractiveShellRunner runner = new NonInteractiveShellRunner(shell,
+                CliArgHelper.parse(asArray("--fail-fast")));
         runner.run();
     }
 
@@ -31,7 +32,8 @@ public class NonInteractiveShellRunnerTest {
                 "good1\n" +
                         "bad\n" +
                         "good2\n");
-        NonInteractiveShellRunner runner = new NonInteractiveShellRunner(shell, CliArgHelper.parse(asArray("-ff")));
+        NonInteractiveShellRunner runner = new NonInteractiveShellRunner(shell,
+                CliArgHelper.parse(asArray("--fail-fast")));
         try {
             runner.run();
             fail("Expected an exception to be thrown");
@@ -49,7 +51,8 @@ public class NonInteractiveShellRunnerTest {
                 "bad\n" +
                 "good2\nSuccess\n";
         TestShell shell = new TestShell(input);
-        NonInteractiveShellRunner runner = new NonInteractiveShellRunner(shell, CliArgHelper.parse(asArray("-fae")));
+        NonInteractiveShellRunner runner = new NonInteractiveShellRunner(shell,
+                CliArgHelper.parse(asArray("--fail-at-end")));
         try {
             runner.run();
             fail("Expected an exit code to be set");

--- a/cypher-shell/src/test/java/org/neo4j/shell/StringShellRunnerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/StringShellRunnerTest.java
@@ -30,7 +30,7 @@ public class StringShellRunnerTest {
     public void cypherShouldBePassedToRun() throws IOException, CommandException {
         String cypherString = "nonsense string";
         SimpleShell shell = new SimpleShell();
-        StringShellRunner runner = new StringShellRunner(shell, CliArgHelper.parse("--cypher", cypherString));
+        StringShellRunner runner = new StringShellRunner(shell, CliArgHelper.parse(cypherString));
         runner.run();
         assertEquals(cypherString, shell.cypher);
     }
@@ -38,7 +38,7 @@ public class StringShellRunnerTest {
     @Test
     public void errorsShouldThrow() throws IOException, CommandException {
         SimpleShell shell = new SimpleShell();
-        StringShellRunner runner = new StringShellRunner(shell, CliArgHelper.parse("--cypher", SimpleShell.ERROR));
+        StringShellRunner runner = new StringShellRunner(shell, CliArgHelper.parse(SimpleShell.ERROR));
         try {
             runner.run();
         } catch (ClientException e) {

--- a/cypher-shell/src/test/java/org/neo4j/shell/StringShellRunnerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/StringShellRunnerTest.java
@@ -1,0 +1,61 @@
+package org.neo4j.shell;
+
+
+import org.junit.Test;
+import org.neo4j.driver.v1.exceptions.ClientException;
+
+import javax.annotation.Nonnull;
+
+import java.io.IOException;
+
+import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+
+public class StringShellRunnerTest {
+
+    @Test
+    public void nullCypherShouldThrowException() throws IOException {
+        String cypherString = null;
+        SimpleShell shell = new SimpleShell();
+        try {
+            new StringShellRunner(shell, new CliArgHelper.CliArgs());
+            fail("Expected an exception");
+        } catch (NullPointerException e) {
+            assertEquals("No cypher string specified",
+                    e.getMessage());
+        }
+    }
+
+    @Test
+    public void cypherShouldBePassedToRun() throws IOException, CommandException {
+        String cypherString = "nonsense string";
+        SimpleShell shell = new SimpleShell();
+        StringShellRunner runner = new StringShellRunner(shell, CliArgHelper.parse("--cypher", cypherString));
+        runner.run();
+        assertEquals(cypherString, shell.cypher);
+    }
+
+    @Test
+    public void errorsShouldThrow() throws IOException, CommandException {
+        SimpleShell shell = new SimpleShell();
+        StringShellRunner runner = new StringShellRunner(shell, CliArgHelper.parse("--cypher", SimpleShell.ERROR));
+        try {
+            runner.run();
+        } catch (ClientException e) {
+            assertEquals(SimpleShell.ERROR, e.getMessage());
+        }
+    }
+
+    class SimpleShell extends TestShell {
+        static final String ERROR = "error";
+        String cypher;
+
+        @Override
+        void executeCypher(@Nonnull String cypher) {
+            if (ERROR.equals(cypher)) {
+                throw new ClientException(ERROR);
+            }
+            this.cypher = cypher;
+        }
+    }
+}

--- a/cypher-shell/src/test/java/org/neo4j/shell/TestShell.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/TestShell.java
@@ -1,0 +1,29 @@
+package org.neo4j.shell;
+
+
+import javax.annotation.Nonnull;
+
+public abstract class TestShell extends CypherShell {
+
+    TestShell() {
+        super("", 1, "", "");
+    }
+
+    abstract void executeCypher(@Nonnull final String cypher);
+
+    @Override
+    public void connect(@Nonnull String host, int port,
+                        @Nonnull String username, @Nonnull String password) throws CommandException {
+        throw new RuntimeException("Test shell can't connect");
+    }
+
+    @Override
+    public void disconnect() throws CommandException {
+        throw new RuntimeException("Test shell can't disconnect");
+    }
+
+    @Override
+    boolean isConnected() {
+        return true;
+    }
+}


### PR DESCRIPTION
New help text: `cypher-shell --help`

```
usage: neo4j-shell [-h] [-a ADDRESS] [-u USERNAME] [-p PASSWORD] [--fail-fast | --fail-at-end] [cypher]

A command line shell where you can execute Cypher against an instance of Neo4j

positional arguments:
  cypher                 an optional string of cypher to execute and then exit

optional arguments:
  -h, --help             show this help message and exit
  --fail-fast            exit and report failure on first error when reading from file (this is the default behavior)
  --fail-at-end          exit and report failures at end of input when reading from file

connection arguments:
  -a ADDRESS, --address ADDRESS
                         address and port to connect to (default: localhost:7687)
  -u USERNAME, --username USERNAME
                         username to connect as (default: )
  -p PASSWORD, --password PASSWORD
                         password to connect with (default: )

```

Example usage:

```sh
$ cypher-shell "CREATE (n:Person {name:'Jonas'}) RETURN n"
n
{name: "Jonas"}
```

Example error:

```sh
$ cypher-shell "MATCH (n) RETURN m"
Variable `m` not defined (line 1, column 18 (offset: 17))
"MATCH (n) RETURN m"
                  ^
```