### PR TITLE
Transaction support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ out/temp/cypher-shell/bin/cypher-shell: out dist
 	mkdir -p out/temp
 	cp -r cypher-shell/build/install/cypher-shell out/temp/cypher-shell
 
+run: dist ## Build and run cypher-shell with no arguments
+	cypher-shell/build/install/cypher-shell/bin/cypher-shell
+
 dist: ## Build and test cypher-shell
 	./gradlew clean check installDist
 

--- a/README.md
+++ b/README.md
@@ -9,3 +9,14 @@ Use `make help` to list possible tasks. But you probably want either
    which builds a runnable script and packages it up for you as: `out/neo4j-shell.zip`
 
 You can then just run the executable under the `bin/` sub-directory.
+
+## How to run, the fast way
+
+This clears any previously known neo4j hosts, starts a throw-away
+instance of neo4j, and connects to it.
+
+```sh
+rm -rf ~/.neo4j/known_hosts
+docker run --detach -p 7687:7687 -e NEO4J_AUTH=none neo4j:3.0
+make run
+```

--- a/cypher-shell/src/main/java/org/neo4j/shell/CommandHelper.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/CommandHelper.java
@@ -23,6 +23,9 @@ public class CommandHelper {
         registerCommand(new Connect(cypherShell));
         registerCommand(new Disconnect(cypherShell));
         registerCommand(new History(cypherShell));
+        registerCommand(new Begin(cypherShell));
+        registerCommand(new Commit(cypherShell));
+        registerCommand(new Rollback(cypherShell));
     }
 
     private void registerCommand(@Nonnull final Command command) throws DuplicateCommandException {

--- a/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
@@ -244,5 +244,10 @@ public class CypherShell extends Shell {
         tx.close();
         tx = null;
     }
+
+    public void rollbackTransaction() {
+        tx.failure();
+        tx.close();
+        tx = null;
     }
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
@@ -236,6 +236,13 @@ public class CypherShell extends Shell {
     }
 
     public void beginTransaction() {
-        this.tx = session.beginTransaction();
+        tx = session.beginTransaction();
+    }
+
+    public void commitTransaction() {
+        tx.success();
+        tx.close();
+        tx = null;
+    }
     }
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/commands/Begin.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/commands/Begin.java
@@ -1,0 +1,70 @@
+package org.neo4j.shell.commands;
+
+import org.neo4j.shell.Command;
+import org.neo4j.shell.CommandException;
+import org.neo4j.shell.CypherShell;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This command starts a transaction.
+ */
+public class Begin implements Command {
+    private static final String COMMAND_NAME = ":begin";
+    private final CypherShell shell;
+
+    public Begin(@Nonnull final CypherShell shell) {
+        this.shell = shell;
+    }
+
+    @Nonnull
+    @Override
+    public String getName() {
+        return COMMAND_NAME;
+    }
+
+    @Nonnull
+    @Override
+    public String getDescription() {
+        return "Open a transaction";
+    }
+
+    @Nonnull
+    @Override
+    public String getUsage() {
+        return "";
+    }
+
+    @Nonnull
+    @Override
+    public String getHelp() {
+        return "Start a transaction which will be open until combla or rollbla is called";
+    }
+
+    @Nonnull
+    @Override
+    public List<String> getAliases() {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public void execute(@Nonnull List<String> args) throws Exit.ExitException, CommandException {
+        if (!args.isEmpty()) {
+            throw new CommandException(
+                    String.format(("Too many arguments. @|bold %s|@ does not accepts any arguments"),
+                            COMMAND_NAME));
+        }
+
+        if (!shell.isConnected()) {
+            throw new CommandException("Not connected to Neo4j");
+        }
+
+        if (shell.getCurrentTransaction().isPresent()) {
+            throw new CommandException("There is already an open transaction");
+        }
+
+        shell.beginTransaction();
+    }
+}

--- a/cypher-shell/src/main/java/org/neo4j/shell/commands/Commit.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/commands/Commit.java
@@ -9,13 +9,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * This command starts a transaction.
+ * This command marks a transaction as successful and closes it.
  */
-public class Begin implements Command {
-    private static final String COMMAND_NAME = ":begin";
+public class Commit implements Command {
+    public static final String COMMAND_NAME = ":commit";
     private final CypherShell shell;
 
-    public Begin(@Nonnull final CypherShell shell) {
+    public Commit(@Nonnull final CypherShell shell) {
         this.shell = shell;
     }
 
@@ -28,7 +28,7 @@ public class Begin implements Command {
     @Nonnull
     @Override
     public String getDescription() {
-        return "Open a transaction";
+        return "Commit the currently open transaction";
     }
 
     @Nonnull
@@ -40,8 +40,7 @@ public class Begin implements Command {
     @Nonnull
     @Override
     public String getHelp() {
-        return String.format("Start a transaction which will remain open until %s or rollbla is called",
-                Commit.COMMAND_NAME);
+        return "Commits and closes the currently open transaction";
     }
 
     @Nonnull
@@ -62,10 +61,10 @@ public class Begin implements Command {
             throw new CommandException("Not connected to Neo4j");
         }
 
-        if (shell.getCurrentTransaction().isPresent()) {
-            throw new CommandException("There is already an open transaction");
+        if (!shell.getCurrentTransaction().isPresent()) {
+            throw new CommandException("There is no open transaction to commit");
         }
 
-        shell.beginTransaction();
+        shell.commitTransaction();
     }
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/commands/Disconnect.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/commands/Disconnect.java
@@ -52,6 +52,12 @@ public class Disconnect implements Command {
 
     @Override
     public void execute(@Nonnull List<String> args) throws Exit.ExitException, CommandException {
+        if (!args.isEmpty()) {
+            throw new CommandException(
+                    String.format(("Too many arguments. @|bold %s|@ does not accept any arguments"),
+                            COMMAND_NAME));
+        }
+
         shell.disconnect();
         shell.printOut("Disconnected");
     }

--- a/cypher-shell/src/main/java/org/neo4j/shell/commands/Exit.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/commands/Exit.java
@@ -1,6 +1,7 @@
 package org.neo4j.shell.commands;
 
 import org.neo4j.shell.Command;
+import org.neo4j.shell.CommandException;
 import org.neo4j.shell.CypherShell;
 
 import javax.annotation.Nonnull;
@@ -49,7 +50,13 @@ public class Exit implements Command {
     }
 
     @Override
-    public void execute(@Nonnull List<String> args) throws ExitException {
+    public void execute(@Nonnull List<String> args) throws ExitException, CommandException {
+        if (!args.isEmpty()) {
+            throw new CommandException(
+                    String.format(("Too many arguments. @|bold %s|@ does not accept any arguments"),
+                            COMMAND_NAME));
+        }
+
         shell.printOut("Exiting. Bye bye.");
 
         throw new ExitException(0);

--- a/cypher-shell/src/main/java/org/neo4j/shell/commands/Help.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/commands/Help.java
@@ -86,8 +86,17 @@ public class Help implements Command {
 
         shell.printOut("\nAvailable commands:");
 
+        // Get longest command so we can align them nicely
+        int longestCmd = 0;
         for (Command cmd: commandHelper.getAllCommands()) {
-            shell.printOut(String.format("  @|bold %s|@ %s", cmd.getName(), cmd.getDescription()));
+            if (cmd.getName().length() > longestCmd) {
+                longestCmd = cmd.getName().length();
+            }
+        }
+
+        for (Command cmd: commandHelper.getAllCommands()) {
+            shell.printOut(String.format("  @|bold %-" + longestCmd + "s|@ %s",
+                    cmd.getName(), cmd.getDescription()));
         }
 
         shell.printOut("\nFor help on a specific command type:");

--- a/cypher-shell/src/main/java/org/neo4j/shell/commands/Rollback.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/commands/Rollback.java
@@ -9,13 +9,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * This command starts a transaction.
+ * This command marks a transaction as failed and closes it.
  */
-public class Begin implements Command {
-    private static final String COMMAND_NAME = ":begin";
+public class Rollback implements Command {
+    public static final String COMMAND_NAME = ":rollback";
     private final CypherShell shell;
 
-    public Begin(@Nonnull final CypherShell shell) {
+    public Rollback(@Nonnull final CypherShell shell) {
         this.shell = shell;
     }
 
@@ -28,7 +28,7 @@ public class Begin implements Command {
     @Nonnull
     @Override
     public String getDescription() {
-        return "Open a transaction";
+        return "Rollback the currently open transaction";
     }
 
     @Nonnull
@@ -40,8 +40,7 @@ public class Begin implements Command {
     @Nonnull
     @Override
     public String getHelp() {
-        return String.format("Start a transaction which will remain open until %s or %s is called",
-                Commit.COMMAND_NAME, Rollback.COMMAND_NAME);
+        return "Rolls back and closes the currently open transaction";
     }
 
     @Nonnull
@@ -62,10 +61,10 @@ public class Begin implements Command {
             throw new CommandException("Not connected to Neo4j");
         }
 
-        if (shell.getCurrentTransaction().isPresent()) {
-            throw new CommandException("There is already an open transaction");
+        if (!shell.getCurrentTransaction().isPresent()) {
+            throw new CommandException("There is no open transaction to rollback");
         }
 
-        shell.beginTransaction();
+        shell.rollbackTransaction();
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
@@ -1,31 +1,28 @@
 package org.neo4j.shell;
 
-import org.junit.Before;
 import org.junit.Test;
+import org.neo4j.driver.v1.Transaction;
 
 import javax.annotation.Nonnull;
-
 import java.io.IOException;
+import java.util.Optional;
 
+import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.fail;
 
 
 public class CypherShellTest {
-    private ThrowingShell shell;
-
-    @Before
-    public void setup() {
-        shell = new ThrowingShell();
-    }
 
     @Test
     public void commentsShouldNotBeExecuted() throws Exception {
+        ThrowingShell shell = new ThrowingShell();
         shell.executeLine("// Hi, I'm a comment!");
         // If no exception was thrown, we have success
     }
 
     @Test
     public void emptyLinesShouldNotBeExecuted() throws Exception {
+        ThrowingShell shell = new ThrowingShell();
         shell.executeLine("");
         // If no exception was thrown, we have success
     }
@@ -34,16 +31,37 @@ public class CypherShellTest {
     public void specifyingACypherStringShouldGiveAStringRunner() throws IOException {
         CliArgHelper.CliArgs cliArgs = CliArgHelper.parse("MATCH (n) RETURN n");
 
-        ShellRunner shellRunner = shell.getShellRunner(cliArgs);
+        ShellRunner shellRunner = new TestShell().getShellRunner(cliArgs);
 
         if (!(shellRunner instanceof StringShellRunner)) {
             fail("Expected a different runner than: " + shellRunner.getClass().getSimpleName());
         }
     }
 
-    class ThrowingShell extends TestShell {
+    @Test
+    public void shouldExecuteInTransactionIfOpen() throws CommandException {
+        TestShell shell = new TestShell();
+        shell.connect();
+        shell.beginTransaction();
+
+        TestTransaction tx = null;
+        Optional<Transaction> txo = shell.getCurrentTransaction();
+        if (txo.isPresent()) {
+            tx = (TestTransaction) txo.get();
+        } else {
+            fail("No transaction");
+        }
+
+        String cypherLine = "THIS IS CYPEHR";
+
+        shell.executeCypher(cypherLine);
+
+        assertEquals("did not execute in TX correctly", cypherLine, tx.getLastCypherStatement());
+    }
+
+    private class ThrowingShell extends TestShell {
         @Override
-        void executeCypher(@Nonnull String line) {
+        protected void executeCypher(@Nonnull String line) {
             throw new RuntimeException("Unexpected cypher execution");
         }
     }

--- a/cypher-shell/src/test/java/org/neo4j/shell/StringShellRunnerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/StringShellRunnerTest.java
@@ -1,6 +1,7 @@
 package org.neo4j.shell;
 
 
+import org.junit.Before;
 import org.junit.Test;
 import org.neo4j.driver.v1.exceptions.ClientException;
 
@@ -13,10 +14,16 @@ import static org.junit.Assert.assertEquals;
 
 public class StringShellRunnerTest {
 
+    private SimpleShell shell;
+
+    @Before
+    public void setup() throws CommandException {
+        shell = new SimpleShell();
+        shell.connect();
+    }
+
     @Test
     public void nullCypherShouldThrowException() throws IOException {
-        String cypherString = null;
-        SimpleShell shell = new SimpleShell();
         try {
             new StringShellRunner(shell, new CliArgHelper.CliArgs());
             fail("Expected an exception");
@@ -29,16 +36,16 @@ public class StringShellRunnerTest {
     @Test
     public void cypherShouldBePassedToRun() throws IOException, CommandException {
         String cypherString = "nonsense string";
-        SimpleShell shell = new SimpleShell();
         StringShellRunner runner = new StringShellRunner(shell, CliArgHelper.parse(cypherString));
+
         runner.run();
         assertEquals(cypherString, shell.cypher);
     }
 
     @Test
     public void errorsShouldThrow() throws IOException, CommandException {
-        SimpleShell shell = new SimpleShell();
         StringShellRunner runner = new StringShellRunner(shell, CliArgHelper.parse(SimpleShell.ERROR));
+
         try {
             runner.run();
         } catch (ClientException e) {
@@ -51,7 +58,7 @@ public class StringShellRunnerTest {
         String cypher;
 
         @Override
-        void executeCypher(@Nonnull String cypher) {
+        protected void executeCypher(@Nonnull String cypher) {
             if (ERROR.equals(cypher)) {
                 throw new ClientException(ERROR);
             }

--- a/cypher-shell/src/test/java/org/neo4j/shell/TestSession.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/TestSession.java
@@ -1,0 +1,55 @@
+package org.neo4j.shell;
+
+import org.neo4j.driver.v1.*;
+import org.neo4j.driver.v1.types.TypeSystem;
+
+import java.util.Map;
+
+public class TestSession implements Session {
+    private boolean open = true;
+
+    @Override
+    public Transaction beginTransaction() {
+        return new TestTransaction();
+    }
+
+    @Override
+    public boolean isOpen() {
+        return open;
+    }
+
+    @Override
+    public void close() {
+        open = false;
+    }
+
+    @Override
+    public StatementResult run(String statementTemplate, Value parameters) {
+        return new TestStatementResult();
+    }
+
+    @Override
+    public StatementResult run(String statementTemplate, Map<String, Object> statementParameters) {
+        return new TestStatementResult();
+    }
+
+    @Override
+    public StatementResult run(String statementTemplate, Record statementParameters) {
+        return new TestStatementResult();
+    }
+
+    @Override
+    public StatementResult run(String statementTemplate) {
+        return new TestStatementResult();
+    }
+
+    @Override
+    public StatementResult run(Statement statement) {
+        return new TestStatementResult();
+    }
+
+    @Override
+    public TypeSystem typeSystem() {
+        return null;
+    }
+}

--- a/cypher-shell/src/test/java/org/neo4j/shell/TestShell.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/TestShell.java
@@ -3,27 +3,24 @@ package org.neo4j.shell;
 
 import javax.annotation.Nonnull;
 
-public abstract class TestShell extends CypherShell {
+public class TestShell extends CypherShell {
 
-    TestShell() {
+    public TestShell() {
         super("", 1, "", "");
     }
 
-    abstract void executeCypher(@Nonnull final String cypher);
+    public void connect() throws CommandException {
+        this.connect("bla", 99, "bob", "pass");
+    }
 
     @Override
     public void connect(@Nonnull String host, int port,
                         @Nonnull String username, @Nonnull String password) throws CommandException {
-        throw new RuntimeException("Test shell can't connect");
+        this.session = new TestSession();
     }
 
     @Override
     public void disconnect() throws CommandException {
-        throw new RuntimeException("Test shell can't disconnect");
-    }
-
-    @Override
-    boolean isConnected() {
-        return true;
+        this.session = null;
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/TestStatementResult.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/TestStatementResult.java
@@ -1,0 +1,51 @@
+package org.neo4j.shell;
+
+import org.neo4j.driver.v1.Record;
+import org.neo4j.driver.v1.StatementResult;
+import org.neo4j.driver.v1.exceptions.NoSuchRecordException;
+import org.neo4j.driver.v1.summary.ResultSummary;
+import org.neo4j.driver.v1.util.Function;
+
+import java.util.List;
+
+public class TestStatementResult implements StatementResult {
+    @Override
+    public List<String> keys() {
+        return null;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return false;
+    }
+
+    @Override
+    public Record next() {
+        return null;
+    }
+
+    @Override
+    public Record single() throws NoSuchRecordException {
+        return null;
+    }
+
+    @Override
+    public Record peek() {
+        return null;
+    }
+
+    @Override
+    public List<Record> list() {
+        return null;
+    }
+
+    @Override
+    public <T> List<T> list(Function<Record, T> mapFunction) {
+        return null;
+    }
+
+    @Override
+    public ResultSummary consume() {
+        return null;
+    }
+}

--- a/cypher-shell/src/test/java/org/neo4j/shell/TestTransaction.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/TestTransaction.java
@@ -1,0 +1,69 @@
+package org.neo4j.shell;
+
+import org.neo4j.driver.v1.*;
+import org.neo4j.driver.v1.types.TypeSystem;
+
+import java.util.Map;
+
+public class TestTransaction implements Transaction {
+
+    private String lastCypherStatement = null;
+
+    @Override
+    public void success() {
+
+    }
+
+    @Override
+    public void failure() {
+
+    }
+
+    @Override
+    public boolean isOpen() {
+        return false;
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public StatementResult run(String cypher, Value parameters) {
+        lastCypherStatement = cypher;
+        return new TestStatementResult();
+    }
+
+    @Override
+    public StatementResult run(String cypher, Map<String, Object> statementParameters) {
+        lastCypherStatement = cypher;
+        return new TestStatementResult();
+    }
+
+    @Override
+    public StatementResult run(String cypher, Record statementParameters) {
+        lastCypherStatement = cypher;
+        return new TestStatementResult();
+    }
+
+    @Override
+    public StatementResult run(String cypher) {
+        lastCypherStatement = cypher;
+        return new TestStatementResult();
+    }
+
+    @Override
+    public StatementResult run(Statement statement) {
+        return new TestStatementResult();
+    }
+
+    @Override
+    public TypeSystem typeSystem() {
+        return null;
+    }
+
+    public String getLastCypherStatement() {
+        return lastCypherStatement;
+    }
+}

--- a/cypher-shell/src/test/java/org/neo4j/shell/TestTransaction.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/TestTransaction.java
@@ -8,25 +8,27 @@ import java.util.Map;
 public class TestTransaction implements Transaction {
 
     private String lastCypherStatement = null;
+    private boolean success = false;
+    private boolean open = true;
 
     @Override
     public void success() {
-
+        this.success = true;
     }
 
     @Override
     public void failure() {
-
+        this.success = false;
     }
 
     @Override
     public boolean isOpen() {
-        return false;
+        return open;
     }
 
     @Override
     public void close() {
-
+        this.open = false;
     }
 
     @Override
@@ -65,5 +67,9 @@ public class TestTransaction implements Transaction {
 
     public String getLastCypherStatement() {
         return lastCypherStatement;
+    }
+
+    public boolean isSuccess() {
+        return success;
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/commands/BeginTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/commands/BeginTest.java
@@ -1,0 +1,71 @@
+package org.neo4j.shell.commands;
+
+
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.shell.Command;
+import org.neo4j.shell.CommandException;
+import org.neo4j.shell.TestShell;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static junit.framework.TestCase.*;
+
+public class BeginTest {
+
+    private TestShell shell;
+    private Command cmd;
+
+    @Before
+    public void setup() {
+        this.shell = new TestShell();
+        this.cmd = new Begin(shell);
+    }
+
+    @Test
+    public void shouldNotAcceptArgs() {
+        try {
+            cmd.execute(Arrays.asList("bob"));
+            fail("Should not accept args");
+        } catch (CommandException e) {
+            assertTrue("Unexepcted error", e.getMessage().startsWith("Too many arguments"));
+        }
+    }
+
+    @Test
+    public void needsToBeConnected() throws CommandException {
+        shell.disconnect();
+        try {
+            cmd.execute(new ArrayList<>());
+            fail("Should throw");
+        } catch (CommandException e) {
+            assertTrue("unexepcted error", e.getMessage().contains("Not connected"));
+        }
+    }
+
+    @Test
+    public void openTransaction() throws CommandException {
+        shell.connect();
+        assertFalse("Did not expect an open transaction here", shell.getCurrentTransaction().isPresent());
+
+        cmd.execute(new ArrayList<>());
+
+        assertTrue("Expected an open transaction", shell.getCurrentTransaction().isPresent());
+    }
+
+    @Test
+    public void nestedTransactionsAreNotSupported() throws CommandException {
+        shell.connect();
+        assertFalse("Did not expect an open transaction here", shell.getCurrentTransaction().isPresent());
+        cmd.execute(new ArrayList<>());
+        assertTrue("Expected an open transaction", shell.getCurrentTransaction().isPresent());
+
+        try {
+            cmd.execute(new ArrayList<>());
+            fail("Should throw");
+        } catch (CommandException e) {
+            assertTrue("unexpected error", e.getMessage().contains("already an open transaction"));
+        }
+    }
+}

--- a/cypher-shell/src/test/java/org/neo4j/shell/commands/CommitTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/commands/CommitTest.java
@@ -1,0 +1,75 @@
+package org.neo4j.shell.commands;
+
+
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.shell.Command;
+import org.neo4j.shell.CommandException;
+import org.neo4j.shell.TestShell;
+import org.neo4j.shell.TestTransaction;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static junit.framework.TestCase.*;
+
+public class CommitTest {
+
+    private TestShell shell;
+    private Command cmd;
+
+    @Before
+    public void setup() {
+        this.shell = new TestShell();
+        this.cmd = new Commit(shell);
+    }
+
+    @Test
+    public void shouldNotAcceptArgs() {
+        try {
+            cmd.execute(Arrays.asList("bob"));
+            fail("Should not accept args");
+        } catch (CommandException e) {
+            assertTrue("Unexepcted error", e.getMessage().startsWith("Too many arguments"));
+        }
+    }
+
+    @Test
+    public void needsToBeConnected() throws CommandException {
+        shell.disconnect();
+        try {
+            cmd.execute(new ArrayList<>());
+            fail("Should throw");
+        } catch (CommandException e) {
+            assertTrue("unexepcted error", e.getMessage().contains("Not connected"));
+        }
+    }
+
+    @Test
+    public void closeTransaction() throws CommandException {
+        shell.connect();
+        shell.beginTransaction();
+
+        assertTrue("Expected an open transaction", shell.getCurrentTransaction().isPresent());
+
+        TestTransaction tx = (TestTransaction) shell.getCurrentTransaction().get();
+
+        cmd.execute(new ArrayList<>());
+
+        assertFalse("Transaction should not still be open", tx.isOpen());
+        assertTrue("Transaction should be successful", tx.isSuccess());
+        assertFalse("Expected tx to be gone", shell.getCurrentTransaction().isPresent());
+    }
+
+    @Test
+    public void closingWhenNoTXOpenShouldThrow() throws CommandException {
+        shell.connect();
+        assertFalse("Did not expect an open transaction here", shell.getCurrentTransaction().isPresent());
+        try {
+            cmd.execute(new ArrayList<>());
+            fail("Can't commit when no tx is open!");
+        } catch (CommandException e ) {
+            assertTrue("unexpected error", e.getMessage().contains("no open transaction to commit"));
+        }
+    }
+}

--- a/cypher-shell/src/test/java/org/neo4j/shell/commands/ConnectTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/commands/ConnectTest.java
@@ -1,0 +1,35 @@
+package org.neo4j.shell.commands;
+
+
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.shell.Command;
+import org.neo4j.shell.CommandException;
+import org.neo4j.shell.TestShell;
+
+import java.util.Arrays;
+
+import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.fail;
+
+public class ConnectTest {
+
+    private TestShell shell;
+    private Command cmd;
+
+    @Before
+    public void setup() {
+        this.shell = new TestShell();
+        this.cmd = new Connect(shell);
+    }
+
+    @Test
+    public void shouldNotAcceptTooManyArgs() {
+        try {
+            cmd.execute(Arrays.asList("bob", "alice"));
+            fail("Should not accept too many args");
+        } catch (CommandException e) {
+            assertTrue("Unexepcted error", e.getMessage().startsWith("Too many arguments"));
+        }
+    }
+}

--- a/cypher-shell/src/test/java/org/neo4j/shell/commands/DisconnectTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/commands/DisconnectTest.java
@@ -1,0 +1,34 @@
+package org.neo4j.shell.commands;
+
+
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.shell.CommandException;
+import org.neo4j.shell.TestShell;
+
+import java.util.Arrays;
+
+import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.fail;
+
+public class DisconnectTest {
+
+    private TestShell shell;
+    private Disconnect cmd;
+
+    @Before
+    public void setup() {
+        this.shell = new TestShell();
+        this.cmd = new Disconnect(shell);
+    }
+
+    @Test
+    public void shouldNotAcceptArgs() {
+        try {
+            cmd.execute(Arrays.asList("bob"));
+            fail("Should not accept args");
+        } catch (CommandException e) {
+            assertTrue("Unexepcted error", e.getMessage().startsWith("Too many arguments"));
+        }
+    }
+}

--- a/cypher-shell/src/test/java/org/neo4j/shell/commands/ExitTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/commands/ExitTest.java
@@ -1,0 +1,34 @@
+package org.neo4j.shell.commands;
+
+
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.shell.CommandException;
+import org.neo4j.shell.TestShell;
+
+import java.util.Arrays;
+
+import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.fail;
+
+public class ExitTest {
+
+    private TestShell shell;
+    private Exit cmd;
+
+    @Before
+    public void setup() {
+        this.shell = new TestShell();
+        this.cmd = new Exit(shell);
+    }
+
+    @Test
+    public void shouldNotAcceptArgs() {
+        try {
+            cmd.execute(Arrays.asList("bob"));
+            fail("Should not accept args");
+        } catch (CommandException e) {
+            assertTrue("Unexepcted error", e.getMessage().startsWith("Too many arguments"));
+        }
+    }
+}

--- a/cypher-shell/src/test/java/org/neo4j/shell/commands/HelpTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/commands/HelpTest.java
@@ -1,0 +1,35 @@
+package org.neo4j.shell.commands;
+
+
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.shell.Command;
+import org.neo4j.shell.CommandException;
+import org.neo4j.shell.TestShell;
+
+import java.util.Arrays;
+
+import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.fail;
+
+public class HelpTest {
+
+    private TestShell shell;
+    private Command cmd;
+
+    @Before
+    public void setup() {
+        this.shell = new TestShell();
+        this.cmd = new Help(shell);
+    }
+
+    @Test
+    public void shouldNotAcceptTooManyArgs() {
+        try {
+            cmd.execute(Arrays.asList("bob", "alice"));
+            fail("Should not accept too many args");
+        } catch (CommandException e) {
+            assertTrue("Unexepcted error", e.getMessage().startsWith("Too many arguments"));
+        }
+    }
+}

--- a/cypher-shell/src/test/java/org/neo4j/shell/commands/HistoryTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/commands/HistoryTest.java
@@ -1,0 +1,35 @@
+package org.neo4j.shell.commands;
+
+
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.shell.Command;
+import org.neo4j.shell.CommandException;
+import org.neo4j.shell.TestShell;
+
+import java.util.Arrays;
+
+import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.fail;
+
+public class HistoryTest {
+
+    private TestShell shell;
+    private Command cmd;
+
+    @Before
+    public void setup() {
+        this.shell = new TestShell();
+        this.cmd = new History(shell);
+    }
+
+    @Test
+    public void shouldNotAcceptArgs() {
+        try {
+            cmd.execute(Arrays.asList("bob"));
+            fail("Should not accept args");
+        } catch (CommandException e) {
+            assertTrue("Unexepcted error", e.getMessage().startsWith("Too many arguments"));
+        }
+    }
+}

--- a/cypher-shell/src/test/java/org/neo4j/shell/commands/RollbackTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/commands/RollbackTest.java
@@ -1,0 +1,75 @@
+package org.neo4j.shell.commands;
+
+
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.shell.Command;
+import org.neo4j.shell.CommandException;
+import org.neo4j.shell.TestShell;
+import org.neo4j.shell.TestTransaction;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static junit.framework.TestCase.*;
+
+public class RollbackTest {
+
+    private TestShell shell;
+    private Command cmd;
+
+    @Before
+    public void setup() {
+        this.shell = new TestShell();
+        this.cmd = new Rollback(shell);
+    }
+
+    @Test
+    public void shouldNotAcceptArgs() {
+        try {
+            cmd.execute(Arrays.asList("bob"));
+            fail("Should not accept args");
+        } catch (CommandException e) {
+            assertTrue("Unexepcted error", e.getMessage().startsWith("Too many arguments"));
+        }
+    }
+
+    @Test
+    public void needsToBeConnected() throws CommandException {
+        shell.disconnect();
+        try {
+            cmd.execute(new ArrayList<>());
+            fail("Should throw");
+        } catch (CommandException e) {
+            assertTrue("unexepcted error", e.getMessage().contains("Not connected"));
+        }
+    }
+
+    @Test
+    public void rollbackTransaction() throws CommandException {
+        shell.connect();
+        shell.beginTransaction();
+
+        assertTrue("Expected an open transaction", shell.getCurrentTransaction().isPresent());
+
+        TestTransaction tx = (TestTransaction) shell.getCurrentTransaction().get();
+
+        cmd.execute(new ArrayList<>());
+
+        assertFalse("Transaction should not still be open", tx.isOpen());
+        assertFalse("Transaction should not be successful", tx.isSuccess());
+        assertFalse("Expected tx to be gone", shell.getCurrentTransaction().isPresent());
+    }
+
+    @Test
+    public void closingWhenNoTXOpenShouldThrow() throws CommandException {
+        shell.connect();
+        assertFalse("Did not expect an open transaction here", shell.getCurrentTransaction().isPresent());
+        try {
+            cmd.execute(new ArrayList<>());
+            fail("Can't commit when no tx is open!");
+        } catch (CommandException e ) {
+            assertTrue("unexpected error", e.getMessage().contains("no open transaction to rollback"));
+        }
+    }
+}


### PR DESCRIPTION
Based on #4 , only commits on Jul 7 are relevant here

Help text

```
neo4j> :help

Available commands:
  :begin      Open a transaction
  :commit     Commit the currently open transaction
  :connect    Connect to a running instance of neo4j
  :disconnect Disconnect from neo4j
  :exit       Exit the shell
  :help       Show this help message
  :history    Print a list of the last commands executed
  :rollback   Rollback the currently open transaction

For help on a specific command type:
    :help command

neo4j> :help begin

usage: :begin 

Start a transaction which will remain open until :commit or :rollback is called

neo4j> :help commit

usage: :commit 

Commits and closes the currently open transaction

neo4j> :help rollback

usage: :rollback 

Rolls back and closes the currently open transaction

```

Example session:

```
neo4j> :commit
There is no open transaction to commit
neo4j> :rollback
There is no open transaction to rollback
neo4j> :begin
neo4j> :begin
There is already an open transaction
neo4j> CREATE (n) RETURN n
n
{}
neo4j> :rollback
neo4j> :begin
neo4j> CREATE (n) RETURN n
n
{}
neo4j> :commit
neo4j> MATCH (n) RETURN n
n
{}
neo4j> 
```