### PR TITLE
Query parameters

### DIFF
--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellIntegrationTest.java
@@ -8,8 +8,6 @@ import org.neo4j.shell.Command;
 import org.neo4j.shell.CypherShell;
 import org.neo4j.shell.exception.CommandException;
 
-import java.util.ArrayList;
-
 import static junit.framework.TestCase.assertTrue;
 
 public class CypherShellIntegrationTest {
@@ -32,9 +30,9 @@ public class CypherShellIntegrationTest {
     @Test
     public void rollbackScenario() throws CommandException {
         try {
-            beginCommand.execute(new ArrayList<>());
+            beginCommand.execute("");
             shell.executeLine("CREATE (:Random)");
-            rollbackCommand.execute(new ArrayList<>());
+            rollbackCommand.execute("");
             shell.executeLine("MATCH (n) RETURN n");
         } catch (CommandException e) {
             assertTrue("unexepcted error", e.getMessage().contains("Not connected"));
@@ -44,9 +42,9 @@ public class CypherShellIntegrationTest {
     @Test
     public void commitScenario() throws CommandException {
         try {
-            beginCommand.execute(new ArrayList<>());
+            beginCommand.execute("");
             shell.executeLine("CREATE (:Person {name: \"John Smith\"})");
-            commitCommand.execute(new ArrayList<>());
+            commitCommand.execute("");
         } catch (CommandException e) {
             assertTrue("unexepcted error", e.getMessage().contains("Not connected"));
         }

--- a/cypher-shell/src/main/java/org/neo4j/shell/Command.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/Command.java
@@ -27,5 +27,5 @@ public interface Command {
     @Nonnull
     List<String> getAliases();
 
-    void execute(@Nonnull final List<String> args) throws ExitException, CommandException;
+    void execute(@Nonnull final String args) throws ExitException, CommandException;
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/CommandHelper.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/CommandHelper.java
@@ -4,7 +4,7 @@ import org.neo4j.shell.commands.*;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.*;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 /**
@@ -26,6 +26,7 @@ public class CommandHelper {
         registerCommand(new Begin(cypherShell));
         registerCommand(new Commit(cypherShell));
         registerCommand(new Rollback(cypherShell));
+        registerCommand(new Set(cypherShell));
     }
 
     private void registerCommand(@Nonnull final Command command) throws DuplicateCommandException {

--- a/cypher-shell/src/main/java/org/neo4j/shell/CommandHelper.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/CommandHelper.java
@@ -1,6 +1,8 @@
 package org.neo4j.shell;
 
 import org.neo4j.shell.commands.*;
+import org.neo4j.shell.exception.CommandException;
+import org.neo4j.shell.exception.DuplicateCommandException;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -65,9 +67,36 @@ public class CommandHelper {
         return commands.values().stream().distinct().collect(Collectors.toList());
     }
 
-    private class DuplicateCommandException extends RuntimeException {
-        public DuplicateCommandException(String s) {
-            super(s);
+    /**
+     * Split an argument string on whitespace
+     */
+    @Nonnull
+    public static String[] simpleArgParse(@Nonnull final String argString, int expectedCount,
+                                          @Nonnull final String commandName, @Nonnull final String usage)
+            throws CommandException {
+        return simpleArgParse(argString, expectedCount, expectedCount, commandName, usage);
+    }
+
+    /**
+     * Split an argument string on whitespace
+     */
+    @Nonnull
+    public static String[] simpleArgParse(@Nonnull final String argString, int minCount, int maxCount,
+                                          @Nonnull final String commandName, @Nonnull final String usage)
+            throws CommandException {
+        final String[] args;
+        if (argString.trim().isEmpty()) {
+            args = new String[] {};
+        } else {
+            args = argString.trim().split("\\s+");
         }
+
+        if (args.length < minCount || args.length > maxCount) {
+            throw new CommandException(
+                    String.format(("Incorrect number of arguments.\nusage: @|bold %s|@ %s"),
+                            commandName, usage));
+        }
+
+        return args;
     }
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/CommandHelper.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/CommandHelper.java
@@ -27,6 +27,7 @@ public class CommandHelper {
         registerCommand(new Commit(cypherShell));
         registerCommand(new Rollback(cypherShell));
         registerCommand(new Set(cypherShell));
+        registerCommand(new Env(cypherShell));
     }
 
     private void registerCommand(@Nonnull final Command command) throws DuplicateCommandException {

--- a/cypher-shell/src/main/java/org/neo4j/shell/CommandHelper.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/CommandHelper.java
@@ -30,6 +30,7 @@ public class CommandHelper {
         registerCommand(new Rollback(cypherShell));
         registerCommand(new Set(cypherShell));
         registerCommand(new Env(cypherShell));
+        registerCommand(new Unset(cypherShell));
     }
 
     private void registerCommand(@Nonnull final Command command) throws DuplicateCommandException {
@@ -93,7 +94,7 @@ public class CommandHelper {
 
         if (args.length < minCount || args.length > maxCount) {
             throw new CommandException(
-                    String.format(("Incorrect number of arguments.\nusage: @|bold %s|@ %s"),
+                    String.format("Incorrect number of arguments.\nusage: @|bold %s|@ %s",
                             commandName, usage));
         }
 

--- a/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
@@ -87,9 +87,9 @@ public class CypherShell implements Shell {
     @Override
     public void executeLine(@Nonnull final String line) throws ExitException, CommandException {
         // See if it's a shell command
-        CommandExecutable cmd = getCommandExecutable(line);
-        if (cmd != null) {
-            executeCmd(cmd);
+        Optional<CommandExecutable> cmd = getCommandExecutable(line);
+        if (cmd.isPresent()) {
+            executeCmd(cmd.get());
             return;
         }
         // Comments and empty lines have to be ignored (Bolt throws errors on "empty" lines)
@@ -136,12 +136,12 @@ public class CypherShell implements Shell {
         return session != null && session.isOpen();
     }
 
-    @Nullable
-    CommandExecutable getCommandExecutable(@Nonnull final String line) {
+    @Nonnull
+    Optional<CommandExecutable> getCommandExecutable(@Nonnull final String line) {
         String[] parts = line.trim().split("\\s");
 
         if (parts.length < 1) {
-            return null;
+            return Optional.empty();
         }
 
         String name = parts[0];
@@ -153,10 +153,10 @@ public class CypherShell implements Shell {
             for (int i = 1; i < parts.length; i++) {
                 args.add(parts[i]);
             }
-            return () -> cmd.execute(args);
+            return Optional.of(() -> cmd.execute(args));
         }
 
-        return null;
+        return Optional.empty();
     }
 
     void executeCmd(@Nonnull final CommandExecutable cmdExe) throws ExitException, CommandException {

--- a/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
@@ -39,7 +39,8 @@ public class CypherShell implements Shell {
     protected PrintStream out = System.out;
     protected PrintStream err = System.err;
 
-    protected static final String COMMENT_PREFIX = "//";
+    // Final space to catch newline
+    protected static final Pattern cmdNamePattern = Pattern.compile("^\\s*(?<name>[^\\s]+)\\b(?<args>.*)\\s*$");
     protected final CommandHelper commandHelper;
     protected final String host;
     protected final int port;
@@ -93,10 +94,6 @@ public class CypherShell implements Shell {
             executeCmd(cmd.get());
             return;
         }
-        // Comments and empty lines have to be ignored (Bolt throws errors on "empty" lines)
-        if (line.isEmpty() || line.startsWith(COMMENT_PREFIX)) {
-            return;
-        }
 
         // Else it will be parsed as Cypher, but for that we need to be connected
         if (!isConnected()) {
@@ -139,8 +136,6 @@ public class CypherShell implements Shell {
 
     @Nonnull
     Optional<CommandExecutable> getCommandExecutable(@Nonnull final String line) {
-        Pattern cmdNamePattern = Pattern.compile("^\\s*(?<name>[^\\s]+)\\b\\s*(?<args>.*)$");
-
         Matcher m = cmdNamePattern.matcher(line);
         if (!m.matches()) {
             return Optional.empty();
@@ -148,7 +143,6 @@ public class CypherShell implements Shell {
 
         String name = m.group("name");
         String args = m.group("args");
-        //String name = parts[0];
 
         Command cmd = commandHelper.getCommand(name);
 

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/InteractiveShellRunner.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/InteractiveShellRunner.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.io.IOException;
 
 import static java.lang.System.getProperty;
+import static org.neo4j.shell.BoltHelper.getSensibleMsg;
 
 /**
  * An interactive shell
@@ -82,8 +83,9 @@ public class InteractiveShellRunner extends ShellRunner {
             } catch (ExitException e) {
                 throw e;
             } catch (ClientException e) {
-                shell.printError(BoltHelper.getSensibleMsg(e));
-            } catch (CommandException e) {
+                shell.printError(getSensibleMsg(e));
+            }
+            catch (CommandException e) {
                 shell.printError(e.getMessage());
             } catch (Throwable t) {
                 // TODO: 6/21/16 Unknown errors maybe should be handled differently

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/NonInteractiveShellRunner.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/NonInteractiveShellRunner.java
@@ -13,6 +13,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
 
+import static org.neo4j.shell.BoltHelper.getSensibleMsg;
+
 /**
  * A shell runner which reads from STDIN and executes commands until completion. In case of errors, the failBehavior
  * determines if the shell exits immediately, or if it should keep trying the next commands.
@@ -54,7 +56,7 @@ public class NonInteractiveShellRunner extends ShellRunner {
             } catch (ClientException e) {
                 errorOccurred = true;
                 if (CliArgHelper.FailBehavior.FAIL_AT_END == failBehavior) {
-                    shell.printError(BoltHelper.getSensibleMsg(e));
+                    shell.printError(getSensibleMsg(e));
                 } else {
                     throw e;
                 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/NonInteractiveShellRunner.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/NonInteractiveShellRunner.java
@@ -3,7 +3,6 @@ package org.neo4j.shell.cli;
 import jline.console.ConsoleReader;
 import jline.console.history.History;
 import org.neo4j.driver.v1.exceptions.ClientException;
-import org.neo4j.shell.BoltHelper;
 import org.neo4j.shell.Shell;
 import org.neo4j.shell.ShellRunner;
 import org.neo4j.shell.exception.CommandException;
@@ -14,6 +13,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 
 import static org.neo4j.shell.BoltHelper.getSensibleMsg;
+
 
 /**
  * A shell runner which reads from STDIN and executes commands until completion. In case of errors, the failBehavior

--- a/cypher-shell/src/main/java/org/neo4j/shell/commands/Begin.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/commands/Begin.java
@@ -9,6 +9,8 @@ import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.neo4j.shell.CommandHelper.simpleArgParse;
+
 /**
  * This command starts a transaction.
  */
@@ -52,12 +54,8 @@ public class Begin implements Command {
     }
 
     @Override
-    public void execute(@Nonnull List<String> args) throws ExitException, CommandException {
-        if (!args.isEmpty()) {
-            throw new CommandException(
-                    String.format("Too many arguments. @|bold %s|@ does not accept any arguments",
-                            COMMAND_NAME));
-        }
+    public void execute(@Nonnull final String argString) throws ExitException, CommandException {
+        simpleArgParse(argString, 0, COMMAND_NAME, getUsage());
 
         if (!shell.isConnected()) {
             throw new CommandException("Not connected to Neo4j");

--- a/cypher-shell/src/main/java/org/neo4j/shell/commands/Commit.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/commands/Commit.java
@@ -9,6 +9,8 @@ import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.neo4j.shell.CommandHelper.simpleArgParse;
+
 /**
  * This command marks a transaction as successful and closes it.
  */
@@ -51,12 +53,8 @@ public class Commit implements Command {
     }
 
     @Override
-    public void execute(@Nonnull List<String> args) throws ExitException, CommandException {
-        if (!args.isEmpty()) {
-            throw new CommandException(
-                    String.format("Too many arguments. @|bold %s|@ does not accept any arguments",
-                            COMMAND_NAME));
-        }
+    public void execute(@Nonnull final String argString) throws ExitException, CommandException {
+        simpleArgParse(argString, 0, COMMAND_NAME, getUsage());
 
         if (!shell.isConnected()) {
             throw new CommandException("Not connected to Neo4j");

--- a/cypher-shell/src/main/java/org/neo4j/shell/commands/Connect.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/commands/Connect.java
@@ -11,6 +11,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 
+import static org.neo4j.shell.CommandHelper.simpleArgParse;
+
 /**
  * Command to connect to an instance of Neo4j.
  */
@@ -54,23 +56,20 @@ public class Connect implements Command {
     }
 
     @Override
-    public void execute(@Nonnull List<String> args) throws ExitException, CommandException {
+    public void execute(@Nonnull final String argString) throws ExitException, CommandException {
         // Default arguments
         String host = "localhost";
         int port = 7687;
         String username = "";
         String password = "";
 
-        if (args.size() > 1) {
-            throw new CommandException(
-                    String.format(("Too many arguments. @|bold %s|@ accepts a single optional argument.\n"
-                                    + "usage: @|bold %s|@ %s"),
-                            COMMAND_NAME, COMMAND_NAME, getUsage()));
-        } else if (args.size() == 1) {
-            Matcher m = CliArgHelper.addressArgPattern.matcher(args.get(0));
+        String[] args = simpleArgParse(argString, 0, 1, COMMAND_NAME, getUsage());
+
+        if (args.length == 1) {
+            Matcher m = CliArgHelper.addressArgPattern.matcher(args[0]);
             if (!m.matches()) {
-                throw new CommandException(String.format("Could not parse @|bold %s|@\nusage: @|bold %s|@ %s",
-                        args.get(0), COMMAND_NAME, getUsage()));
+                 throw new CommandException(String.format("Could not parse @|bold %s|@\nusage: @|bold %s|@ %s",
+                         args[0], COMMAND_NAME, getUsage()));
             }
 
             if (null != m.group("host")) {

--- a/cypher-shell/src/main/java/org/neo4j/shell/commands/Disconnect.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/commands/Disconnect.java
@@ -9,6 +9,8 @@ import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.neo4j.shell.CommandHelper.simpleArgParse;
+
 /**
  * Command to connect to an instance of Neo4j.
  */
@@ -52,12 +54,8 @@ public class Disconnect implements Command {
     }
 
     @Override
-    public void execute(@Nonnull List<String> args) throws ExitException, CommandException {
-        if (!args.isEmpty()) {
-            throw new CommandException(
-                    String.format("Too many arguments. @|bold %s|@ does not accept any arguments",
-                            COMMAND_NAME));
-        }
+    public void execute(@Nonnull final String argString) throws ExitException, CommandException {
+        simpleArgParse(argString, 0, COMMAND_NAME, getUsage());
 
         shell.disconnect();
         shell.printOut("Disconnected");

--- a/cypher-shell/src/main/java/org/neo4j/shell/commands/Env.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/commands/Env.java
@@ -1,0 +1,79 @@
+package org.neo4j.shell.commands;
+
+import org.neo4j.shell.Command;
+import org.neo4j.shell.CommandException;
+import org.neo4j.shell.CypherShell;
+
+import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * This lists all query parameters which have been set
+ */
+public class Env implements Command {
+    public static final String COMMAND_NAME = ":env";
+    private final CypherShell shell;
+
+    public Env(@Nonnull final CypherShell shell) {
+        this.shell = shell;
+    }
+
+    @Nonnull
+    @Override
+    public String getName() {
+        return COMMAND_NAME;
+    }
+
+    @Nonnull
+    @Override
+    public String getDescription() {
+        return "Prints all variables and their values";
+    }
+
+    @Nonnull
+    @Override
+    public String getUsage() {
+        return "";
+    }
+
+    @Nonnull
+    @Override
+    public String getHelp() {
+        return "Print a table of all currently set variables";
+    }
+
+    @Nonnull
+    @Override
+    public List<String> getAliases() {
+        return Arrays.asList();
+    }
+
+    @Override
+    public void execute(@Nonnull final List<String> args) throws CommandException {
+        if (args.size() > 0) {
+            throw new CommandException(
+                    String.format(("Incorrect number of arguments. @|bold %s|@ accepts no arguments.\n"
+                                    + "usage: @|bold %s|@ %s"),
+                            COMMAND_NAME, COMMAND_NAME, getUsage()));
+        }
+
+        List<String> keys = shell.getQueryParams().keySet().stream().collect(Collectors.toList());
+
+        Collections.sort(keys);
+
+        int leftColWidth = 0;
+        // Get longest name for alignment
+        for (String k: keys) {
+            if (k.length() > leftColWidth) {
+                leftColWidth = k.length();
+            }
+        }
+
+        for (String k: keys) {
+            shell.printOut(String.format("%-" + leftColWidth + "s: %s", k, shell.getQueryParams().get(k)));
+        }
+    }
+}

--- a/cypher-shell/src/main/java/org/neo4j/shell/commands/Env.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/commands/Env.java
@@ -1,14 +1,17 @@
 package org.neo4j.shell.commands;
 
 import org.neo4j.shell.Command;
-import org.neo4j.shell.CommandException;
 import org.neo4j.shell.CypherShell;
+import org.neo4j.shell.exception.CommandException;
+import org.neo4j.shell.exception.ExitException;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static org.neo4j.shell.CommandHelper.simpleArgParse;
 
 /**
  * This lists all query parameters which have been set
@@ -52,13 +55,8 @@ public class Env implements Command {
     }
 
     @Override
-    public void execute(@Nonnull final List<String> args) throws CommandException {
-        if (args.size() > 0) {
-            throw new CommandException(
-                    String.format(("Incorrect number of arguments. @|bold %s|@ accepts no arguments.\n"
-                                    + "usage: @|bold %s|@ %s"),
-                            COMMAND_NAME, COMMAND_NAME, getUsage()));
-        }
+    public void execute(@Nonnull final String argString) throws ExitException, CommandException {
+        simpleArgParse(argString, 0, COMMAND_NAME, getUsage());
 
         List<String> keys = shell.getQueryParams().keySet().stream().collect(Collectors.toList());
 

--- a/cypher-shell/src/main/java/org/neo4j/shell/commands/Exit.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/commands/Exit.java
@@ -9,6 +9,8 @@ import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.neo4j.shell.CommandHelper.simpleArgParse;
+
 /**
  * Command to exit the shell. Equivalent to hitting Ctrl-D.
  */
@@ -51,12 +53,8 @@ public class Exit implements Command {
     }
 
     @Override
-    public void execute(@Nonnull List<String> args) throws ExitException, CommandException {
-        if (!args.isEmpty()) {
-            throw new CommandException(
-                    String.format("Too many arguments. @|bold %s|@ does not accept any arguments",
-                            COMMAND_NAME));
-        }
+    public void execute(@Nonnull final String argString) throws ExitException, CommandException {
+        simpleArgParse(argString, 0, COMMAND_NAME, getUsage());
 
         shell.printOut("Exiting. Bye bye.");
 

--- a/cypher-shell/src/main/java/org/neo4j/shell/commands/Help.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/commands/Help.java
@@ -54,13 +54,8 @@ public class Help implements Command {
 
     @Override
     public void execute(@Nonnull final String argString) throws CommandException {
-        String[] args = simpleArgParse(argString, 1, COMMAND_NAME, getUsage());
-        if (args.length > 1) {
-            throw new CommandException(
-                    String.format(("Too many arguments. @|bold %s|@ accepts a single optional argument.\n"
-                                    + "usage: @|bold %s|@ %s"),
-                            COMMAND_NAME, COMMAND_NAME, getUsage()));
-        } else if (args.length == 0) {
+        String[] args = simpleArgParse(argString, 0, 1, COMMAND_NAME, getUsage());
+        if (args.length == 0) {
             printGeneralHelp();
         } else {
             printHelpFor(args[0]);

--- a/cypher-shell/src/main/java/org/neo4j/shell/commands/Help.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/commands/Help.java
@@ -9,6 +9,8 @@ import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.neo4j.shell.CommandHelper.simpleArgParse;
+
 /**
  * Help command, which prints help documentation.
  */
@@ -51,16 +53,17 @@ public class Help implements Command {
     }
 
     @Override
-    public void execute(@Nonnull final List<String> args) throws CommandException {
-        if (args.size() > 1) {
+    public void execute(@Nonnull final String argString) throws CommandException {
+        String[] args = simpleArgParse(argString, 1, COMMAND_NAME, getUsage());
+        if (args.length > 1) {
             throw new CommandException(
                     String.format(("Too many arguments. @|bold %s|@ accepts a single optional argument.\n"
                                     + "usage: @|bold %s|@ %s"),
                             COMMAND_NAME, COMMAND_NAME, getUsage()));
-        } else if (args.isEmpty()) {
+        } else if (args.length == 0) {
             printGeneralHelp();
         } else {
-            printHelpFor(args.get(0));
+            printHelpFor(args[0]);
         }
     }
 

--- a/cypher-shell/src/main/java/org/neo4j/shell/commands/History.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/commands/History.java
@@ -10,6 +10,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static org.neo4j.shell.CommandHelper.simpleArgParse;
+
 /**
  * Show command history
  */
@@ -54,12 +56,8 @@ public class History implements Command {
     }
 
     @Override
-    public void execute(@Nonnull List<String> args) throws ExitException, CommandException {
-        if (args.size() > 0) {
-            throw new CommandException(
-                    String.format("Too many arguments. @|bold %s|@ accepts no arguments.",
-                            COMMAND_NAME));
-        }
+    public void execute(@Nonnull String argString) throws ExitException, CommandException {
+        simpleArgParse(argString, 0, COMMAND_NAME, getUsage());
 
         Optional<jline.console.history.History> possibleHistory = shell.getHistory();
 

--- a/cypher-shell/src/main/java/org/neo4j/shell/commands/Rollback.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/commands/Rollback.java
@@ -9,6 +9,8 @@ import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.neo4j.shell.CommandHelper.simpleArgParse;
+
 /**
  * This command marks a transaction as failed and closes it.
  */
@@ -51,12 +53,8 @@ public class Rollback implements Command {
     }
 
     @Override
-    public void execute(@Nonnull List<String> args) throws ExitException, CommandException {
-        if (!args.isEmpty()) {
-            throw new CommandException(
-                    String.format("Too many arguments. @|bold %s|@ does not accept any arguments",
-                            COMMAND_NAME));
-        }
+    public void execute(@Nonnull final String argString) throws ExitException, CommandException {
+        simpleArgParse(argString, 0, COMMAND_NAME, getUsage());
 
         if (!shell.isConnected()) {
             throw new CommandException("Not connected to Neo4j");

--- a/cypher-shell/src/main/java/org/neo4j/shell/commands/Set.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/commands/Set.java
@@ -2,12 +2,14 @@ package org.neo4j.shell.commands;
 
 import org.neo4j.driver.v1.Record;
 import org.neo4j.shell.Command;
-import org.neo4j.shell.CommandException;
 import org.neo4j.shell.CypherShell;
+import org.neo4j.shell.exception.CommandException;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.List;
+
+import static org.neo4j.shell.CommandHelper.simpleArgParse;
 
 /**
  * This command sets a variable to a name, for use as query parameter.
@@ -51,20 +53,15 @@ public class Set implements Command {
     }
 
     @Override
-    public void execute(@Nonnull final List<String> args) throws CommandException {
-        if (args.size() != 2) {
-            throw new CommandException(
-                    String.format(("Incorrect number of arguments. @|bold %s|@ accepts exactly 2 arguments.\n"
-                                    + "usage: @|bold %s|@ %s"),
-                            COMMAND_NAME, COMMAND_NAME, getUsage()));
-        }
+    public void execute(@Nonnull final String argString) throws CommandException {
+        String[] args = simpleArgParse(argString, 2, COMMAND_NAME, getUsage());
 
         if (!shell.isConnected()) {
             throw new CommandException("Not connected to Neo4j");
         }
 
-        String name = args.get(0);
-        String valueString = args.get(1);
+        String name = args[0];
+        String valueString = args[1];
 
         Record record = shell.doCypherSilently("RETURN " + valueString + " as " + name).single();
         shell.getQueryParams().put(name, record.get(name).asObject());

--- a/cypher-shell/src/main/java/org/neo4j/shell/commands/Set.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/commands/Set.java
@@ -60,7 +60,7 @@ public class Set implements Command {
 
         if (!m.matches()) {
             throw new CommandException(
-                    String.format(("Incorrect number of arguments.\nusage: @|bold %s|@ %s"),
+                    String.format("Incorrect number of arguments.\nusage: @|bold %s|@ %s",
                             COMMAND_NAME, getUsage()));
         }
 

--- a/cypher-shell/src/main/java/org/neo4j/shell/commands/Set.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/commands/Set.java
@@ -1,0 +1,73 @@
+package org.neo4j.shell.commands;
+
+import org.neo4j.driver.v1.Record;
+import org.neo4j.shell.Command;
+import org.neo4j.shell.CommandException;
+import org.neo4j.shell.CypherShell;
+
+import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * This command sets a variable to a name, for use as query parameter.
+ */
+public class Set implements Command {
+    public static final String COMMAND_NAME = ":set";
+    private final CypherShell shell;
+
+    public Set(@Nonnull final CypherShell shell) {
+        this.shell = shell;
+    }
+
+    @Nonnull
+    @Override
+    public String getName() {
+        return COMMAND_NAME;
+    }
+
+    @Nonnull
+    @Override
+    public String getDescription() {
+        return "Set the value of a query parameter";
+    }
+
+    @Nonnull
+    @Override
+    public String getUsage() {
+        return "name value";
+    }
+
+    @Nonnull
+    @Override
+    public String getHelp() {
+        return "Set the specified query parameter to the value given";
+    }
+
+    @Nonnull
+    @Override
+    public List<String> getAliases() {
+        return Arrays.asList(":export");
+    }
+
+    @Override
+    public void execute(@Nonnull final List<String> args) throws CommandException {
+        if (args.size() != 2) {
+            throw new CommandException(
+                    String.format(("Incorrect number of arguments. @|bold %s|@ accepts exactly 2 arguments.\n"
+                                    + "usage: @|bold %s|@ %s"),
+                            COMMAND_NAME, COMMAND_NAME, getUsage()));
+        }
+
+        if (!shell.isConnected()) {
+            throw new CommandException("Not connected to Neo4j");
+        }
+
+        String name = args.get(0);
+        String valueString = args.get(1);
+
+        Record record = shell.doCypherSilently("RETURN " + valueString + " as " + name).single();
+        shell.getQueryParams().put(name, record.get(name).asObject());
+    }
+
+}

--- a/cypher-shell/src/main/java/org/neo4j/shell/commands/Unset.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/commands/Unset.java
@@ -1,0 +1,61 @@
+package org.neo4j.shell.commands;
+
+import org.neo4j.shell.Command;
+import org.neo4j.shell.CypherShell;
+import org.neo4j.shell.exception.CommandException;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.neo4j.shell.CommandHelper.simpleArgParse;
+
+/**
+ * This command clears a previously set variable, or does nothing in case it is already cleared.
+ */
+public class Unset implements Command {
+    public static final String COMMAND_NAME = ":unset";
+    private final CypherShell shell;
+
+    public Unset(@Nonnull final CypherShell shell) {
+        this.shell = shell;
+    }
+
+    @Nonnull
+    @Override
+    public String getName() {
+        return COMMAND_NAME;
+    }
+
+    @Nonnull
+    @Override
+    public String getDescription() {
+        return "Unset the value of a query parameter";
+    }
+
+    @Nonnull
+    @Override
+    public String getUsage() {
+        return "name";
+    }
+
+    @Nonnull
+    @Override
+    public String getHelp() {
+        return "Clear the specified query parameter, or do nothing in case it is not set";
+    }
+
+    @Nonnull
+    @Override
+    public List<String> getAliases() {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public void execute(@Nonnull final String argString) throws CommandException {
+        String[] args = simpleArgParse(argString, 1, COMMAND_NAME, getUsage());
+
+        shell.getQueryParams().remove(args[0]);
+    }
+
+}

--- a/cypher-shell/src/main/java/org/neo4j/shell/exception/DuplicateCommandException.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/exception/DuplicateCommandException.java
@@ -1,0 +1,7 @@
+package org.neo4j.shell.exception;
+
+public class DuplicateCommandException extends RuntimeException {
+    public DuplicateCommandException(String s) {
+        super(s);
+    }
+}

--- a/cypher-shell/src/test/java/org/neo4j/shell/CommandHelperTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/CommandHelperTest.java
@@ -1,0 +1,30 @@
+package org.neo4j.shell;
+
+import org.junit.Test;
+import org.neo4j.shell.exception.CommandException;
+
+import static org.junit.Assert.*;
+import static org.neo4j.shell.CommandHelper.simpleArgParse;
+
+public class CommandHelperTest {
+
+    @Test
+    public void emptyStringIsNoArgs() throws CommandException {
+        assertEquals(0, simpleArgParse("", 0, "", "").length);
+    }
+
+    @Test
+    public void whitespaceStringIsNoArgs() throws CommandException {
+        assertEquals(0, simpleArgParse("    \t  ", 0, "", "").length);
+    }
+
+    @Test
+    public void oneArg() throws CommandException {
+        try {
+            assertEquals(0, simpleArgParse("bob", 0, "", ""));
+            fail();
+        } catch (CommandException e) {
+            assertTrue(e.getMessage().contains("Incorrect number of arguments"));
+        }
+    }
+}

--- a/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
@@ -9,10 +9,32 @@ import org.neo4j.shell.exception.CommandException;
 import java.io.IOException;
 import java.util.Optional;
 
-import static junit.framework.TestCase.*;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertFalse;
 
 
 public class CypherShellTest {
+
+    @Test
+    public void commandNameShouldBeParsed() {
+        ThrowingShell shell = new ThrowingShell();
+
+        Optional<CommandExecutable> exe = shell.getCommandExecutable("   :help    ");
+
+        assertTrue(exe.isPresent());
+    }
+
+
+    @Test
+    public void commandWithArgsShouldBeParsed() {
+        ThrowingShell shell = new ThrowingShell();
+
+        Optional<CommandExecutable> exe = shell.getCommandExecutable("   :help   arg1 arg2 ");
+
+        assertTrue(exe.isPresent());
+    }
 
     @Test
     public void commentsShouldNotBeExecuted() throws Exception {

--- a/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
@@ -26,6 +26,14 @@ public class CypherShellTest {
         assertTrue(exe.isPresent());
     }
 
+    @Test
+    public void commandNameShouldBeParsedWithNewline() {
+        ThrowingShell shell = new ThrowingShell();
+
+        Optional<CommandExecutable> exe = shell.getCommandExecutable("   :help    \n");
+
+        assertTrue(exe.isPresent());
+    }
 
     @Test
     public void commandWithArgsShouldBeParsed() {
@@ -121,10 +129,17 @@ public class CypherShellTest {
         assertEquals("did not execute in TX correctly", cypherLine, tx.getLastCypherStatement());
     }
 
+    @Test
+    public void shouldParseCommandsAndArgs() {
+        TestShell shell = new TestShell();
+        assertTrue(shell.getCommandExecutable(":help").isPresent());
+        assertTrue(shell.getCommandExecutable(":help :set").isPresent());
+        assertTrue(shell.getCommandExecutable(":set \"A piece of string\"").isPresent());
+    }
+
     private TestShell connectedShell() throws CommandException {
         TestShell shell = new TestShell();
         shell.connect("bla", 99, "bob", "pass");
         return shell;
     }
-
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/StreamShell.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/StreamShell.java
@@ -55,4 +55,19 @@ public class StreamShell extends CypherShell {
     public String getErrLog() {
         return errStream.toString();
     }
+
+    public void connect() throws CommandException {
+        connect("", 0, "", "");
+    }
+
+    @Override
+    public void connect(@Nonnull String host, int port,
+                        @Nonnull String username, @Nonnull String password) throws CommandException {
+        this.session = new TestSession();
+    }
+
+    @Override
+    public void disconnect() throws CommandException {
+        this.session = null;
+    }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/StreamShell.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/StreamShell.java
@@ -14,6 +14,10 @@ public class StreamShell extends CypherShell {
     private final ByteArrayOutputStream errStream;
     private final ByteArrayOutputStream outStream;
 
+    public StreamShell() {
+        this("");
+    }
+
     public StreamShell(@Nonnull final String input) {
         super("bla", 99, "bob", "pass");
         in = new ByteArrayInputStream(input.getBytes());

--- a/cypher-shell/src/test/java/org/neo4j/shell/TestRecord.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/TestRecord.java
@@ -1,0 +1,92 @@
+package org.neo4j.shell;
+
+import org.neo4j.driver.v1.Record;
+import org.neo4j.driver.v1.Value;
+import org.neo4j.driver.v1.util.Function;
+import org.neo4j.driver.v1.util.Pair;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+
+public class TestRecord implements Record {
+
+    final TreeMap<String, Value> valueMap = new TreeMap<>();
+
+    public TestRecord() {
+    }
+
+    @Override
+    public List<String> keys() {
+        return valueMap.keySet().stream().collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Value> values() {
+        return valueMap.values().stream().collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean containsKey(String key) {
+        return valueMap.containsKey(key);
+    }
+
+    @Override
+    public int index(String key) {
+        return keys().indexOf(key);
+    }
+
+    @Override
+    public Value get(String key) {
+        return valueMap.get(key);
+    }
+
+    @Override
+    public Value get(int index) {
+        return valueMap.get(keys().get(index));
+    }
+
+    @Override
+    public int size() {
+        return valueMap.size();
+    }
+
+    @Override
+    public Map<String, Object> asMap() {
+        throw new Util.NotImplementedYetException("Not implemented as no test has required it yet");
+    }
+
+    @Override
+    public <T> Map<String, T> asMap(Function<Value, T> mapper) {
+        throw new Util.NotImplementedYetException("Not implemented as no test has required it yet");
+    }
+
+    @Override
+    public List<Pair<String, Value>> fields() {
+        throw new Util.NotImplementedYetException("Not implemented as no test has required it yet");
+    }
+
+    public static TestRecord of(@Nonnull String key, @Nonnull String value) {
+        return of(key, new TestValue() {
+            @Override
+            public Object asObject() {
+                return value;
+            }
+
+            @Override
+            public String asString() {
+                return value;
+            }
+        });
+    }
+
+    public static TestRecord of(@Nonnull String key, @Nonnull Value value) {
+        TestRecord record = new TestRecord();
+        record.valueMap.put(key, value);
+
+        return record;
+    }
+}

--- a/cypher-shell/src/test/java/org/neo4j/shell/TestSession.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/TestSession.java
@@ -25,22 +25,22 @@ public class TestSession implements Session {
 
     @Override
     public StatementResult run(String statementTemplate, Value parameters) {
-        return new TestStatementResult();
+        return TestStatementResult.parseStatement(statementTemplate);
     }
 
     @Override
     public StatementResult run(String statementTemplate, Map<String, Object> statementParameters) {
-        return new TestStatementResult();
+        return TestStatementResult.parseStatement(statementTemplate);
     }
 
     @Override
     public StatementResult run(String statementTemplate, Record statementParameters) {
-        return new TestStatementResult();
+        return TestStatementResult.parseStatement(statementTemplate);
     }
 
     @Override
     public StatementResult run(String statementTemplate) {
-        return new TestStatementResult();
+        return TestStatementResult.parseStatement(statementTemplate);
     }
 
     @Override

--- a/cypher-shell/src/test/java/org/neo4j/shell/TestShell.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/TestShell.java
@@ -11,6 +11,10 @@ public class TestShell extends CypherShell {
         super("", 1, "", "");
     }
 
+    public void connect() throws CommandException {
+        connect("", 0, "", "");
+    }
+
     @Override
     public void connect(@Nonnull String host, int port,
                         @Nonnull String username, @Nonnull String password) throws CommandException {

--- a/cypher-shell/src/test/java/org/neo4j/shell/TestStatementResult.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/TestStatementResult.java
@@ -2,16 +2,35 @@ package org.neo4j.shell;
 
 import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.StatementResult;
+import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.exceptions.NoSuchRecordException;
 import org.neo4j.driver.v1.summary.ResultSummary;
 import org.neo4j.driver.v1.util.Function;
+import org.neo4j.driver.v1.util.Pair;
 
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class TestStatementResult implements StatementResult {
+
+    private final List<Record> records;
+
+    public TestStatementResult() {
+        records = new ArrayList<>();
+    }
+
+    public TestStatementResult(@Nonnull final List<Record> records) {
+        this.records = records;
+    }
+
     @Override
     public List<String> keys() {
-        return null;
+        throw new Util.NotImplementedYetException("Not implemented yet");
     }
 
     @Override
@@ -21,31 +40,57 @@ public class TestStatementResult implements StatementResult {
 
     @Override
     public Record next() {
-        return null;
+        throw new Util.NotImplementedYetException("Not implemented yet");
     }
 
     @Override
     public Record single() throws NoSuchRecordException {
-        return null;
+        if (records.size() == 1) {
+            return records.get(0);
+        }
+        throw new NoSuchRecordException("There are more than records");
     }
 
     @Override
     public Record peek() {
-        return null;
+        throw new Util.NotImplementedYetException("Not implemented yet");
     }
 
     @Override
     public List<Record> list() {
-        return null;
+        return records;
     }
 
     @Override
     public <T> List<T> list(Function<Record, T> mapFunction) {
-        return null;
+        throw new Util.NotImplementedYetException("Not implemented yet");
     }
 
     @Override
     public ResultSummary consume() {
-        return null;
+        throw new Util.NotImplementedYetException("Not implemented yet");
+    }
+
+    /**
+     * Supports fake parsing of very limited cypher statements, only for basic test purposes
+     */
+    public static TestStatementResult parseStatement(@Nonnull final String statement) {
+
+        Pattern returnPattern = Pattern.compile("^return (.*)$", Pattern.CASE_INSENSITIVE);
+        Pattern returnAsPattern = Pattern.compile("^return (.*?) as (.*)$", Pattern.CASE_INSENSITIVE);
+        for (Pattern p: Arrays.asList(returnAsPattern, returnPattern)) {
+            Matcher m = returnAsPattern.matcher(statement);
+            if (m.find()) {
+                String value = m.group(1);
+                String key = value;
+                if (m.groupCount() > 1) {
+                    key = m.group(2);
+                }
+                TestStatementResult statementResult = new TestStatementResult();
+                statementResult.records.add(TestRecord.of(key, value));
+                return statementResult;
+            }
+        }
+        throw new IllegalArgumentException("No idea how to parse this statement");
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/TestStatementResult.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/TestStatementResult.java
@@ -77,7 +77,7 @@ public class TestStatementResult implements StatementResult {
     public static TestStatementResult parseStatement(@Nonnull final String statement) {
 
         Pattern returnPattern = Pattern.compile("^return (.*)$", Pattern.CASE_INSENSITIVE);
-        Pattern returnAsPattern = Pattern.compile("^return (.*?) as (.*)$", Pattern.CASE_INSENSITIVE);
+        Pattern returnAsPattern = Pattern.compile("^return (.*) as (.*)$", Pattern.CASE_INSENSITIVE);
         for (Pattern p: Arrays.asList(returnAsPattern, returnPattern)) {
             Matcher m = returnAsPattern.matcher(statement);
             if (m.find()) {

--- a/cypher-shell/src/test/java/org/neo4j/shell/TestValue.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/TestValue.java
@@ -1,0 +1,157 @@
+package org.neo4j.shell;
+
+import org.neo4j.driver.v1.Value;
+import org.neo4j.driver.v1.exceptions.value.Uncoercible;
+import org.neo4j.driver.v1.types.*;
+import org.neo4j.driver.v1.util.Function;
+
+import java.util.List;
+import java.util.Map;
+
+
+public class TestValue implements Value {
+    @Override
+    public int size() {
+        return 0;
+    }
+
+    @Override
+    public Iterable<Value> values() {
+        return null;
+    }
+
+    @Override
+    public <T> Iterable<T> values(Function<Value, T> mapFunction) {
+        return null;
+    }
+
+    @Override
+    public Map<String, Object> asMap() {
+        return null;
+    }
+
+    @Override
+    public <T> Map<String, T> asMap(Function<Value, T> mapFunction) {
+        return null;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return false;
+    }
+
+    @Override
+    public Iterable<String> keys() {
+        return null;
+    }
+
+    @Override
+    public boolean containsKey(String key) {
+        return false;
+    }
+
+    @Override
+    public Value get(String key) {
+        return null;
+    }
+
+    @Override
+    public Value get(int index) {
+        return null;
+    }
+
+    @Override
+    public Type type() {
+        return null;
+    }
+
+    @Override
+    public boolean hasType(Type type) {
+        return false;
+    }
+
+    @Override
+    public boolean isTrue() {
+        return false;
+    }
+
+    @Override
+    public boolean isFalse() {
+        return false;
+    }
+
+    @Override
+    public boolean isNull() {
+        return false;
+    }
+
+    @Override
+    public Object asObject() {
+        throw new Uncoercible(getClass().getSimpleName(), "Object");
+    }
+
+    @Override
+    public boolean asBoolean() {
+        throw new Uncoercible(getClass().getSimpleName(), "Bool");
+    }
+
+    @Override
+    public String asString() {
+        throw new Uncoercible(getClass().getSimpleName(), "String");
+    }
+
+    @Override
+    public Number asNumber() {
+        throw new Uncoercible(getClass().getSimpleName(), "Number");
+    }
+
+    @Override
+    public long asLong() {
+        throw new Uncoercible(getClass().getSimpleName(), "Long");
+    }
+
+    @Override
+    public int asInt() {
+        throw new Uncoercible(getClass().getSimpleName(), "Int");
+    }
+
+    @Override
+    public double asDouble() {
+        throw new Uncoercible(getClass().getSimpleName(), "Double");
+    }
+
+    @Override
+    public float asFloat() {
+        throw new Uncoercible(getClass().getSimpleName(), "Float");
+    }
+
+    @Override
+    public List<Object> asList() {
+        throw new Uncoercible(getClass().getSimpleName(), "List");
+    }
+
+    @Override
+    public <T> List<T> asList(Function<Value, T> mapFunction) {
+        throw new Uncoercible(getClass().getSimpleName(), "List");
+    }
+
+    @Override
+    public Entity asEntity() {
+        throw new Uncoercible(getClass().getSimpleName(), "Entity");
+    }
+
+    @Override
+    public Node asNode() {
+        throw new Uncoercible(getClass().getSimpleName(), "Node");
+    }
+
+    @Override
+    public Relationship asRelationship() {
+        throw new Uncoercible(getClass().getSimpleName(), "Relationship");
+    }
+
+    @Override
+    public Path asPath() {
+        throw new Uncoercible(getClass().getSimpleName(), "Path");
+    }
+}

--- a/cypher-shell/src/test/java/org/neo4j/shell/Util.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/Util.java
@@ -7,4 +7,10 @@ public class Util {
     static Object[] asObjectArray(Object... arguments) {
         return arguments;
     }
+
+    public static class NotImplementedYetException extends RuntimeException {
+        public NotImplementedYetException(String message) {
+            super(message);
+        }
+    }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/Util.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/Util.java
@@ -4,4 +4,7 @@ public class Util {
     public static String[] asArray(String... arguments) {
         return arguments;
     }
+    static Object[] asObjectArray(Object... arguments) {
+        return arguments;
+    }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/cli/CommandReaderTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/cli/CommandReaderTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNull;
 
 public class CommandReaderTest {
+
     @Test
     public void readCommandReadsFromTheConsole() throws Exception {
         StreamShell streamShell = new StreamShell("CREATE (n:Person) RETURN n\n");

--- a/cypher-shell/src/test/java/org/neo4j/shell/commands/BeginTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/commands/BeginTest.java
@@ -9,11 +9,7 @@ import org.neo4j.shell.Command;
 import org.neo4j.shell.Shell;
 import org.neo4j.shell.exception.CommandException;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.fail;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.mockito.Mockito.*;
 
 public class BeginTest {
@@ -31,10 +27,9 @@ public class BeginTest {
     @Test
     public void shouldNotAcceptArgs() throws CommandException {
         thrown.expect(CommandException.class);
-        thrown.expectMessage("Too many arguments. @|bold :begin|@ does not accept any arguments");
+        thrown.expectMessage(containsString("Incorrect number of arguments"));
 
-        beginCommand.execute(Arrays.asList("bob"));
-        fail("should not accept args");
+        beginCommand.execute("bob");
     }
 
     @Test
@@ -44,30 +39,15 @@ public class BeginTest {
 
         when(mockShell.isConnected()).thenReturn(false);
 
-        beginCommand.execute(new ArrayList<>());
-        fail("shell is disconnected");
+        beginCommand.execute("");
     }
 
     @Test
     public void beginTransactionOnShell() throws CommandException {
         when(mockShell.isConnected()).thenReturn(true);
 
-        beginCommand.execute(new ArrayList<>());
+        beginCommand.execute("");
 
         verify(mockShell).beginTransaction();
-    }
-
-    @Test
-    public void nestedTransactionsAreNotSupported() throws CommandException {
-        when(mockShell.isConnected()).thenReturn(true);
-        CommandException expectedException = new CommandException("transaction already open");
-        doThrow(expectedException).when(mockShell).beginTransaction();
-
-        try {
-            beginCommand.execute(new ArrayList<>());
-            fail("Should throw");
-        } catch (CommandException actual) {
-            assertEquals(expectedException, actual);
-        }
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/commands/CommitTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/commands/CommitTest.java
@@ -9,12 +9,9 @@ import org.neo4j.shell.Command;
 import org.neo4j.shell.Shell;
 import org.neo4j.shell.exception.CommandException;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.fail;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.mockito.Mockito.*;
+
 
 public class CommitTest {
     @Rule
@@ -30,43 +27,27 @@ public class CommitTest {
     @Test
     public void shouldNotAcceptArgs() throws CommandException {
         thrown.expect(CommandException.class);
-        thrown.expectMessage("Too many arguments. @|bold :commit|@ does not accept any arguments");
+        thrown.expectMessage(containsString("Incorrect number of arguments"));
 
-        commitCommand.execute(Arrays.asList("bob"));
-        fail("should not accept args");
+        commitCommand.execute("bob");
     }
 
     @Test
-    public void throwExceptionWhenShellIsDisconnected() throws CommandException {
+    public void needsToBeConnected() throws CommandException {
         thrown.expect(CommandException.class);
         thrown.expectMessage("Not connected to Neo4j");
 
         when(mockShell.isConnected()).thenReturn(false);
 
-        commitCommand.execute(new ArrayList<>());
-        fail("shell is disconnected");
+        commitCommand.execute("");
     }
 
     @Test
     public void commitTransactionOnShell() throws CommandException {
         when(mockShell.isConnected()).thenReturn(true);
 
-        commitCommand.execute(new ArrayList<>());
+        commitCommand.execute("");
 
         verify(mockShell).commitTransaction();
-    }
-
-    @Test
-    public void closingWhenNoTXOpenShouldThrow() throws CommandException {
-        when(mockShell.isConnected()).thenReturn(true);
-        CommandException expectedException = new CommandException("no open transaction");
-        doThrow(expectedException).when(mockShell).commitTransaction();
-
-        try {
-            commitCommand.execute(new ArrayList<>());
-            fail("Can't commit when no tx is open!");
-        } catch (CommandException actual) {
-            assertEquals(expectedException, actual);
-        }
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/commands/ConnectTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/commands/ConnectTest.java
@@ -8,8 +8,6 @@ import org.neo4j.shell.Shell;
 import org.neo4j.shell.TestShell;
 import org.neo4j.shell.exception.CommandException;
 
-import java.util.Arrays;
-
 import static junit.framework.TestCase.assertTrue;
 import static junit.framework.TestCase.fail;
 
@@ -27,10 +25,10 @@ public class ConnectTest {
     @Test
     public void shouldNotAcceptTooManyArgs() {
         try {
-            cmd.execute(Arrays.asList("bob", "alice"));
+            cmd.execute("bob alice");
             fail("Should not accept too many args");
         } catch (CommandException e) {
-            assertTrue("Unexepcted error", e.getMessage().startsWith("Too many arguments"));
+            assertTrue("Unexpected error", e.getMessage().startsWith("Incorrect number of arguments"));
         }
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/commands/DisconnectTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/commands/DisconnectTest.java
@@ -7,8 +7,6 @@ import org.neo4j.shell.Shell;
 import org.neo4j.shell.TestShell;
 import org.neo4j.shell.exception.CommandException;
 
-import java.util.Arrays;
-
 import static junit.framework.TestCase.assertTrue;
 import static junit.framework.TestCase.fail;
 
@@ -26,10 +24,10 @@ public class DisconnectTest {
     @Test
     public void shouldNotAcceptArgs() {
         try {
-            cmd.execute(Arrays.asList("bob"));
+            cmd.execute("bob");
             fail("Should not accept args");
         } catch (CommandException e) {
-            assertTrue("Unexepcted error", e.getMessage().startsWith("Too many arguments"));
+            assertTrue("Unexpected error", e.getMessage().startsWith("Incorrect number of arguments"));
         }
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/commands/EnvTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/commands/EnvTest.java
@@ -1,0 +1,55 @@
+package org.neo4j.shell.commands;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.shell.CommandException;
+import org.neo4j.shell.StreamShell;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class EnvTest {
+    private StreamShell shell;
+    private Env cmd;
+
+    @Before
+    public void setup() throws CommandException {
+        shell = new StreamShell();
+        shell.connect();
+        cmd = new Env(shell);
+    }
+
+    @Test
+    public void runCommand() throws CommandException {
+        // given
+        Set set = new Set(shell);
+        set.execute("var 9");
+        // when
+        cmd.execute("");
+        // then
+        assertEquals("var: 9\n", shell.getOutLog());
+    }
+
+    @Test
+    public void runCommandAlignment() throws CommandException {
+        // given
+        Set set = new Set(shell);
+        set.execute("var 9");
+        set.execute("param 99999");
+        // when
+        cmd.execute("");
+        // then
+        assertEquals("param: 99999\nvar  : 9\n", shell.getOutLog());
+    }
+
+    @Test
+    public void shouldNotAcceptArgs() {
+        try {
+            cmd.execute("bob");
+            fail("Should not accept args");
+        } catch (CommandException e) {
+            assertTrue("Unexpected error", e.getMessage().startsWith("Incorrect number of arguments"));
+        }
+    }
+}

--- a/cypher-shell/src/test/java/org/neo4j/shell/commands/EnvTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/commands/EnvTest.java
@@ -2,12 +2,10 @@ package org.neo4j.shell.commands;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.neo4j.shell.CommandException;
 import org.neo4j.shell.StreamShell;
+import org.neo4j.shell.exception.CommandException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public class EnvTest {
     private StreamShell shell;

--- a/cypher-shell/src/test/java/org/neo4j/shell/commands/ExitTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/commands/ExitTest.java
@@ -7,8 +7,6 @@ import org.neo4j.shell.Shell;
 import org.neo4j.shell.TestShell;
 import org.neo4j.shell.exception.CommandException;
 
-import java.util.Arrays;
-
 import static junit.framework.TestCase.assertTrue;
 import static junit.framework.TestCase.fail;
 
@@ -26,10 +24,10 @@ public class ExitTest {
     @Test
     public void shouldNotAcceptArgs() {
         try {
-            cmd.execute(Arrays.asList("bob"));
+            cmd.execute("bob");
             fail("Should not accept args");
         } catch (CommandException e) {
-            assertTrue("Unexepcted error", e.getMessage().startsWith("Too many arguments"));
+            assertTrue("Unexpected error", e.getMessage().startsWith("Incorrect number of arguments"));
         }
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/commands/HelpTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/commands/HelpTest.java
@@ -23,6 +23,12 @@ public class HelpTest {
     }
 
     @Test
+    public void shouldAcceptNoArgs() throws CommandException {
+        cmd.execute("");
+        // Should not throw
+    }
+
+    @Test
     public void shouldNotAcceptTooManyArgs() {
         try {
             cmd.execute("bob alice");

--- a/cypher-shell/src/test/java/org/neo4j/shell/commands/HelpTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/commands/HelpTest.java
@@ -8,8 +8,6 @@ import org.neo4j.shell.Shell;
 import org.neo4j.shell.TestShell;
 import org.neo4j.shell.exception.CommandException;
 
-import java.util.Arrays;
-
 import static junit.framework.TestCase.assertTrue;
 import static junit.framework.TestCase.fail;
 
@@ -27,10 +25,10 @@ public class HelpTest {
     @Test
     public void shouldNotAcceptTooManyArgs() {
         try {
-            cmd.execute(Arrays.asList("bob", "alice"));
+            cmd.execute("bob alice");
             fail("Should not accept too many args");
         } catch (CommandException e) {
-            assertTrue("Unexepcted error", e.getMessage().startsWith("Too many arguments"));
+            assertTrue("Unexpected error", e.getMessage().startsWith("Incorrect number of arguments"));
         }
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/commands/HistoryTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/commands/HistoryTest.java
@@ -8,8 +8,6 @@ import org.neo4j.shell.Shell;
 import org.neo4j.shell.TestShell;
 import org.neo4j.shell.exception.CommandException;
 
-import java.util.Arrays;
-
 import static junit.framework.TestCase.assertTrue;
 import static junit.framework.TestCase.fail;
 
@@ -27,10 +25,10 @@ public class HistoryTest {
     @Test
     public void shouldNotAcceptArgs() {
         try {
-            cmd.execute(Arrays.asList("bob"));
+            cmd.execute("bob");
             fail("Should not accept args");
         } catch (CommandException e) {
-            assertTrue("Unexepcted error", e.getMessage().startsWith("Too many arguments"));
+            assertTrue("Unexpected error", e.getMessage().startsWith("Incorrect number of arguments"));
         }
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/commands/RollbackTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/commands/RollbackTest.java
@@ -9,12 +9,10 @@ import org.neo4j.shell.Command;
 import org.neo4j.shell.Shell;
 import org.neo4j.shell.exception.CommandException;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.fail;
-import static org.mockito.Mockito.*;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class RollbackTest {
 
@@ -33,10 +31,9 @@ public class RollbackTest {
     @Test
     public void shouldNotAcceptArgs() throws CommandException {
         thrown.expect(CommandException.class);
-        thrown.expectMessage("Too many arguments. @|bold :rollback|@ does not accept any arguments");
+        thrown.expectMessage(containsString("Incorrect number of arguments"));
 
-        rollbackCommand.execute(Arrays.asList("bob"));
-        fail("should not accept args");
+        rollbackCommand.execute("bob");
     }
 
     @Test
@@ -46,31 +43,15 @@ public class RollbackTest {
 
         when(mockShell.isConnected()).thenReturn(false);
 
-        rollbackCommand.execute(new ArrayList<>());
-        fail("shell is disconnected");
+        rollbackCommand.execute("");
     }
 
     @Test
     public void rollbackTransaction() throws CommandException {
         when(mockShell.isConnected()).thenReturn(true);
 
-        rollbackCommand.execute(new ArrayList<>());
+        rollbackCommand.execute("");
 
         verify(mockShell).rollbackTransaction();
-    }
-
-    @Test
-    public void closingWhenNoTXOpenShouldThrow() throws CommandException {
-        when(mockShell.isConnected()).thenReturn(true);
-        CommandException expectedException = new CommandException("no open transaction");
-        doThrow(expectedException).when(mockShell).rollbackTransaction();
-
-        try {
-            rollbackCommand.execute(new ArrayList<>());
-            fail("Can't commit when no tx is open!");
-        } catch (CommandException actual) {
-            assertEquals(expectedException, actual);
-        }
-
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/commands/SetTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/commands/SetTest.java
@@ -42,20 +42,26 @@ public class SetTest {
     }
 
     @Test
-    public void shouldFailIfTooManyArgs() {
-        try {
-            cmd.execute("bob mob zob");
-            fail("Expected error");
-        } catch (CommandException e) {
-            assertTrue("Unexpected error", e.getMessage().startsWith("Incorrect number of arguments"));
-        }
-    }
-
-    @Test
     public void setValue() throws CommandException {
         shell.connect();
         cmd.execute("bob   9");
         assertEquals("Expected param to be set",
                 "9", shell.getQueryParams().get("bob").toString());
+    }
+
+    @Test
+    public void shouldNotSplitOnSpace() throws CommandException {
+        shell.connect();
+        cmd.execute("bob 'one two'");
+        assertEquals("Expected param to be set",
+                "'one two'", shell.getQueryParams().get("bob").toString());
+    }
+
+    @Test
+    public void shouldNotExecuteEscapedCypher() throws CommandException {
+        shell.connect();
+        cmd.execute("bob \"RETURN 5 as bob\"");
+        assertEquals("Expected param to be set",
+                "\"RETURN 5 as bob\"", shell.getQueryParams().get("bob").toString());
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/commands/SetTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/commands/SetTest.java
@@ -4,39 +4,37 @@ package org.neo4j.shell.commands;
 import org.junit.Before;
 import org.junit.Test;
 import org.neo4j.shell.Command;
-import org.neo4j.shell.CommandException;
 import org.neo4j.shell.TestShell;
+import org.neo4j.shell.exception.CommandException;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-
-import static junit.framework.TestCase.*;
+import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
 
 public class SetTest {
 
-    private TestShell shell;
+    private TestShell shell = new TestShell();
     private Command cmd;
 
     @Before
     public void setup() {
-        this.shell = new TestShell();
         this.cmd = new Set(shell);
     }
 
     @Test
     public void shouldFailIfNoArgs() {
         try {
-            cmd.execute(new ArrayList<>());
+            cmd.execute("");
             fail("Expected error");
         } catch (CommandException e) {
-            assertTrue("Unexpected error", e.getMessage().startsWith("Incorrect number of arguments"));
+            assertTrue("Unexpected error: " + e.getMessage(), e.getMessage().startsWith("Incorrect number of arguments"));
         }
     }
 
     @Test
     public void shouldFailIfOneArg() {
         try {
-            cmd.execute(Arrays.asList("bob"));
+            cmd.execute("bob");
             fail("Expected error");
         } catch (CommandException e) {
             assertTrue("Unexpected error", e.getMessage().startsWith("Incorrect number of arguments"));
@@ -46,7 +44,7 @@ public class SetTest {
     @Test
     public void shouldFailIfTooManyArgs() {
         try {
-            cmd.execute(Arrays.asList("bob", "mob", "zob"));
+            cmd.execute("bob mob zob");
             fail("Expected error");
         } catch (CommandException e) {
             assertTrue("Unexpected error", e.getMessage().startsWith("Incorrect number of arguments"));
@@ -56,7 +54,7 @@ public class SetTest {
     @Test
     public void setValue() throws CommandException {
         shell.connect();
-        cmd.execute(Arrays.asList("bob", "9"));
+        cmd.execute("bob   9");
         assertEquals("Expected param to be set",
                 "9", shell.getQueryParams().get("bob").toString());
     }

--- a/cypher-shell/src/test/java/org/neo4j/shell/commands/SetTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/commands/SetTest.java
@@ -1,0 +1,63 @@
+package org.neo4j.shell.commands;
+
+
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.shell.Command;
+import org.neo4j.shell.CommandException;
+import org.neo4j.shell.TestShell;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static junit.framework.TestCase.*;
+
+public class SetTest {
+
+    private TestShell shell;
+    private Command cmd;
+
+    @Before
+    public void setup() {
+        this.shell = new TestShell();
+        this.cmd = new Set(shell);
+    }
+
+    @Test
+    public void shouldFailIfNoArgs() {
+        try {
+            cmd.execute(new ArrayList<>());
+            fail("Expected error");
+        } catch (CommandException e) {
+            assertTrue("Unexpected error", e.getMessage().startsWith("Incorrect number of arguments"));
+        }
+    }
+
+    @Test
+    public void shouldFailIfOneArg() {
+        try {
+            cmd.execute(Arrays.asList("bob"));
+            fail("Expected error");
+        } catch (CommandException e) {
+            assertTrue("Unexpected error", e.getMessage().startsWith("Incorrect number of arguments"));
+        }
+    }
+
+    @Test
+    public void shouldFailIfTooManyArgs() {
+        try {
+            cmd.execute(Arrays.asList("bob", "mob", "zob"));
+            fail("Expected error");
+        } catch (CommandException e) {
+            assertTrue("Unexpected error", e.getMessage().startsWith("Incorrect number of arguments"));
+        }
+    }
+
+    @Test
+    public void setValue() throws CommandException {
+        shell.connect();
+        cmd.execute(Arrays.asList("bob", "9"));
+        assertEquals("Expected param to be set",
+                "9", shell.getQueryParams().get("bob").toString());
+    }
+}

--- a/cypher-shell/src/test/java/org/neo4j/shell/commands/UnsetTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/commands/UnsetTest.java
@@ -1,0 +1,72 @@
+package org.neo4j.shell.commands;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.shell.Command;
+import org.neo4j.shell.TestShell;
+import org.neo4j.shell.exception.CommandException;
+
+import static org.junit.Assert.*;
+
+public class UnsetTest {
+
+    private TestShell shell;
+    private Command cmd;
+
+    @Before
+    public void setup() {
+        this.shell = new TestShell();
+        this.cmd = new Unset(shell);
+    }
+
+    @Test
+    public void shouldFailIfNoArgs() {
+        try {
+            cmd.execute("");
+            fail("Expected error");
+        } catch (CommandException e) {
+            assertTrue("Unexpected error", e.getMessage().startsWith("Incorrect number of arguments"));
+        }
+    }
+
+    @Test
+    public void shouldFailIfMoreThanOneArg() {
+        try {
+            cmd.execute("bob nob");
+            fail("Expected error");
+        } catch (CommandException e) {
+            assertTrue("Unexpected error", e.getMessage().startsWith("Incorrect number of arguments"));
+        }
+    }
+
+    @Test
+    public void unsetValue() throws CommandException {
+        // given
+        shell.connect();
+        new Set(shell).execute("bob 9");
+
+        assertEquals("Expected param to be set",
+                "9", shell.getQueryParams().get("bob"));
+
+        // when
+        cmd.execute("bob");
+        // then
+        assertFalse("Expected param to be unset",
+                shell.getQueryParams().containsKey("bob"));
+    }
+
+    @Test
+    public void unsetAlreadyClearedValue() throws CommandException {
+        // given
+        shell.connect();
+
+        assertFalse("Expected param to be unset",
+                shell.getQueryParams().containsKey("nob"));
+
+        // when
+        cmd.execute("nob");
+        // then
+        assertFalse("Expected a no-op",
+                shell.getQueryParams().containsKey("nob"));
+    }
+}


### PR DESCRIPTION
Adds command to set variables, and passes them to bolt.

An example session:

```
neo4j> :help

Available commands:
  :begin      Open a transaction
  :commit     Commit the currently open transaction
  :connect    Connect to a running instance of neo4j
  :disconnect Disconnect from neo4j
  :env        Prints all variables and their values
  :exit       Exit the shell
  :set        Set the value of a query parameter
  :help       Show this help message
  :history    Print a list of the last commands executed
  :rollback   Rollback the currently open transaction
  :unset      Unset the value of a query parameter

For help on a specific command type:
    :help command

neo4j> :help set

usage: :set name value

Set the specified query parameter to the value given

neo4j> :help env

usage: :env 

Print a table of all currently set variables

neo4j> :help unset

usage: :unset name

Clear the specified query parameter, or do nothing in case it is not set

neo4j> :unset x
neo4j> :env
neo4j> :set x 9
neo4j> :env
x: 9
neo4j> :set parameter "a string param"
neo4j> :env
parameter: a string param
x        : 9
neo4j> :set name "jonas"
neo4j> :unset x
neo4j> :env
name     : jonas
parameter: a string param
neo4j> :export names ["alice", "bob"]
neo4j> :env
name     : jonas
names    : [alice, bob]
parameter: a string param
neo4j> CREATE (n {first: {parameter}, second: {names}}) RETURN n
n
{first: "a string param", second: ["alice", "bob"]}
neo4j>
```