### PR TITLE
Integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,11 @@ run: dist ## Build and run cypher-shell with no arguments
 dist: ## Build and test cypher-shell
 	./gradlew installDist
 
-test: ## Run all tests
-	./gradlew check jacocoTestReport pitest
+test: ## Run all unit tests
+	./gradlew check pitest
+
+integration-test: ## Run all integration tests
+	./gradlew integrationTest
 
 out:
 	mkdir -p out

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ allprojects {
 }
 
 subprojects {
+    apply from: "$rootProject.projectDir/gradle/integration-test.gradle"
     apply plugin: 'pmd'
     apply plugin: 'jacoco'
     apply plugin: 'info.solidsoft.pitest'

--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellIntegrationTest.java
@@ -1,0 +1,54 @@
+package org.neo4j.shell.commands;
+
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.shell.Command;
+import org.neo4j.shell.CypherShell;
+import org.neo4j.shell.exception.CommandException;
+
+import java.util.ArrayList;
+
+import static junit.framework.TestCase.assertTrue;
+
+public class CypherShellIntegrationTest {
+
+    private CypherShell shell = new CypherShell("localhost", 7687, "neo4j", "neo");
+    private Command rollbackCommand = new Rollback(shell);
+    private Command commitCommand = new Commit(shell);
+    private Command beginCommand = new Begin(shell);
+
+    @Before
+    public void setUp() throws Exception {
+        shell.connect("localhost", 7687, "", "");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        shell.disconnect();
+    }
+
+    @Test
+    public void rollbackScenario() throws CommandException {
+        try {
+            beginCommand.execute(new ArrayList<>());
+            shell.executeLine("CREATE (:Random)");
+            rollbackCommand.execute(new ArrayList<>());
+            shell.executeLine("MATCH (n) RETURN n");
+        } catch (CommandException e) {
+            assertTrue("unexepcted error", e.getMessage().contains("Not connected"));
+        }
+    }
+
+    @Test
+    public void commitScenario() throws CommandException {
+        try {
+            beginCommand.execute(new ArrayList<>());
+            shell.executeLine("CREATE (:Person {name: \"John Smith\"})");
+            commitCommand.execute(new ArrayList<>());
+        } catch (CommandException e) {
+            assertTrue("unexepcted error", e.getMessage().contains("Not connected"));
+        }
+    }
+}

--- a/gradle/integration-test.gradle
+++ b/gradle/integration-test.gradle
@@ -1,0 +1,27 @@
+// Add integration test source sets
+sourceSets {
+  integrationTest { sourceSet ->
+    ["java", "resources"].each {
+      if (!sourceSet.hasProperty(it)) return
+      sourceSet."$it".srcDir file("src/integration-test/${it}")
+    }
+  }
+}
+
+// Setup dependencies for integration testing
+dependencies {
+  integrationTestCompile sourceSets.main.output
+  integrationTestCompile sourceSets.test.output
+  integrationTestCompile configurations.testCompile
+  integrationTestRuntime configurations.testRuntime
+}
+
+// Define integration test task
+task integrationTest(type: Test) {
+  testClassesDir = sourceSets.integrationTest.output.classesDir
+  classpath = sourceSets.integrationTest.runtimeClasspath
+}
+
+// Make sure 'check' task calls integration test
+// No, run it manually instead
+// check.dependsOn integrationTest


### PR DESCRIPTION
Based on original work in #9 

Based on #10 , needs to be rebased on master once that is merged

Run integration tests either by doing `gradlew integrationTest` or by doing `gradlew check`

They currently assume you have a neo4j instance up on localhost (bolt port `7687`) with no authorization requirements (this is true on team city). We should make this configurable ideally.