### PR TITLE
Better error prints

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/Main.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/Main.java
@@ -1,10 +1,9 @@
 package org.neo4j.shell;
 
-import org.fusesource.jansi.AnsiConsole;
 import org.neo4j.shell.cli.CliArgHelper;
 import org.neo4j.shell.commands.CommandHelper;
-import org.neo4j.shell.log.Logger;
 import org.neo4j.shell.log.AnsiLogger;
+import org.neo4j.shell.log.Logger;
 
 import javax.annotation.Nonnull;
 
@@ -15,16 +14,8 @@ public class Main {
     public static void main(String[] args) {
         CliArgHelper.CliArgs cliArgs = CliArgHelper.parse(args);
 
-        configureTerminal(cliArgs.getSuppressColor());
-
         Main main = new Main();
         main.startShell(cliArgs);
-    }
-
-    private static void configureTerminal(boolean suppressColor) {
-        if (!suppressColor) {
-            AnsiConsole.systemInstall();
-        }
     }
 
     private void startShell(@Nonnull CliArgHelper.CliArgs cliArgs) {

--- a/cypher-shell/src/main/java/org/neo4j/shell/Main.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/Main.java
@@ -8,7 +8,7 @@ import org.neo4j.shell.log.AnsiLogger;
 
 import javax.annotation.Nonnull;
 
-import static org.neo4j.shell.exception.Helper.getSensibleMsg;
+import static org.neo4j.shell.exception.Helper.getFormattedMessage;
 
 public class Main {
 
@@ -47,7 +47,7 @@ public class Main {
             int code = shellRunner.runUntilEnd(shell);
             System.exit(code);
         } catch (Throwable e) {
-            logger.printError(getSensibleMsg(e));
+            logger.printError(getFormattedMessage(e));
             System.exit(1);
         }
     }

--- a/cypher-shell/src/main/java/org/neo4j/shell/ShellRunner.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/ShellRunner.java
@@ -1,6 +1,10 @@
 package org.neo4j.shell;
 
-import org.neo4j.shell.cli.*;
+import org.neo4j.shell.cli.CliArgHelper;
+import org.neo4j.shell.cli.CommandReader;
+import org.neo4j.shell.cli.InteractiveShellRunner;
+import org.neo4j.shell.cli.NonInteractiveShellRunner;
+import org.neo4j.shell.cli.StringShellRunner;
 import org.neo4j.shell.log.Logger;
 
 import javax.annotation.Nonnull;
@@ -34,7 +38,7 @@ public interface ShellRunner {
         CommandReader commandReader = new CommandReader(logger, true);
         if (cliArgs.getCypher().isPresent()) {
             return new StringShellRunner(cliArgs, logger);
-        } else if (isInteractive()) {
+        } else if (isInputInteractive()) {
             return new InteractiveShellRunner(commandReader, logger);
         } else {
             return new NonInteractiveShellRunner(cliArgs.getFailBehavior(), commandReader, logger);
@@ -42,9 +46,9 @@ public interface ShellRunner {
     }
 
     /**
-     * @return true if the shell is a TTY, false otherwise (e.g., we are reading from a file)
+     * @return true if the shell reading from a TTY, false otherwise (e.g., we are reading from a file)
      */
-    static boolean isInteractive() {
+    static boolean isInputInteractive() {
         return 1 == isatty(STDIN_FILENO);
     }
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CommandReader.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CommandReader.java
@@ -4,8 +4,9 @@ import jline.console.ConsoleReader;
 import jline.console.history.FileHistory;
 import jline.console.history.History;
 import jline.console.history.MemoryHistory;
-import org.fusesource.jansi.AnsiRenderer;
+import org.fusesource.jansi.Ansi;
 import org.neo4j.shell.Historian;
+import org.neo4j.shell.log.AnsiFormattedText;
 import org.neo4j.shell.log.Logger;
 
 import javax.annotation.Nonnull;
@@ -27,7 +28,8 @@ public class CommandReader implements Historian {
     static final Pattern MULTILINE_BREAK = Pattern.compile("\\\\\\s*$");
     //Pattern matches comments
     static final Pattern COMMENTS = Pattern.compile("//.*$");
-    private final String prompt = AnsiRenderer.render("@|bold neo4j>|@ ");
+    private final String prompt = Ansi.ansi().render(AnsiFormattedText.s().bold().append("neo4j> ")
+                                                                      .formattedString()).toString();
 
     public CommandReader(@Nonnull Logger logger, final boolean useHistoryFile) throws IOException {
         this(System.in, logger, useHistoryFile);

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/InteractiveShellRunner.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/InteractiveShellRunner.java
@@ -10,7 +10,7 @@ import org.neo4j.shell.log.Logger;
 import javax.annotation.Nonnull;
 import java.io.IOException;
 
-import static org.neo4j.shell.exception.Helper.getSensibleMsg;
+import static org.neo4j.shell.exception.Helper.getFormattedMessage;
 
 /**
  * An interactive shell
@@ -36,7 +36,7 @@ public class InteractiveShellRunner implements ShellRunner {
                 exitCode = e.getCode();
                 running = false;
             } catch (Throwable e) {
-                logger.printError(getSensibleMsg(e));
+                logger.printError(getFormattedMessage(e));
             }
         }
         return exitCode;

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/NonInteractiveShellRunner.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/NonInteractiveShellRunner.java
@@ -8,7 +8,7 @@ import org.neo4j.shell.log.Logger;
 
 import javax.annotation.Nonnull;
 
-import static org.neo4j.shell.exception.Helper.getSensibleMsg;
+import static org.neo4j.shell.exception.Helper.getFormattedMessage;
 
 
 /**
@@ -51,7 +51,7 @@ public class NonInteractiveShellRunner implements ShellRunner {
                 running = false;
             } catch (Throwable e) {
                 exitCode = 1;
-                logger.printError(getSensibleMsg(e));
+                logger.printError(getFormattedMessage(e));
                 if (CliArgHelper.FailBehavior.FAIL_AT_END != failBehavior) {
                     running = false;
                 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/StringShellRunner.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/StringShellRunner.java
@@ -8,7 +8,7 @@ import org.neo4j.shell.log.Logger;
 import javax.annotation.Nonnull;
 import java.util.Optional;
 
-import static org.neo4j.shell.exception.Helper.getSensibleMsg;
+import static org.neo4j.shell.exception.Helper.getFormattedMessage;
 
 /**
  * A shell runner which executes a single String and exits afterward. Any errors will throw immediately.
@@ -34,7 +34,7 @@ public class StringShellRunner implements ShellRunner {
         try {
             executer.execute(cypher.trim());
         } catch (Throwable t) {
-            logger.printError(getSensibleMsg(t));
+            logger.printError(getFormattedMessage(t));
             exitCode = 1;
         }
         return exitCode;

--- a/cypher-shell/src/main/java/org/neo4j/shell/commands/CommandHelper.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/commands/CommandHelper.java
@@ -7,6 +7,7 @@ import org.neo4j.shell.TransactionHandler;
 import org.neo4j.shell.VariableHolder;
 import org.neo4j.shell.exception.CommandException;
 import org.neo4j.shell.exception.DuplicateCommandException;
+import org.neo4j.shell.log.AnsiFormattedText;
 import org.neo4j.shell.log.Logger;
 
 import javax.annotation.Nonnull;
@@ -97,9 +98,8 @@ public class CommandHelper {
         }
 
         if (args.length < minCount || args.length > maxCount) {
-            throw new CommandException(
-                    String.format("Incorrect number of arguments.\nusage: @|bold %s|@ %s",
-                            commandName, usage));
+            throw new CommandException(AnsiFormattedText.from("Incorrect number of arguments.\nusage: ")
+                    .bold().append(commandName).boldOff().append(" ").append(usage));
         }
 
         return args;

--- a/cypher-shell/src/main/java/org/neo4j/shell/commands/Exit.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/commands/Exit.java
@@ -2,6 +2,7 @@ package org.neo4j.shell.commands;
 
 import org.neo4j.shell.exception.CommandException;
 import org.neo4j.shell.exception.ExitException;
+import org.neo4j.shell.log.AnsiFormattedText;
 import org.neo4j.shell.log.Logger;
 
 import javax.annotation.Nonnull;
@@ -42,7 +43,8 @@ public class Exit implements Command {
     @Nonnull
     @Override
     public String getHelp() {
-        return "Exit the logger. Corresponds to entering @|bold CTRL-D|@.";
+        return AnsiFormattedText.from("Exit the logger. Corresponds to entering ").bold().append("CTRL-D").boldOff()
+                                .append(".").formattedString();
     }
 
     @Nonnull

--- a/cypher-shell/src/main/java/org/neo4j/shell/commands/Help.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/commands/Help.java
@@ -2,6 +2,7 @@ package org.neo4j.shell.commands;
 
 import org.neo4j.shell.exception.CommandException;
 import org.neo4j.shell.log.Logger;
+import org.neo4j.shell.log.AnsiFormattedText;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
@@ -70,11 +71,17 @@ public class Help implements Command {
         }
 
         if (cmd == null) {
-            throw new CommandException(String.format("No such command: @|bold %s|@", name));
+            throw new CommandException(AnsiFormattedText.from("No such command: ").bold().append(name));
         }
 
-        logger.printOut(String.format("\nusage: @|bold %s|@ %s\n\n%s\n",
-                cmd.getName(), cmd.getUsage(), cmd.getHelp()));
+        logger.printOut(AnsiFormattedText.from("\nusage: ")
+                                         .bold().append(cmd.getName())
+                                         .boldOff()
+                                         .append(cmd.getUsage())
+                                         .append("\n\n")
+                                         .append(cmd.getHelp())
+                                         .append("\n")
+                                         .formattedString());
     }
 
     private void printGeneralHelp() {
@@ -85,13 +92,17 @@ public class Help implements Command {
 
         int leftColWidth = longestCmdLength(allCommands);
 
-        allCommands.stream().forEach(cmd -> {
-            logger.printOut(String.format("  @|bold %-" + leftColWidth + "s|@ %s",
-                    cmd.getName(), cmd.getDescription()));
-        });
+        allCommands.stream().forEach(cmd -> logger.printOut(
+                AnsiFormattedText.from("  ")
+                                 .bold().append(String.format("%-" + leftColWidth + "s", cmd.getName()))
+                                 .boldOff().append(" " + cmd.getDescription())
+                                 .formattedString()));
 
         logger.printOut("\nFor help on a specific command type:");
-        logger.printOut(String.format("    %s @|bold command|@\n", COMMAND_NAME));
+        logger.printOut(AnsiFormattedText.from("    ")
+                                         .append(COMMAND_NAME)
+                                         .bold().append(" command")
+                                         .boldOff().append("\n").formattedString());
     }
 
     private int longestCmdLength(List<Command> allCommands) {

--- a/cypher-shell/src/main/java/org/neo4j/shell/commands/Set.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/commands/Set.java
@@ -2,6 +2,7 @@ package org.neo4j.shell.commands;
 
 import org.neo4j.shell.VariableHolder;
 import org.neo4j.shell.exception.CommandException;
+import org.neo4j.shell.log.AnsiFormattedText;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
@@ -58,9 +59,8 @@ public class Set implements Command {
         Matcher m = argPattern.matcher(argString);
 
         if (!m.matches()) {
-            throw new CommandException(
-                    String.format("Incorrect number of arguments.\nusage: @|bold %s|@ %s",
-                            COMMAND_NAME, getUsage()));
+            throw new CommandException(AnsiFormattedText.from("Incorrect number of arguments.\nusage: ")
+                    .bold().append(COMMAND_NAME).boldOff().append(" ").append(getUsage()));
         }
 
         variableHolder.set(m.group("key"), m.group("value"));

--- a/cypher-shell/src/main/java/org/neo4j/shell/exception/AnsiFormattedException.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/exception/AnsiFormattedException.java
@@ -1,0 +1,28 @@
+package org.neo4j.shell.exception;
+
+import org.neo4j.shell.log.AnsiFormattedText;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * A type of exception where the message can formatted with Ansi codes.
+ */
+public class AnsiFormattedException extends Exception {
+    private final AnsiFormattedText message;
+
+    public AnsiFormattedException(@Nullable String message) {
+        super(message);
+        this.message = AnsiFormattedText.from(message);
+    }
+
+    public AnsiFormattedException(@Nonnull AnsiFormattedText message) {
+        super(message.plainString());
+        this.message = message;
+    }
+
+    @Nonnull
+    public AnsiFormattedText getFormattedMessage() {
+        return message;
+    }
+}

--- a/cypher-shell/src/main/java/org/neo4j/shell/exception/CommandException.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/exception/CommandException.java
@@ -1,10 +1,19 @@
 package org.neo4j.shell.exception;
 
+import org.neo4j.shell.log.AnsiFormattedText;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 /**
  * And exception indicating that a command invocation failed.
  */
-public class CommandException extends Exception {
-    public CommandException(String msg) {
+public class CommandException extends AnsiFormattedException {
+    public CommandException(@Nullable String msg) {
         super(msg);
+    }
+
+    public CommandException(@Nonnull AnsiFormattedText append) {
+        super(append);
     }
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/exception/Helper.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/exception/Helper.java
@@ -23,7 +23,7 @@ public class Helper {
      */
     @Nonnull
     public static String getSensibleMsg(@Nonnull final Throwable e) {
-        final String msg;
+        String msg;
         Throwable cause = getRootCause(e);
 
         if (cause instanceof CertificateException) {
@@ -31,6 +31,10 @@ public class Helper {
             msg = cause.getMessage();
         } else {
             msg = cause.getMessage();
+        }
+
+        if (msg == null) {
+            msg = cause.getClass().getSimpleName();
         }
 
         return msg;

--- a/cypher-shell/src/main/java/org/neo4j/shell/exception/Helper.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/exception/Helper.java
@@ -1,7 +1,8 @@
 package org.neo4j.shell.exception;
 
+import org.neo4j.shell.log.AnsiFormattedText;
+
 import javax.annotation.Nonnull;
-import java.security.cert.CertificateException;
 
 /**
  * Utility functions with regards to exception messages
@@ -22,21 +23,20 @@ public class Helper {
      * Interpret the cause of a Bolt exception and translate it into a sensible error message.
      */
     @Nonnull
-    public static String getSensibleMsg(@Nonnull final Throwable e) {
-        String msg;
+    public static String getFormattedMessage(@Nonnull final Throwable e) {
+        AnsiFormattedText msg = AnsiFormattedText.s().colorRed();
         Throwable cause = getRootCause(e);
 
-        if (cause instanceof CertificateException) {
-            // These seem to have sensible error messages in them
-            msg = cause.getMessage();
+        if (cause instanceof AnsiFormattedException) {
+            msg = msg.append(((AnsiFormattedException) cause).getFormattedMessage());
         } else {
-            msg = cause.getMessage();
+            if (cause.getMessage() != null ){
+                msg = msg.append(cause.getMessage());
+            } else {
+                msg = msg.append(cause.getClass().getSimpleName());
+            }
         }
 
-        if (msg == null) {
-            msg = cause.getClass().getSimpleName();
-        }
-
-        return msg;
+        return msg.formattedString();
     }
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/log/AnsiFormattedText.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/log/AnsiFormattedText.java
@@ -1,0 +1,202 @@
+package org.neo4j.shell.log;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A piece of text which can be rendered with Ansi format codes.
+ */
+public class AnsiFormattedText {
+
+    private static final String RED = "RED";
+    private static final String BOLD = "BOLD";
+    private static final String DEFAULT_COLOR = "DEFAULT";
+    // no mapping means not defined
+    private final Map<String, Boolean> attributes = new HashMap<>();
+    // Each piece is formatted separately
+    private final LinkedList<AnsiFormattedString> pieces = new LinkedList<>();
+    // can be defined, or undefined. null means undefined.
+    private String color = null;
+
+    /**
+     * Return a new map which is a copy of the first map, with the keys/values from the second if they do not override
+     * anything already defined in the first map.
+     */
+    private static <K, V> Map<K, V> mergeMaps(Map<K, V> primary, Map<K, V> secondary) {
+        Map<K, V> result = new HashMap<>();
+        result.putAll(primary);
+        secondary.forEach(result::putIfAbsent);
+        return result;
+    }
+
+    /**
+     *
+     * @return a new empty instance
+     */
+    public static AnsiFormattedText s() {
+        return new AnsiFormattedText();
+    }
+
+    /**
+     *
+     * @param string to start with, may be null in which case it is ignored
+     * @return a new instance containing the unformatted text in string, or empty if it was null
+     */
+    public static AnsiFormattedText from(@Nullable String string) {
+        AnsiFormattedText st = new AnsiFormattedText();
+        if (string != null) {
+            st.append(string);
+        }
+        return st;
+    }
+
+    /**
+     * @return the text as a string including possible formatting
+     */
+    @Nonnull
+    public String formattedString() {
+        StringBuilder sb = new StringBuilder();
+        for (AnsiFormattedString s : pieces) {
+            List<String> codes = new ArrayList<>();
+
+            // color
+            if (s.color != null && !DEFAULT_COLOR.equals(s.color)) {
+                codes.add(s.color);
+            }
+            // attributes
+            if (s.attributes.getOrDefault(BOLD, false)) {
+                codes.add(BOLD);
+            }
+            // Only do formatting if we actually have some formatting to apply
+            if (!codes.isEmpty()) {
+                sb.append("@|")
+                  .append(join(",", codes))
+                  .append(" ");
+            }
+            // string
+            sb.append(s.string);
+            // Only reset formatting if we actually did some formatting
+            if (!codes.isEmpty()) {
+                sb.append("|@");
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Join a list of strings together into a single string, separated by the specified delimiter
+     * @param delimiter to separate each string with
+     * @param strings to join together
+     * @return a single string. if strings contained a single item, that is returned as is.
+     */
+    private String join(String delimiter, List<String> strings) {
+        return strings.stream().skip(1).reduce(strings.get(0), (s1, s2) -> s1 + delimiter + s2);
+    }
+
+    @Override
+    public String toString() {
+        return formattedString();
+    }
+
+    /**
+     * @return the text as a plain string without any formatting
+     */
+    @Nonnull
+    public String plainString() {
+        StringBuilder sb = new StringBuilder();
+        pieces.forEach(sb::append);
+        return sb.toString();
+    }
+
+    /**
+     * Append an already formatted string. If any formatting codes are defined, then they will be ignored in favor
+     * of this instance's formatting.
+     *
+     * @param existing text to append using this instance's formatting
+     * @return this
+     */
+    public AnsiFormattedText append(AnsiFormattedText existing) {
+        existing.pieces.forEach(s -> pieces.add(new AnsiFormattedString(color != null ? color : s.color,
+                mergeMaps(attributes, s.attributes), s.string)));
+        return this;
+    }
+
+    /**
+     * Append a string using the current formatting
+     *
+     * @param s string to append using this instance's formatting
+     * @return this
+     */
+    public AnsiFormattedText append(String s) {
+        pieces.add(new AnsiFormattedString(color, attributes, s));
+        return this;
+    }
+
+    /**
+     * Set formatting to bold. Note that this has no effect on strings already in the text.
+     *
+     * @return this
+     */
+    public AnsiFormattedText bold() {
+        attributes.put(BOLD, true);
+        return this;
+    }
+
+    /**
+     * Set formatting to not bold. Note that this has no effect on strings already in the text.
+     *
+     * @return this
+     */
+    public AnsiFormattedText boldOff() {
+        attributes.put(BOLD, false);
+        return this;
+    }
+
+    /**
+     * Set color to red. Note that this has no effect on strings already in the text.
+     *
+     * @return this
+     */
+    public AnsiFormattedText colorRed() {
+        color = RED;
+        return this;
+    }
+
+    /**
+     * Set color to default. Note that this has no effect on strings already in the text.
+     *
+     * @return this
+     */
+    public AnsiFormattedText colorDefault() {
+        color = DEFAULT_COLOR;
+        return this;
+    }
+
+
+    /**
+     * A formatted string
+     */
+    private static class AnsiFormattedString {
+        // can be defined, or undefined. null means undefined.
+        final String color;
+        // same here, no mapping means undefined
+        final Map<String, Boolean> attributes = new HashMap<>();
+        final String string;
+
+        AnsiFormattedString(String color, Map<String, Boolean> attributes, String s) {
+            this.color = color;
+            this.attributes.putAll(attributes);
+            this.string = s;
+        }
+
+        @Override
+        public String toString() {
+            return string;
+        }
+    }
+}

--- a/cypher-shell/src/main/java/org/neo4j/shell/log/AnsiFormattedText.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/log/AnsiFormattedText.java
@@ -75,7 +75,7 @@ public class AnsiFormattedText {
             // Only do formatting if we actually have some formatting to apply
             if (!codes.isEmpty()) {
                 sb.append("@|")
-                  .append(join(",", codes))
+                  .append(String.join(",", codes))
                   .append(" ");
             }
             // string
@@ -86,16 +86,6 @@ public class AnsiFormattedText {
             }
         }
         return sb.toString();
-    }
-
-    /**
-     * Join a list of strings together into a single string, separated by the specified delimiter
-     * @param delimiter to separate each string with
-     * @param strings to join together
-     * @return a single string. if strings contained a single item, that is returned as is.
-     */
-    private String join(String delimiter, List<String> strings) {
-        return strings.stream().skip(1).reduce(strings.get(0), (s1, s2) -> s1 + delimiter + s2);
     }
 
     @Override

--- a/cypher-shell/src/main/java/org/neo4j/shell/log/AnsiLogger.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/log/AnsiLogger.java
@@ -1,9 +1,14 @@
 package org.neo4j.shell.log;
 
 import org.fusesource.jansi.Ansi;
+import org.fusesource.jansi.AnsiConsole;
 
 import javax.annotation.Nonnull;
 import java.io.PrintStream;
+
+import static org.fusesource.jansi.internal.CLibrary.STDERR_FILENO;
+import static org.fusesource.jansi.internal.CLibrary.STDOUT_FILENO;
+import static org.fusesource.jansi.internal.CLibrary.isatty;
 
 /**
  * A basic logger which prints Ansi formatted text to STDOUT and STDERR
@@ -19,6 +24,13 @@ public class AnsiLogger implements Logger {
     public AnsiLogger(@Nonnull PrintStream out, @Nonnull PrintStream err) {
         this.out = out;
         this.err = err;
+
+        if (isOutputInteractive()) {
+            Ansi.setEnabled(true);
+            AnsiConsole.systemInstall();
+        } else {
+            Ansi.setEnabled(false);
+        }
     }
 
     @Nonnull
@@ -41,5 +53,12 @@ public class AnsiLogger implements Logger {
     @Override
     public void printOut(@Nonnull final String msg) {
         out.println(Ansi.ansi().render(msg).toString());
+    }
+
+    /**
+     * @return true if the shell is outputting to a TTY, false otherwise (e.g., we are writing to a file)
+     */
+    private static boolean isOutputInteractive() {
+        return 1 == isatty(STDOUT_FILENO) && 1 == isatty(STDERR_FILENO);
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
@@ -4,6 +4,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.neo4j.driver.v1.StatementRunner;
 import org.neo4j.shell.cli.CliArgHelper;
 import org.neo4j.shell.cli.StringShellRunner;
 import org.neo4j.shell.commands.CommandExecutable;
@@ -20,10 +21,13 @@ import static junit.framework.TestCase.assertTrue;
 import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.contains;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 
 public class CypherShellTest {
@@ -187,5 +191,23 @@ public class CypherShellTest {
         // when
         // then
         assertFalse("Expected param to be unset", shell.remove("unknown var").isPresent());
+    }
+
+    @Test
+    public void setWithSomeBoltError() throws CommandException {
+        // then
+        thrown.expect(CommandException.class);
+        thrown.expectMessage("Failed to set value of parameter");
+
+        // given
+        StatementRunner runner = mock(StatementRunner.class);
+        when(runner.run(anyString(), anyMap())).thenReturn(null);
+        BoltStateHandler bh = mockedBoltStateHandler;
+        doReturn(runner).when(bh).getStatementRunner();
+
+        CypherShell shell = new CypherShell(logger, bh);
+
+        // when
+        shell.set("bob", "99");
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/cli/InteractiveShellRunnerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/cli/InteractiveShellRunnerTest.java
@@ -64,7 +64,7 @@ public class InteractiveShellRunnerTest {
         verify(cmdExecuter).execute("good3\n");
         verifyNoMoreInteractions(cmdExecuter);
 
-        verify(logger, times(2)).printError("bad cmd");
+        verify(logger, times(2)).printError("@|RED bad cmd|@");
     }
 
     @Test
@@ -94,6 +94,6 @@ public class InteractiveShellRunnerTest {
         verify(cmdExecuter).execute("exit\n");
         verifyNoMoreInteractions(cmdExecuter);
 
-        verify(logger).printError("bad cmd");
+        verify(logger).printError("@|RED bad cmd|@");
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/cli/NonInteractiveShellRunnerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/cli/NonInteractiveShellRunnerTest.java
@@ -60,7 +60,7 @@ public class NonInteractiveShellRunnerTest {
         int code = runner.runUntilEnd(cmdExecuter);
 
         assertEquals("Exit code incorrect", 1, code);
-        verify(logger).printError(eq("Found a bad line"));
+        verify(logger).printError(eq("@|RED Found a bad line|@"));
     }
 
     @Test
@@ -81,7 +81,7 @@ public class NonInteractiveShellRunnerTest {
         int code = runner.runUntilEnd(cmdExecuter);
 
         assertEquals("Exit code incorrect", 1, code);
-        verify(logger, times(2)).printError(eq("Found a bad line"));
+        verify(logger, times(2)).printError(eq("@|RED Found a bad line|@"));
     }
 
     private class GoodBadExecuter implements StatementExecuter {

--- a/cypher-shell/src/test/java/org/neo4j/shell/cli/StringShellRunnerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/cli/StringShellRunnerTest.java
@@ -56,6 +56,6 @@ public class StringShellRunnerTest {
         int code = runner.runUntilEnd(statementExecuter);
 
         assertEquals("Wrong exit code", 1, code);
-        verify(logger).printError("Error kaboom");
+        verify(logger).printError("@|RED Error kaboom|@");
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/commands/HelpTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/commands/HelpTest.java
@@ -16,10 +16,9 @@ import java.util.List;
 import static junit.framework.TestCase.fail;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.eq;
 
 public class HelpTest {
 
@@ -32,6 +31,7 @@ public class HelpTest {
 
     @Before
     public void setup() {
+
         this.cmd = new Help(logger, cmdHelper);
     }
 
@@ -65,11 +65,10 @@ public class HelpTest {
 
         // then
         verify(logger).printOut("\nAvailable commands:");
-        verify(logger).printOut("  @|bold bob  |@ description for bob");
-        verify(logger).printOut("  @|bold bobby|@ description for bobby");
+        verify(logger).printOut("  @|BOLD bob  |@ description for bob");
+        verify(logger).printOut("  @|BOLD bobby|@ description for bobby");
         verify(logger).printOut("\nFor help on a specific command type:");
-        verify(logger).printOut("    :help @|bold command|@\n");
-        verifyNoMoreInteractions(logger);
+        verify(logger).printOut("    :help@|BOLD  command|@\n");
     }
 
     @Test
@@ -81,16 +80,15 @@ public class HelpTest {
         cmd.execute("bob");
 
         // then
-        verify(logger).printOut("\nusage: @|bold bob|@ usage for bob\n"
+        verify(logger).printOut("\nusage: @|BOLD bob|@usage for bob\n"
                                + "\nhelp for bob\n");
-        verifyNoMoreInteractions(logger);
     }
 
     @Test
     public void helpForNonExistingCommandThrows() throws CommandException {
         // then
         thrown.expect(CommandException.class);
-        thrown.expectMessage("No such command: @|bold notacommandname|@");
+        thrown.expectMessage("No such command: notacommandname");
 
         // when
         cmd.execute("notacommandname");
@@ -105,9 +103,8 @@ public class HelpTest {
         cmd.execute("bob");
 
         // then
-        verify(logger).printOut("\nusage: @|bold :bob|@ usage for :bob\n"
+        verify(logger).printOut("\nusage: @|BOLD :bob|@usage for :bob\n"
                 + "\nhelp for :bob\n");
-        verifyNoMoreInteractions(logger);
     }
 
     private class FakeCommand implements Command {

--- a/cypher-shell/src/test/java/org/neo4j/shell/exception/HelperTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/exception/HelperTest.java
@@ -4,22 +4,23 @@ import org.junit.Test;
 import org.neo4j.driver.v1.exceptions.ClientException;
 
 import static org.junit.Assert.assertEquals;
-import static org.neo4j.shell.exception.Helper.getSensibleMsg;
+import static org.neo4j.shell.exception.Helper.getFormattedMessage;
 
 public class HelperTest {
     @Test
     public void testSimple() {
-        assertEquals("yahoo", getSensibleMsg(new NullPointerException("yahoo")));
+        assertEquals("@|RED yahoo|@", getFormattedMessage(new NullPointerException("yahoo")));
     }
 
     @Test
     public void testNested() {
-        assertEquals("nested", getSensibleMsg(new ClientException("outer", new CommandException("nested"))));
+        assertEquals("@|RED nested|@", getFormattedMessage(new ClientException("outer",
+                new CommandException("nested"))));
     }
 
     @Test
     public void testNestedDeep() {
-        assertEquals("nested deep", getSensibleMsg(
+        assertEquals("@|RED nested deep|@", getFormattedMessage(
                 new ClientException("outer",
                         new ClientException("nested",
                                 new ClientException("nested deep")))));
@@ -27,8 +28,8 @@ public class HelperTest {
 
     @Test
     public void testNullMessage() {
-        assertEquals("ClientException", getSensibleMsg(new ClientException(null)));
-        assertEquals("NullPointerException",
-                getSensibleMsg(new ClientException("outer", new NullPointerException(null))));
+        assertEquals("@|RED ClientException|@", getFormattedMessage(new ClientException(null)));
+        assertEquals("@|RED NullPointerException|@",
+                getFormattedMessage(new ClientException("outer", new NullPointerException(null))));
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/exception/HelperTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/exception/HelperTest.java
@@ -24,4 +24,11 @@ public class HelperTest {
                         new ClientException("nested",
                                 new ClientException("nested deep")))));
     }
+
+    @Test
+    public void testNullMessage() {
+        assertEquals("ClientException", getSensibleMsg(new ClientException(null)));
+        assertEquals("NullPointerException",
+                getSensibleMsg(new ClientException("outer", new NullPointerException(null))));
+    }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/log/AnsiFormattedTextTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/log/AnsiFormattedTextTest.java
@@ -1,0 +1,87 @@
+package org.neo4j.shell.log;
+
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class AnsiFormattedTextTest {
+
+    @Test
+    public void simpleString() {
+        AnsiFormattedText st = AnsiFormattedText.from("hello");
+        assertEquals("hello", st.plainString());
+        assertEquals("hello", st.formattedString());
+    }
+
+    @Test
+    public void noStyleShouldBePlain() throws Exception {
+        AnsiFormattedText st = AnsiFormattedText.s()
+                                                .colorDefault()
+                                                .boldOff()
+                                                .append("yo");
+
+        assertEquals("yo", st.plainString());
+        assertEquals("yo", st.formattedString());
+    }
+
+    @Test
+    public void withFormatting() throws Exception {
+        AnsiFormattedText st = AnsiFormattedText.s()
+                                                .bold()
+                                                .colorRed()
+                                                .append("hello")
+                                                .colorDefault()
+                                                .boldOff()
+                                                .append(" world");
+
+        assertEquals("hello world", st.plainString());
+        assertEquals("@|RED,BOLD hello|@ world", st.formattedString());
+        assertEquals("@|RED,BOLD hello|@ world", st.toString());
+    }
+
+    @Test
+    public void nestedFormattingWorks() throws Exception {
+        AnsiFormattedText st = AnsiFormattedText.s()
+                                                .colorDefault()
+                                                .bold()
+                                                .append("hello")
+                                                .boldOff()
+                                                .append(" world");
+        st = AnsiFormattedText.s().colorRed().append(st);
+
+        assertEquals("hello world", st.plainString());
+        assertEquals("@|RED,BOLD hello|@@|RED  world|@", st.formattedString());
+    }
+
+    @Test
+    public void outerAttributeTakesColorPrecedence() throws Exception {
+        AnsiFormattedText st = AnsiFormattedText.s().colorRed().append("inner");
+
+        assertEquals("@|RED inner|@", st.formattedString());
+
+        st = AnsiFormattedText.s().colorDefault().append(st);
+
+        assertEquals("inner", st.formattedString());
+    }
+
+    @Test
+    public void outerAttributeTakesBoldPrecedence() throws Exception {
+        AnsiFormattedText st = AnsiFormattedText.s().colorRed().bold().append("inner");
+
+        assertEquals("@|RED,BOLD inner|@", st.formattedString());
+
+        st = AnsiFormattedText.s().boldOff().append(st);
+
+        assertEquals("@|RED inner|@", st.formattedString());
+    }
+
+    @Test
+    public void shouldAppend() throws Exception {
+        AnsiFormattedText st = AnsiFormattedText.from("hello");
+
+        st = st.append(" world");
+
+        assertEquals("hello world", st.plainString());
+    }
+}


### PR DESCRIPTION
Example in interactive session (notice that the error is both red and has something bold)

![selection_056](https://cloud.githubusercontent.com/assets/223655/17175663/164e3bde-5409-11e6-8a8d-213f5f2d6008.png)

If output is piped to a file, then no formatting gets applied:

![selection_057](https://cloud.githubusercontent.com/assets/223655/17175673/22105bb4-5409-11e6-88e6-8e2fa79c8b1a.png)
