### PR TITLE
Force JLine to throw exceptions on errors and catch them

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CommandReader.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CommandReader.java
@@ -109,13 +109,13 @@ public class CommandReader implements Historian {
      */
     @Nullable
     public String readCommand() throws IOException {
-        StringBuffer stringBuffer = new StringBuffer();
+        StringBuilder stringBuilder = new StringBuilder();
         boolean reading = true;
         while (reading) {
             String line = reader.readLine(prompt);
             if (line == null) {
                 reading = false;
-                if (stringBuffer.length() == 0) {
+                if (stringBuilder.length() == 0) {
                     return null;
                 }
             } else {
@@ -125,14 +125,14 @@ public class CommandReader implements Historian {
                 String parsedString = m.replaceAll("");
 
                 if (!parsedString.trim().isEmpty()) {
-                    stringBuffer.append(parsedString).append("\n");
+                    stringBuilder.append(parsedString).append("\n");
                 }
-                if (!isMultiline && stringBuffer.length() > 0) {
+                if (!isMultiline && stringBuilder.length() > 0) {
                     reading = false;
                 }
             }
         }
-        return stringBuffer.toString();
+        return stringBuilder.toString();
     }
 
     private String commentSubstitutedLine(String line) {

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CommandReader.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CommandReader.java
@@ -50,6 +50,9 @@ public class CommandReader implements Historian {
         if (historyFile != null) {
             setupHistoryFile(reader, logger, historyFile);
         }
+        // Intercept errors in Jline by catching its error prints. We don't want stack traces to be printed.
+        // Instead, catch the error, and handle it.
+        jline.internal.Log.setOutput(new ErrorPassingPrintStream());
     }
 
     @Nonnull
@@ -136,4 +139,5 @@ public class CommandReader implements Historian {
         Matcher commentsMatcher = COMMENTS.matcher(line);
         return commentsMatcher.replaceAll("");
     }
+
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CommandReader.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CommandReader.java
@@ -30,6 +30,7 @@ public class CommandReader implements Historian {
     static final Pattern COMMENTS = Pattern.compile("//.*$");
     private final String prompt = Ansi.ansi().render(AnsiFormattedText.s().bold().append("neo4j> ")
                                                                       .formattedString()).toString();
+    private FileHistory fileHistory;
 
     public CommandReader(@Nonnull Logger logger, final boolean useHistoryFile) throws IOException {
         this(System.in, logger, useHistoryFile);
@@ -74,6 +75,7 @@ public class CommandReader implements Historian {
                 throw new IOException("Failed to create directory for history: " + dir.getAbsolutePath());
             }
             final FileHistory history = new FileHistory(historyFile);
+            this.fileHistory = history;
             reader.setHistory(history);
 
             // Make sure we flush history on exit
@@ -95,7 +97,7 @@ public class CommandReader implements Historian {
     }
 
     @Nonnull
-    private static File getDefaultHistoryFile() {
+    static File getDefaultHistoryFile() {
         // Storing in same directory as driver uses
         File dir = new File(getProperty("user.home"), ".neo4j");
         return new File(dir, ".neo4j_history");
@@ -140,4 +142,12 @@ public class CommandReader implements Historian {
         return commentsMatcher.replaceAll("");
     }
 
+    /**
+     * Useful in tests only
+     */
+    void flushHistory() throws IOException {
+        if (fileHistory != null) {
+            fileHistory.flush();
+        }
+    }
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CommandReader.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CommandReader.java
@@ -6,6 +6,7 @@ import jline.console.history.History;
 import jline.console.history.MemoryHistory;
 import org.fusesource.jansi.Ansi;
 import org.neo4j.shell.Historian;
+import org.neo4j.shell.exception.JLineException;
 import org.neo4j.shell.log.AnsiFormattedText;
 import org.neo4j.shell.log.Logger;
 
@@ -114,7 +115,22 @@ public class CommandReader implements Historian {
         StringBuilder stringBuilder = new StringBuilder();
         boolean reading = true;
         while (reading) {
-            String line = reader.readLine(prompt);
+            String line;
+            try {
+                line = reader.readLine(prompt);
+            } catch (JLineException e) {
+                // Clear the buffer
+                // in front
+                reader.killLine();
+                // in back
+                boolean moreToDelete = true;
+                while (moreToDelete) {
+                    moreToDelete = reader.backspace();
+                }
+
+                // then rethrow
+                throw e;
+            }
             if (line == null) {
                 reading = false;
                 if (stringBuilder.length() == 0) {

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/ErrorPassingPrintStream.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/ErrorPassingPrintStream.java
@@ -1,0 +1,168 @@
+package org.neo4j.shell.cli;
+
+import org.neo4j.shell.exception.JLineException;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Locale;
+
+/**
+ * This PrintStream will throw an exception when invoked. This is so that JLine gives us the error, instead of
+ * printing directly to STDERR.
+ */
+class ErrorPassingPrintStream extends PrintStream {
+
+    ErrorPassingPrintStream() {
+        super(System.err);
+    }
+
+    @Override
+    public void write(int b) {
+        throw new JLineException();
+    }
+
+    @Override
+    public void write(byte[] buf, int off, int len) {
+        throw new JLineException();
+    }
+
+    @Override
+    public void print(boolean b) {
+        throw new JLineException();
+    }
+
+    @Override
+    public void print(char c) {
+        throw new JLineException();
+    }
+
+    @Override
+    public void print(int i) {
+        throw new JLineException();
+    }
+
+    @Override
+    public void print(long l) {
+        throw new JLineException();
+    }
+
+    @Override
+    public void print(float f) {
+        throw new JLineException();
+    }
+
+    @Override
+    public void print(double d) {
+        throw new JLineException();
+    }
+
+    @Override
+    public void print(char[] s) {
+        throw new JLineException();
+    }
+
+    @Override
+    public void print(String s) {
+        throw new JLineException();
+    }
+
+    @Override
+    public void print(Object obj) {
+        // will receive a string with message, before actual exception is printed. waiting for exception, so ignore
+    }
+
+    @Override
+    public void println() {
+        // Newlines are printed before stacktraces by JLine, so just ignore them
+    }
+
+    @Override
+    public void println(boolean x) {
+        throw new JLineException();
+    }
+
+    @Override
+    public void println(char x) {
+        throw new JLineException();
+    }
+
+    @Override
+    public void println(int x) {
+        throw new JLineException();
+    }
+
+    @Override
+    public void println(long x) {
+        throw new JLineException();
+    }
+
+    @Override
+    public void println(float x) {
+        throw new JLineException();
+    }
+
+    @Override
+    public void println(double x) {
+        throw new JLineException();
+    }
+
+    @Override
+    public void println(char[] x) {
+        throw new JLineException();
+    }
+
+    @Override
+    public void println(String x) {
+        throw new JLineException();
+    }
+
+    @Override
+    public void println(Object x) {
+        // exceptions, when printing stacktraces, will first print themselves
+        if (x instanceof Throwable) {
+            throw new JLineException(((Throwable) x).getMessage());
+        }
+        throw new JLineException(); //java.lang.IllegalArgumentException: !bang": event not found
+    }
+
+    @Override
+    public PrintStream printf(String format, Object... args) {
+        return format(format, args);
+    }
+
+    @Override
+    public PrintStream printf(Locale l, String format, Object... args) {
+        return format(format, args);
+    }
+
+    @Override
+    public PrintStream format(String format, Object... args) {
+        // JLine will print a line such as "[%s]", "ERROR". Exception will be printed later, wait for that.
+        return this;
+    }
+
+    @Override
+    public PrintStream format(Locale l, String format, Object... args) {
+        return format(format, args);
+    }
+
+    @Override
+    public PrintStream append(CharSequence csq) {
+        throw new JLineException();
+    }
+
+    @Override
+    public PrintStream append(CharSequence csq, int start, int end) {
+        throw new JLineException();
+    }
+
+    @Override
+    public PrintStream append(char c) {
+        throw new JLineException();
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+        throw new JLineException();
+    }
+}

--- a/cypher-shell/src/main/java/org/neo4j/shell/commands/Set.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/commands/Set.java
@@ -51,7 +51,7 @@ public class Set implements Command {
     @Nonnull
     @Override
     public List<String> getAliases() {
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     @Override

--- a/cypher-shell/src/main/java/org/neo4j/shell/exception/JLineException.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/exception/JLineException.java
@@ -1,0 +1,17 @@
+package org.neo4j.shell.exception;
+
+import javax.annotation.Nullable;
+
+/**
+ * A generic exception supposed to be thrown in JLine when {@link org.neo4j.shell.cli.ErrorPassingPrintStream} is
+ * invoked.
+ */
+public class JLineException extends RuntimeException {
+    public JLineException() {
+        super("Unable to parse input");
+    }
+
+    public JLineException(@Nullable String message) {
+        super(message);
+    }
+}

--- a/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
@@ -21,7 +21,7 @@ import static junit.framework.TestCase.assertTrue;
 import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.mockito.Matchers.anyMap;
+import static org.mockito.Matchers.anyMapOf;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.contains;
 import static org.mockito.Mockito.doReturn;
@@ -97,7 +97,9 @@ public class CypherShellTest {
 
         assertTrue(shell.getAll().isEmpty());
 
-        assertEquals("99", shell.set("bob", "99").get());
+        Optional result = shell.set("bob", "99");
+        assertTrue(result.isPresent());
+        assertEquals("99", result.get());
         assertEquals("99", shell.getAll().get("bob"));
 
         shell.remove("bob");
@@ -201,7 +203,7 @@ public class CypherShellTest {
 
         // given
         StatementRunner runner = mock(StatementRunner.class);
-        when(runner.run(anyString(), anyMap())).thenReturn(null);
+        when(runner.run(anyString(), anyMapOf(String.class, Object.class))).thenReturn(null);
         BoltStateHandler bh = mockedBoltStateHandler;
         doReturn(runner).when(bh).getStatementRunner();
 

--- a/cypher-shell/src/test/java/org/neo4j/shell/cli/CommandReaderTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/cli/CommandReaderTest.java
@@ -4,23 +4,38 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
 import org.neo4j.shell.exception.JLineException;
 import org.neo4j.shell.log.Logger;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.InputStream;
 import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
 
+import static java.lang.System.getProperty;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class CommandReaderTest {
+    @Rule
+    public TemporaryFolder temp = new TemporaryFolder();
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
     Logger logger = mock(Logger.class);
+    InputStream mockedInput = mock(InputStream.class);
 
     @Before
     public void setup() {
@@ -199,6 +214,49 @@ public class CommandReaderTest {
     }
 
     @Test
+    public void historyIsRecorded() throws Exception {
+        // given
+        File historyFile = temp.newFile();
+
+        String cmd1 = ":set var \"3\"";
+        String cmd2 = ":help exit";
+        String inputString = cmd1 + "\n" + cmd2 + "\n";
+
+        InputStream inputStream = new ByteArrayInputStream(inputString.getBytes());
+        CommandReader commandReader = new CommandReader(inputStream, logger, historyFile);
+
+        // when
+        assertEquals(cmd1 + "\n", commandReader.readCommand());
+        assertEquals(cmd2 + "\n", commandReader.readCommand());
+
+        commandReader.flushHistory();
+
+        // then
+        List<String> history = Files.readAllLines(historyFile.toPath());
+
+        assertEquals(2, history.size());
+        assertEquals(cmd1, history.get(0));
+        assertEquals(cmd2, history.get(1));
+    }
+
+    @Test
+    public void badHistoryFileFallsBackToMemoryFile() throws Exception {
+        new CommandReader(mockedInput, logger,
+                new File("/temp/aasbzs/asfaz/asdfasvzx/asfdasdf/asdfasd"));
+        verify(logger).printError("Could not load history file. Falling back to session-based history.\n" +
+                "Failed to create directory for history: /temp/aasbzs/asfaz/asdfasvzx/asfdasdf");
+
+    }
+
+    @Test
+    public void defaultHistoryFile() throws Exception {
+        Path expectedPath = Paths.get(getProperty("user.home"), ".neo4j", ".neo4j_history");
+
+        File history = CommandReader.getDefaultHistoryFile();
+        assertEquals(expectedPath.toString(), history.getPath());
+    }
+
+    @Test
     public void unescapedBangThrowsException() throws Exception {
         thrown.expect(JLineException.class);
         thrown.expectMessage("!bang\": event not found");
@@ -211,6 +269,9 @@ public class CommandReaderTest {
         String inputString = ":set var \"String with !bang\"\n";
         InputStream inputStream = new ByteArrayInputStream(inputString.getBytes());
         CommandReader commandReader = new CommandReader(inputStream, logger);
+
+        assertEquals(ErrorPassingPrintStream.class.getSimpleName(),
+                jline.internal.Log.getOutput().getClass().getSimpleName());
 
         // when
         commandReader.readCommand();


### PR DESCRIPTION
By default, JLine will print stacktraces to STDERR on errors. We don't want stacktraces, so we force JLine to throw a RuntimeException which we later catch and print more nicely.

Also increases test coverage.

Here is what happens on errors now (unescaped bangs (!) are the only things I know for sure can invoke an error in jline)

![selection_040](https://cloud.githubusercontent.com/assets/223655/17220119/75f6e550-54ee-11e6-883a-fc32842b3543.png)

compare that to the old behavior:

![selection_039](https://cloud.githubusercontent.com/assets/223655/17219814/1286033a-54ed-11e6-8287-1595b6256394.png)
