### PR TITLE
Disable expansion

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CommandReader.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CommandReader.java
@@ -48,6 +48,8 @@ public class CommandReader implements Historian {
     public CommandReader(@Nonnull InputStream inputStream, @Nonnull Logger logger,
                          @Nullable File historyFile) throws IOException {
         reader = new ConsoleReader(inputStream, logger.getOutputStream());
+        // Disable expansion of bangs: !
+        reader.setExpandEvents(false);
         if (historyFile != null) {
             setupHistoryFile(reader, logger, historyFile);
         }

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CommandReader.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CommandReader.java
@@ -30,6 +30,7 @@ public class CommandReader implements Historian {
     static final Pattern COMMENTS = Pattern.compile("//.*$");
     private final String prompt = Ansi.ansi().render(AnsiFormattedText.s().bold().append("neo4j> ")
                                                                       .formattedString()).toString();
+    private FileHistory fileHistory;
 
     public CommandReader(@Nonnull Logger logger, final boolean useHistoryFile) throws IOException {
         this(System.in, logger, useHistoryFile);
@@ -71,6 +72,7 @@ public class CommandReader implements Historian {
                 throw new IOException("Failed to create directory for history: " + dir.getAbsolutePath());
             }
             final FileHistory history = new FileHistory(historyFile);
+            this.fileHistory = history;
             reader.setHistory(history);
 
             // Make sure we flush history on exit
@@ -92,7 +94,7 @@ public class CommandReader implements Historian {
     }
 
     @Nonnull
-    private static File getDefaultHistoryFile() {
+    static File getDefaultHistoryFile() {
         // Storing in same directory as driver uses
         File dir = new File(getProperty("user.home"), ".neo4j");
         return new File(dir, ".neo4j_history");
@@ -135,5 +137,14 @@ public class CommandReader implements Historian {
     private String commentSubstitutedLine(String line) {
         Matcher commentsMatcher = COMMENTS.matcher(line);
         return commentsMatcher.replaceAll("");
+    }
+
+    /**
+     * Useful in tests only
+     */
+    void flushHistory() throws IOException {
+        if (fileHistory != null) {
+            fileHistory.flush();
+        }
     }
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CommandReader.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CommandReader.java
@@ -106,13 +106,13 @@ public class CommandReader implements Historian {
      */
     @Nullable
     public String readCommand() throws IOException {
-        StringBuffer stringBuffer = new StringBuffer();
+        StringBuilder stringBuilder = new StringBuilder();
         boolean reading = true;
         while (reading) {
             String line = reader.readLine(prompt);
             if (line == null) {
                 reading = false;
-                if (stringBuffer.length() == 0) {
+                if (stringBuilder.length() == 0) {
                     return null;
                 }
             } else {
@@ -122,14 +122,14 @@ public class CommandReader implements Historian {
                 String parsedString = m.replaceAll("");
 
                 if (!parsedString.trim().isEmpty()) {
-                    stringBuffer.append(parsedString).append("\n");
+                    stringBuilder.append(parsedString).append("\n");
                 }
-                if (!isMultiline && stringBuffer.length() > 0) {
+                if (!isMultiline && stringBuilder.length() > 0) {
                     reading = false;
                 }
             }
         }
-        return stringBuffer.toString();
+        return stringBuilder.toString();
     }
 
     private String commentSubstitutedLine(String line) {

--- a/cypher-shell/src/main/java/org/neo4j/shell/commands/Set.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/commands/Set.java
@@ -51,7 +51,7 @@ public class Set implements Command {
     @Nonnull
     @Override
     public List<String> getAliases() {
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     @Override

--- a/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
@@ -21,7 +21,7 @@ import static junit.framework.TestCase.assertTrue;
 import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.mockito.Matchers.anyMap;
+import static org.mockito.Matchers.anyMapOf;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.contains;
 import static org.mockito.Mockito.doReturn;
@@ -97,7 +97,9 @@ public class CypherShellTest {
 
         assertTrue(shell.getAll().isEmpty());
 
-        assertEquals("99", shell.set("bob", "99").get());
+        Optional result = shell.set("bob", "99");
+        assertTrue(result.isPresent());
+        assertEquals("99", result.get());
         assertEquals("99", shell.getAll().get("bob"));
 
         shell.remove("bob");
@@ -201,7 +203,7 @@ public class CypherShellTest {
 
         // given
         StatementRunner runner = mock(StatementRunner.class);
-        when(runner.run(anyString(), anyMap())).thenReturn(null);
+        when(runner.run(anyString(), anyMapOf(String.class, Object.class))).thenReturn(null);
         BoltStateHandler bh = mockedBoltStateHandler;
         doReturn(runner).when(bh).getStatementRunner();
 

--- a/cypher-shell/src/test/java/org/neo4j/shell/cli/CommandReaderTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/cli/CommandReaderTest.java
@@ -251,4 +251,34 @@ public class CommandReaderTest {
         File history = CommandReader.getDefaultHistoryFile();
         assertEquals(expectedPath.toString(), history.getPath());
     }
+
+    @Test
+    public void unescapedBangWorks() throws Exception {
+        // given
+        PrintStream mockedErr = mock(PrintStream.class);
+        when(logger.getErrorStream()).thenReturn(mockedErr);
+
+        // Bangs need escaping in JLine by default, just like in bash, but we have disabled that
+        String inputString = ":set var \"String with !bang\"\n";
+        InputStream inputStream = new ByteArrayInputStream(inputString.getBytes());
+        CommandReader commandReader = new CommandReader(inputStream, logger);
+
+        // when then
+        assertEquals(inputString, commandReader.readCommand());
+    }
+
+    @Test
+    public void escapedBangWorks() throws Exception {
+        // given
+        PrintStream mockedErr = mock(PrintStream.class);
+        when(logger.getErrorStream()).thenReturn(mockedErr);
+
+        // Bangs need escaping in JLine, just like in bash
+        String inputString = ":set var \"String with \\!bang\"\n";
+        InputStream inputStream = new ByteArrayInputStream(inputString.getBytes());
+        CommandReader commandReader = new CommandReader(inputStream, logger);
+
+        // when then
+        assertEquals(inputString, commandReader.readCommand());
+    }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/cli/CommandReaderTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/cli/CommandReaderTest.java
@@ -1,21 +1,37 @@
 package org.neo4j.shell.cli;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.neo4j.shell.log.Logger;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.InputStream;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
 
+import static java.lang.System.getProperty;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class CommandReaderTest {
+    @Rule
+    public TemporaryFolder temp = new TemporaryFolder();
 
     Logger logger = mock(Logger.class);
+    InputStream mockedInput = mock(InputStream.class);
 
     @Before
     public void setup() {
@@ -191,5 +207,48 @@ public class CommandReaderTest {
 
         // then
         assertThat(actual, is("CREATE (n: Person{name :\"John \\ Smith\"}) \n RETURN n\n"));
+    }
+
+    @Test
+    public void historyIsRecorded() throws Exception {
+        // given
+        File historyFile = temp.newFile();
+
+        String cmd1 = ":set var \"3\"";
+        String cmd2 = ":help exit";
+        String inputString = cmd1 + "\n" + cmd2 + "\n";
+
+        InputStream inputStream = new ByteArrayInputStream(inputString.getBytes());
+        CommandReader commandReader = new CommandReader(inputStream, logger, historyFile);
+
+        // when
+        assertEquals(cmd1 + "\n", commandReader.readCommand());
+        assertEquals(cmd2 + "\n", commandReader.readCommand());
+
+        commandReader.flushHistory();
+
+        // then
+        List<String> history = Files.readAllLines(historyFile.toPath());
+
+        assertEquals(2, history.size());
+        assertEquals(cmd1, history.get(0));
+        assertEquals(cmd2, history.get(1));
+    }
+
+    @Test
+    public void badHistoryFileFallsBackToMemoryFile() throws Exception {
+        new CommandReader(mockedInput, logger,
+                new File("/temp/aasbzs/asfaz/asdfasvzx/asfdasdf/asdfasd"));
+        verify(logger).printError("Could not load history file. Falling back to session-based history.\n" +
+                "Failed to create directory for history: /temp/aasbzs/asfaz/asdfasvzx/asfdasdf");
+
+    }
+
+    @Test
+    public void defaultHistoryFile() throws Exception {
+        Path expectedPath = Paths.get(getProperty("user.home"), ".neo4j", ".neo4j_history");
+
+        File history = CommandReader.getDefaultHistoryFile();
+        assertEquals(expectedPath.toString(), history.getPath());
     }
 }


### PR DESCRIPTION
Make sure JLine doesn't print stack traces, and that new users don't get confused, by disabling expansion of bangs (`!`).

Example (bangs are no longer special and do not need to be escaped):

![selection_041](https://cloud.githubusercontent.com/assets/223655/17242628/601f05e8-5578-11e6-8f32-dafa61fb2acb.png)

Supercedes #19 