### PR TITLE
Do some basic Ctrl-C handling

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CommandReader.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CommandReader.java
@@ -50,6 +50,8 @@ public class CommandReader implements Historian {
         reader = new ConsoleReader(inputStream, logger.getOutputStream());
         // Disable expansion of bangs: !
         reader.setExpandEvents(false);
+        // Have JLine throw exception on Ctrl-C so one can abort search and stuff without quitting
+        reader.setHandleUserInterrupt(true);
         if (historyFile != null) {
             setupHistoryFile(reader, logger, historyFile);
         }

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/InteractiveShellRunner.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/InteractiveShellRunner.java
@@ -1,10 +1,12 @@
 package org.neo4j.shell.cli;
 
-import org.neo4j.shell.StatementExecuter;
+import jline.console.UserInterruptException;
 import org.neo4j.shell.Historian;
 import org.neo4j.shell.ShellRunner;
+import org.neo4j.shell.StatementExecuter;
 import org.neo4j.shell.exception.CommandException;
 import org.neo4j.shell.exception.ExitException;
+import org.neo4j.shell.log.AnsiFormattedText;
 import org.neo4j.shell.log.Logger;
 
 import javax.annotation.Nonnull;
@@ -35,6 +37,9 @@ public class InteractiveShellRunner implements ShellRunner {
             } catch (ExitException e) {
                 exitCode = e.getCode();
                 running = false;
+            } catch (UserInterruptException e) {
+                // Not very nice to print "UserInterruptException"
+                logger.printError(AnsiFormattedText.s().colorRed().append("KeyboardInterrupt").formattedString());
             } catch (Throwable e) {
                 logger.printError(getFormattedMessage(e));
             }

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/NonInteractiveShellRunner.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/NonInteractiveShellRunner.java
@@ -1,8 +1,9 @@
 package org.neo4j.shell.cli;
 
-import org.neo4j.shell.StatementExecuter;
+import jline.console.UserInterruptException;
 import org.neo4j.shell.Historian;
 import org.neo4j.shell.ShellRunner;
+import org.neo4j.shell.StatementExecuter;
 import org.neo4j.shell.exception.ExitException;
 import org.neo4j.shell.log.Logger;
 
@@ -45,7 +46,7 @@ public class NonInteractiveShellRunner implements ShellRunner {
                 if (!command.trim().isEmpty()) {
                     executer.execute(command);
                 }
-            } catch (ExitException e) {
+            } catch (ExitException | UserInterruptException e) {
                 // These exceptions are always fatal
                 exitCode = 1;
                 running = false;

--- a/cypher-shell/src/test/java/org/neo4j/shell/test/Util.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/test/Util.java
@@ -4,13 +4,28 @@ public class Util {
     public static String[] asArray(String... arguments) {
         return arguments;
     }
-    static Object[] asObjectArray(Object... arguments) {
-        return arguments;
-    }
 
     public static class NotImplementedYetException extends RuntimeException {
         public NotImplementedYetException(String message) {
             super(message);
         }
+    }
+
+    /**
+     * Generate the control code for the specified character. For example, give this method 'C', and it will return
+     * the code for `Ctrl-C`, which you can append to an inputbuffer for example, in order to simulate the  user
+     * pressing Ctrl-C.
+     *
+     * @param let character to generate code for, must be between A and Z
+     * @return control code for given character
+     */
+    public static char ctrl(final char let) {
+        if (let < 'A' || let > 'Z') {
+            throw new IllegalArgumentException("Cannot generate CTRL code for "
+                    + "char '" + let + "' (" + ((int) let) + ")");
+        }
+
+        int result = ((int) let) - 'A' + 1;
+        return (char) result;
     }
 }


### PR DESCRIPTION
This changes nothing if the shell is blocking inside bolt. But
if we are currently reading a command, or in history, or otherwise
"shell located", it does.
    
- NonInteractiveShell
  CtrlC is always a terminating action
    
- InteractiveShell
  CtrlC is an interrupt action and will reset your
  prompt. It will not exit the shell. (E.g., hit Ctrl-R to search history,
  then hit Ctrl-C to get out of it).
    
This mirrors behavior in for example the iPython shell.
