### PR TITLE
Multiline niceness

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CommandReader.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CommandReader.java
@@ -1,6 +1,7 @@
 package org.neo4j.shell.cli;
 
 import jline.console.ConsoleReader;
+import jline.console.UserInterruptException;
 import jline.console.history.FileHistory;
 import jline.console.history.History;
 import jline.console.history.MemoryHistory;
@@ -112,7 +113,15 @@ public class CommandReader implements Historian {
     @Nullable
     public String readCommand() throws IOException {
         while (!parser.isStatementComplete()) {
-            String line = reader.readLine(parser.getPrompt().renderedString());
+            String line;
+            try {
+                line = reader.readLine(parser.getPrompt().renderedString());
+            } catch (UserInterruptException e) {
+                // Uesr pressed Ctrl-C, clear current parser state
+                parser.reset();
+                // Handle this error like the rest
+                throw e;
+            }
             if (line == null) {
                 return null;
             }

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CommandReader.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CommandReader.java
@@ -1,7 +1,6 @@
 package org.neo4j.shell.cli;
 
 import jline.console.ConsoleReader;
-import jline.console.UserInterruptException;
 import jline.console.history.FileHistory;
 import jline.console.history.History;
 import jline.console.history.MemoryHistory;
@@ -113,20 +112,18 @@ public class CommandReader implements Historian {
     @Nullable
     public String readCommand() throws IOException {
         while (!parser.isStatementComplete()) {
-            String line;
             try {
-                line = reader.readLine(parser.getPrompt().renderedString());
-            } catch (UserInterruptException e) {
-                // Uesr pressed Ctrl-C, clear current parser state
+                String line = reader.readLine(parser.getPrompt().renderedString());
+                if (line == null) {
+                    return null;
+                }
+                parser.parseLine(line);
+            } catch (Throwable t) {
+                // User pressed Ctrl-C, or made a boo-boo, clear current parser state
                 parser.reset();
                 // Handle this error like the rest
-                throw e;
+                throw t;
             }
-            if (line == null) {
-                return null;
-            }
-
-            parser.parseLine(line);
         }
         return parser.consumeStatement();
     }

--- a/cypher-shell/src/main/java/org/neo4j/shell/exception/IncompleteStatementException.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/exception/IncompleteStatementException.java
@@ -1,0 +1,4 @@
+package org.neo4j.shell.exception;
+
+public class IncompleteStatementException extends IllegalArgumentException {
+}

--- a/cypher-shell/src/main/java/org/neo4j/shell/exception/UnconsumedStatementException.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/exception/UnconsumedStatementException.java
@@ -1,0 +1,4 @@
+package org.neo4j.shell.exception;
+
+public class UnconsumedStatementException extends IllegalArgumentException {
+}

--- a/cypher-shell/src/main/java/org/neo4j/shell/log/AnsiFormattedText.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/log/AnsiFormattedText.java
@@ -1,5 +1,7 @@
 package org.neo4j.shell.log;
 
+import org.fusesource.jansi.Ansi;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -56,7 +58,7 @@ public class AnsiFormattedText {
     }
 
     /**
-     * @return the text as a string including possible formatting
+     * @return the text as a string including possible formatting, ready for ANSI formatting
      */
     @Nonnull
     public String formattedString() {
@@ -88,9 +90,17 @@ public class AnsiFormattedText {
         return sb.toString();
     }
 
+    /**
+     * @return the text as a string rendered with ANSI escape codes
+     */
+    @Nonnull
+    public String renderedString() {
+        return Ansi.ansi().render(formattedString()).toString();
+    }
+
     @Override
     public String toString() {
-        return formattedString();
+        return renderedString();
     }
 
     /**

--- a/cypher-shell/src/main/java/org/neo4j/shell/log/AnsiFormattedText.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/log/AnsiFormattedText.java
@@ -98,11 +98,6 @@ public class AnsiFormattedText {
         return Ansi.ansi().render(formattedString()).toString();
     }
 
-    @Override
-    public String toString() {
-        return renderedString();
-    }
-
     /**
      * @return the text as a plain string without any formatting
      */

--- a/cypher-shell/src/main/java/org/neo4j/shell/parser/CypherParser.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/parser/CypherParser.java
@@ -24,7 +24,7 @@ public class CypherParser {
      * @throws UnconsumedStatementException if current state is COMPLETE
      */
     @Nonnull
-    public static StatementParser.State parseLine(@Nonnull String line,
+    public StatementParser.State parseLine(@Nonnull String line,
                                            @Nonnull StringBuilder statementBuilder,
                                            @Nonnull StatementParser.State currentState) {
         if (StatementParser.State.COMPLETE == currentState) {

--- a/cypher-shell/src/main/java/org/neo4j/shell/parser/CypherParser.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/parser/CypherParser.java
@@ -1,0 +1,56 @@
+package org.neo4j.shell.parser;
+
+import org.neo4j.shell.exception.UnconsumedStatementException;
+
+import javax.annotation.Nonnull;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A parser for Cypher.
+ */
+public class CypherParser {
+    //Pattern matches a back slash at the end of the line for multiline commands
+    private static final Pattern MULTILINE_BREAK = Pattern.compile("\\\\\\s*$");
+    //Pattern matches comments
+    private static final Pattern COMMENTS = Pattern.compile("//.*$");
+
+    /**
+     * Parse the given line, appending it to the statementBuilder as appropriate, depending on the state.
+     * @param line to parse
+     * @param statementBuilder to append correct lines to
+     * @param currentState of the parser
+     * @return the next state of the parser
+     * @throws UnconsumedStatementException if current state is COMPLETE
+     */
+    @Nonnull
+    public static StatementParser.State parseLine(@Nonnull String line,
+                                           @Nonnull StringBuilder statementBuilder,
+                                           @Nonnull StatementParser.State currentState) {
+        if (StatementParser.State.COMPLETE == currentState) {
+            throw new UnconsumedStatementException();
+        }
+
+        String withoutComments = commentSubstitutedLine(line);
+        Matcher m = MULTILINE_BREAK.matcher(withoutComments);
+        boolean isMultiline = m.find();
+        String parsedString = m.replaceAll("");
+
+        if (!parsedString.trim().isEmpty()) {
+            statementBuilder.append(parsedString).append("\n");
+        }
+
+        if (!isMultiline && statementBuilder.length() > 0) {
+            return StatementParser.State.COMPLETE;
+        } else if (isMultiline){
+            return StatementParser.State.INCOMPLETE;
+        } else {
+            return currentState;
+        }
+    }
+
+    private static String commentSubstitutedLine(String line) {
+        Matcher commentsMatcher = COMMENTS.matcher(line);
+        return commentsMatcher.replaceAll("");
+    }
+}

--- a/cypher-shell/src/main/java/org/neo4j/shell/parser/StatementParser.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/parser/StatementParser.java
@@ -84,7 +84,7 @@ public class StatementParser {
     /**
      * Resets the parser to empty state.
      */
-    private void reset() {
+    public void reset() {
         currentState = State.EMPTY;
         statementBuilder = new StringBuilder();
     }

--- a/cypher-shell/src/main/java/org/neo4j/shell/parser/StatementParser.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/parser/StatementParser.java
@@ -1,0 +1,95 @@
+package org.neo4j.shell.parser;
+
+import org.neo4j.shell.exception.IncompleteStatementException;
+import org.neo4j.shell.exception.UnconsumedStatementException;
+import org.neo4j.shell.log.AnsiFormattedText;
+
+import javax.annotation.Nonnull;
+import java.util.regex.Pattern;
+
+/**
+ * A cypher aware parser which can detect shell commands (:prefixed) or cypher.
+ */
+public class StatementParser {
+
+    protected static final Pattern shellCmdPattern = Pattern.compile("^\\s*:.+\\s*$");
+    private State currentState = State.EMPTY;
+    private StringBuilder statementBuilder = new StringBuilder();
+
+    /**
+     * Returns a context dependent prompt. A different prompt is returned depending on if the line is in the middle of
+     * a multiline statement.
+     * @return the prompt which should be displayed to the user
+     */
+    @Nonnull
+    public AnsiFormattedText getPrompt() {
+        // First line
+        return AnsiFormattedText.s().bold().append("neo4j> ");
+    }
+
+    /**
+     * Takes a single line of input and parses it.
+     * @param line to parse
+     * @throws UnconsumedStatementException in case a complete statement already has been parsed but not consumed yet
+     */
+    public void parseLine(@Nonnull String line) throws UnconsumedStatementException {
+        if (State.COMPLETE == currentState) {
+            throw new UnconsumedStatementException();
+        } else if (State.EMPTY == currentState && shellCmdPattern.matcher(line).matches()) {
+            statementBuilder.append(line);
+            currentState = State.COMPLETE;
+        } else {
+            // currentState = cypherParser.parseLine(line, sb, currentState);
+        }
+    }
+
+    /**
+     * Returns true if the parser contains a complete statement ready for client to {@link #consumeStatement()}
+     * @return true if the line(s) read so far make up a complete statement, false otherwise (also the case if no lines
+     * have been parsed yet)
+     */
+    public boolean isStatementComplete() {
+        return State.COMPLETE == currentState;
+    }
+
+    /**
+     * Is only expected to be called once {@link #isStatementComplete()} returns true.
+     * Will reset the parser to empty once it returns.
+     * @return a complete statement
+     * @throws IncompleteStatementException in case a complete statement has not been parsed yet
+     */
+    @Nonnull
+    public String consumeStatement() throws IncompleteStatementException {
+        switch (currentState) {
+            case COMPLETE:
+                String statement = statementBuilder.toString();
+                reset();
+                return statement;
+            case INCOMPLETE:
+            case EMPTY:
+            default:
+                throw new IncompleteStatementException();
+        }
+    }
+
+    /**
+     * Resets the parser to empty state.
+     */
+    private void reset() {
+        currentState = State.EMPTY;
+        statementBuilder = new StringBuilder();
+    }
+
+    /**
+     * Enum of internal states.
+     */
+    private enum State {
+        // No lines have been parsed so far
+        EMPTY,
+        // Some lines have been parsed, but they do not make up a complete statement
+        INCOMPLETE,
+        // A complete statement has been parsed and is ready to be consumed
+        COMPLETE
+    }
+
+}

--- a/cypher-shell/src/test/java/org/neo4j/shell/log/AnsiFormattedTextTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/log/AnsiFormattedTextTest.java
@@ -37,7 +37,6 @@ public class AnsiFormattedTextTest {
 
         assertEquals("hello world", st.plainString());
         assertEquals("@|RED,BOLD hello|@ world", st.formattedString());
-        assertEquals("@|RED,BOLD hello|@ world", st.toString());
     }
 
     @Test

--- a/cypher-shell/src/test/java/org/neo4j/shell/parser/StatementParserTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/parser/StatementParserTest.java
@@ -1,0 +1,73 @@
+package org.neo4j.shell.parser;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.neo4j.shell.exception.IncompleteStatementException;
+import org.neo4j.shell.exception.UnconsumedStatementException;
+import org.neo4j.shell.parser.StatementParser;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class StatementParserTest {
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    private StatementParser parser;
+
+    @Before
+    public void setup() {
+        parser = new StatementParser();
+    }
+
+    @Test
+    public void emptyWillThrow() throws Exception {
+        thrown.expect(IncompleteStatementException.class);
+        assertFalse(parser.isStatementComplete());
+        parser.consumeStatement();
+    }
+
+    @Test
+    public void singleCommandParses() throws Exception {
+        assertFalse(parser.isStatementComplete());
+        parser.parseLine(":help exit\n");
+        assertTrue(parser.isStatementComplete());
+        assertEquals(":help exit\n", parser.consumeStatement());
+        // Repeat to make sure state got reset
+        assertFalse(parser.isStatementComplete());
+        parser.parseLine(":help bob\n");
+        assertTrue(parser.isStatementComplete());
+        assertEquals(":help bob\n", parser.consumeStatement());
+    }
+
+    @Test
+    public void unconsumedStatementThrowsOnParse() throws Exception {
+        assertFalse(parser.isStatementComplete());
+        parser.parseLine(":help exit\n");
+        assertTrue(parser.isStatementComplete());
+
+        thrown.expect(UnconsumedStatementException.class);
+        parser.parseLine(":help bob\n");
+    }
+
+    @Test
+    public void getPromptChangesWithContext() throws Exception {
+        assertFalse(parser.isStatementComplete());
+        String emptyPrompt = parser.getPrompt().plainString();
+        assertEquals("neo4j> ", emptyPrompt);
+
+        parser.parseLine("CREATE\n");
+
+        assertFalse(parser.isStatementComplete());
+
+        String multiPrompt = parser.getPrompt().plainString();
+
+        assertEquals("...", multiPrompt);
+
+        // For alignment, they should match in length
+        assertEquals("Expected both prompts to have equal length", emptyPrompt.length(), multiPrompt.length());
+    }
+}

--- a/cypher-shell/src/test/java/org/neo4j/shell/parser/StatementParserTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/parser/StatementParserTest.java
@@ -6,7 +6,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.neo4j.shell.exception.IncompleteStatementException;
 import org.neo4j.shell.exception.UnconsumedStatementException;
-import org.neo4j.shell.parser.StatementParser;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -20,7 +19,7 @@ public class StatementParserTest {
 
     @Before
     public void setup() {
-        parser = new StatementParser();
+        parser = new StatementParser(new CypherParser());
     }
 
     @Test
@@ -59,15 +58,23 @@ public class StatementParserTest {
         String emptyPrompt = parser.getPrompt().plainString();
         assertEquals("neo4j> ", emptyPrompt);
 
-        parser.parseLine("CREATE\n");
+        parser.parseLine("CREATE \\\n");
 
         assertFalse(parser.isStatementComplete());
 
         String multiPrompt = parser.getPrompt().plainString();
 
-        assertEquals("...", multiPrompt);
+        assertEquals(".....> ", multiPrompt);
 
         // For alignment, they should match in length
         assertEquals("Expected both prompts to have equal length", emptyPrompt.length(), multiPrompt.length());
+
+        parser.parseLine("()\n");
+
+        assertTrue(parser.isStatementComplete());
+
+        parser.consumeStatement();
+
+        assertEquals("neo4j> ", parser.getPrompt().plainString());
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/parser/StatementParserTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/parser/StatementParserTest.java
@@ -53,6 +53,29 @@ public class StatementParserTest {
     }
 
     @Test
+    public void resetClearsState() throws Exception {
+        // given
+        assertFalse(parser.isStatementComplete());
+        String emptyPrompt = parser.getPrompt().plainString();
+        assertEquals("neo4j> ", emptyPrompt);
+
+        parser.parseLine("CREATE \\\n");
+
+        assertFalse(parser.isStatementComplete());
+
+        String multiPrompt = parser.getPrompt().plainString();
+
+        assertEquals(".....> ", multiPrompt);
+
+        // when
+        parser.reset();
+
+        // thne
+        assertFalse(parser.isStatementComplete());
+        assertEquals(emptyPrompt, parser.getPrompt().plainString());
+    }
+
+    @Test
     public void getPromptChangesWithContext() throws Exception {
         assertFalse(parser.isStatementComplete());
         String emptyPrompt = parser.getPrompt().plainString();


### PR DESCRIPTION
Some ground work for future multiline work, as well as an improvement to the prompt:

Before it was impossible to know if you were currently in the middle of a multiline statement (currently using `\` to make multiline statements). Now the prompt changes to indicate that the shell is expecting a continuation:

## Before

- single statements:

```
neo4j> CREATE (n)
neo4j> CREATE (m)
```

- multiline statement:

```
neo4j> CREATE (n) \
neo4j> CREATE (m)
```

## Now

- multiline statement:

```
neo4j> CREATE (n) \
.....> CREATE (m)
```