### PR TITLE
Return statistics for queries that have no return records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,3 @@ build
 out
 .idea/
 *.iml
-gradle/wrapper/gradle-wrapper.properties
-gradlew.bat

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ build
 out
 .idea/
 *.iml
+gradle/wrapper/gradle-wrapper.properties
+gradlew.bat

--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellIntegrationTest.java
@@ -17,9 +17,7 @@ import java.util.List;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 public class CypherShellIntegrationTest {
     @Rule
@@ -39,6 +37,19 @@ public class CypherShellIntegrationTest {
     @After
     public void tearDown() throws Exception {
         shell.execute("MATCH (n:TestPerson) DETACH DELETE (n)");
+    }
+
+    @Test
+    public void cypherWithNoReturnStatements() throws CommandException {
+        //when
+        shell.execute("CREATE (:TestPerson {name: \"Jane Smith\"})");
+
+        //then
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(logger, times(1)).printOut(captor.capture());
+
+        List<String> result = captor.getAllValues();
+        assertThat(result.get(0), is("Added 1 nodes, Set 1 properties, Added 1 labels"));
     }
 
     @Test

--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellIntegrationTest.java
@@ -54,6 +54,19 @@ public class CypherShellIntegrationTest {
     }
 
     @Test
+    public void cypherWithReturnStatements() throws CommandException {
+        //when
+        shell.execute("CREATE (jane :TestPerson {name: \"Jane Smith\"}) RETURN jane");
+
+        //then
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(logger, times(1)).printOut(captor.capture());
+
+        List<String> result = captor.getAllValues();
+        assertThat(result.get(0), is("jane\n{name: \"Jane Smith\"}\nAdded 1 nodes, Set 1 properties, Added 1 labels"));
+    }
+
+    @Test
     public void connectTwiceThrows() throws CommandException {
         thrown.expect(CommandException.class);
         thrown.expectMessage("Already connected");

--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellIntegrationTest.java
@@ -9,6 +9,7 @@ import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.neo4j.shell.ConnectionConfig;
 import org.neo4j.shell.CypherShell;
+import org.neo4j.shell.cli.CliArgHelper;
 import org.neo4j.shell.exception.CommandException;
 import org.neo4j.shell.log.Logger;
 
@@ -24,7 +25,7 @@ public class CypherShellIntegrationTest {
     public final ExpectedException thrown = ExpectedException.none();
 
     private Logger logger = mock(Logger.class);
-    private CypherShell shell = new CypherShell(logger);
+    private CypherShell shell = new CypherShell(logger, CliArgHelper.Format.VERBOSE);
     private Command rollbackCommand = new Rollback(shell);
     private Command commitCommand = new Commit(shell);
     private Command beginCommand = new Begin(shell);

--- a/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
@@ -1,6 +1,7 @@
 package org.neo4j.shell;
 
 import org.neo4j.driver.v1.StatementResult;
+import org.neo4j.shell.cli.CliArgHelper;
 import org.neo4j.shell.commands.Command;
 import org.neo4j.shell.commands.CommandExecutable;
 import org.neo4j.shell.commands.CommandHelper;
@@ -26,18 +27,20 @@ public class CypherShell implements StatementExecuter, Connector, TransactionHan
     // Final space to catch newline
     protected static final Pattern cmdNamePattern = Pattern.compile("^\\s*(?<name>[^\\s]+)\\b(?<args>.*)\\s*$");
     private final BoltStateHandler boltStateHandler;
+    private final PrettyPrinter prettyPrinter;
     protected CommandHelper commandHelper;
     protected final Map<String, Object> queryParams = new HashMap<>();
-    private PrettyPrinter prettyPrinter;
 
-    public CypherShell(@Nonnull Logger logger) {
-        this(logger, new BoltStateHandler());
+    public CypherShell(@Nonnull Logger logger, @Nonnull CliArgHelper.Format format) {
+        this(logger, new BoltStateHandler(), format);
     }
 
-    protected CypherShell(@Nonnull Logger logger, @Nonnull BoltStateHandler boltStateHandler) {
+    protected CypherShell(@Nonnull Logger logger,
+                          @Nonnull BoltStateHandler boltStateHandler,
+                          @Nonnull CliArgHelper.Format format) {
         this.logger = logger;
         this.boltStateHandler = boltStateHandler;
-        prettyPrinter = new PrettyPrinter();
+        this.prettyPrinter = new PrettyPrinter(format);
     }
 
     @Override

--- a/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
@@ -28,6 +28,7 @@ public class CypherShell implements StatementExecuter, Connector, TransactionHan
     private final BoltStateHandler boltStateHandler;
     protected CommandHelper commandHelper;
     protected final Map<String, Object> queryParams = new HashMap<>();
+    private PrettyPrinter prettyPrinter;
 
     public CypherShell(@Nonnull Logger logger) {
         this(logger, new BoltStateHandler());
@@ -36,6 +37,7 @@ public class CypherShell implements StatementExecuter, Connector, TransactionHan
     protected CypherShell(@Nonnull Logger logger, @Nonnull BoltStateHandler boltStateHandler) {
         this.logger = logger;
         this.boltStateHandler = boltStateHandler;
+        prettyPrinter = new PrettyPrinter();
     }
 
     @Override
@@ -64,7 +66,7 @@ public class CypherShell implements StatementExecuter, Connector, TransactionHan
     protected void executeCypher(@Nonnull final String cypher) throws CommandException {
         final Optional<StatementResult> result = doCypherSilently(cypher);
         if (result.isPresent()) {
-            logger.printOut(PrettyPrinter.format(result.get()));
+            logger.printOut(prettyPrinter.format(result.get()));
         }
     }
 

--- a/cypher-shell/src/main/java/org/neo4j/shell/Main.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/Main.java
@@ -28,7 +28,7 @@ public class Main {
         try {
             ShellRunner shellRunner = ShellRunner.getShellRunner(cliArgs, logger);
 
-            CypherShell shell = new CypherShell(logger);
+            CypherShell shell = new CypherShell(logger, cliArgs.getFormat());
 
             CommandHelper commandHelper = new CommandHelper(logger, shellRunner.getHistorian(), shell);
 

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgHelper.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgHelper.java
@@ -25,8 +25,15 @@ public class CliArgHelper {
     }
 
     public enum Format {
-        DEFAULT,
-        PLAIN
+        VERBOSE,
+        PLAIN;
+
+        public static Format parse(String format) {
+            if (format.equalsIgnoreCase(PLAIN.name())) {
+                return PLAIN;
+            }
+            return VERBOSE;
+        }
     }
 
 
@@ -75,7 +82,7 @@ public class CliArgHelper {
         cliArgs.setFailBehavior(ns.get("fail-behavior"));
 
         //Set Output format
-        cliArgs.setFormat(ns.get("format"));
+        cliArgs.setFormat(Format.parse(ns.get("format")));
 
         return cliArgs;
     }
@@ -121,10 +128,10 @@ public class CliArgHelper {
         parser.setDefault("fail-behavior", FAIL_FAST);
 
         parser.addArgument("--format")
-                .help("output format")
-                .choices(new CollectionArgumentChoice<>(Format.DEFAULT.name(), Format.PLAIN.name()))
-                .setDefault(Format.DEFAULT)
-                .action(new StoreConstArgumentAction());
+                .help("desired output format, verbose(default) displays statistics, plain only displays data")
+                .choices(new CollectionArgumentChoice<>(
+                        Format.VERBOSE.name().toLowerCase(), Format.PLAIN.name().toLowerCase()))
+                .setDefault(Format.VERBOSE.name().toLowerCase());
 
         parser.addArgument("cypher")
                 .nargs("?")
@@ -140,7 +147,7 @@ public class CliArgHelper {
         private String username = "";
         private String password = "";
         private FailBehavior failBehavior = FailBehavior.FAIL_FAST;
-        private Format format = Format.DEFAULT;
+        private Format format = Format.VERBOSE;
         private Optional<String> cypher = Optional.empty();
 
         public boolean getSuppressColor() {

--- a/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/PrettyPrinter.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/PrettyPrinter.java
@@ -4,14 +4,18 @@ import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.exceptions.value.Uncoercible;
+import org.neo4j.driver.v1.summary.ResultSummary;
+import org.neo4j.driver.v1.summary.SummaryCounters;
 import org.neo4j.driver.v1.types.Node;
 import org.neo4j.driver.v1.types.Path;
 import org.neo4j.driver.v1.types.Relationship;
 
 import javax.annotation.Nonnull;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Print the result from neo4j in a intelligible fashion.
@@ -20,11 +24,11 @@ public class PrettyPrinter {
     public static String format(@Nonnull final StatementResult result) {
         // TODO: 6/22/16 Format nicely
         if (!result.hasNext()) {
-            return "";
+            return collectStatistics(result);
         }
 
         StringBuilder sb = new StringBuilder();
-        for (String key: result.keys()) {
+        for (String key : result.keys()) {
             if (sb.length() > 0) {
                 sb.append(" | ");
             }
@@ -37,10 +41,50 @@ public class PrettyPrinter {
         return sb.toString();
     }
 
+    private static String collectStatistics(@Nonnull StatementResult result) {
+        List<String> statistics = new ArrayList<>();
+        ResultSummary consume = result.consume();
+        SummaryCounters counters = consume.counters();
+        if (counters.nodesCreated() != 0) {
+            statistics.add(String.format("Added %d nodes", counters.nodesCreated()));
+        }
+        if (counters.nodesDeleted() != 0) {
+            statistics.add(String.format("Deleted %d nodes", counters.nodesDeleted()));
+        }
+        if (counters.relationshipsCreated() != 0) {
+            statistics.add(String.format("Created %d relationships", counters.relationshipsCreated()));
+        }
+        if (counters.relationshipsDeleted() != 0) {
+            statistics.add(String.format("Deleted %d relationships", counters.relationshipsDeleted()));
+        }
+        if (counters.propertiesSet() != 0) {
+            statistics.add(String.format("Set %d properties", counters.propertiesSet()));
+        }
+        if (counters.labelsAdded() != 0) {
+            statistics.add(String.format("Added %d labels", counters.labelsAdded()));
+        }
+        if (counters.labelsRemoved() != 0) {
+            statistics.add(String.format("Removed %d labels", counters.labelsRemoved()));
+        }
+        if (counters.indexesAdded() != 0) {
+            statistics.add(String.format("Added %d indexes", counters.indexesAdded()));
+        }
+        if (counters.indexesRemoved() != 0) {
+            statistics.add(String.format("Removed %d indexes", counters.indexesRemoved()));
+        }
+        if (counters.constraintsAdded() != 0) {
+            statistics.add(String.format("Added %d constraints", counters.constraintsAdded()));
+        }
+        if (counters.constraintsRemoved() != 0) {
+            statistics.add(String.format("Removed %d constraints", counters.constraintsRemoved()));
+        }
+        return statistics.stream().collect(Collectors.joining(", "));
+    }
+
     private static String format(@Nonnull final Record record) {
         // TODO: 6/22/16 Format nicely
         StringBuilder sb = new StringBuilder();
-        for (Value value: record.values()) {
+        for (Value value : record.values()) {
             if (sb.length() > 0) {
                 sb.append(" | ");
             }

--- a/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/PrettyPrinter.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/PrettyPrinter.java
@@ -7,6 +7,7 @@ import org.neo4j.driver.v1.exceptions.value.Uncoercible;
 import org.neo4j.driver.v1.types.Node;
 import org.neo4j.driver.v1.types.Path;
 import org.neo4j.driver.v1.types.Relationship;
+import org.neo4j.shell.cli.CliArgHelper;
 
 import javax.annotation.Nonnull;
 import java.util.LinkedList;
@@ -20,8 +21,8 @@ public class PrettyPrinter {
 
     private StatisticsCollector statisticsCollector;
 
-    public PrettyPrinter() {
-        statisticsCollector = new StatisticsCollector();
+    public PrettyPrinter(@Nonnull CliArgHelper.Format format) {
+        this.statisticsCollector = new StatisticsCollector(format);
     }
 
     public String format(@Nonnull final StatementResult result) {

--- a/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/PrettyPrinter.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/PrettyPrinter.java
@@ -42,6 +42,10 @@ public class PrettyPrinter {
         while (result.hasNext()) {
             sb.append("\n").append(format(result.next()));
         }
+        String statistics = statisticsCollector.collect(result);
+        if (!statistics.isEmpty()) {
+            sb.append("\n").append(statistics);
+        }
         return sb.toString();
     }
 

--- a/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/PrettyPrinter.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/PrettyPrinter.java
@@ -4,27 +4,30 @@ import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.exceptions.value.Uncoercible;
-import org.neo4j.driver.v1.summary.ResultSummary;
-import org.neo4j.driver.v1.summary.SummaryCounters;
 import org.neo4j.driver.v1.types.Node;
 import org.neo4j.driver.v1.types.Path;
 import org.neo4j.driver.v1.types.Relationship;
 
 import javax.annotation.Nonnull;
-import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Print the result from neo4j in a intelligible fashion.
  */
 public class PrettyPrinter {
-    public static String format(@Nonnull final StatementResult result) {
+
+    private StatisticsCollector statisticsCollector;
+
+    public PrettyPrinter() {
+        statisticsCollector = new StatisticsCollector();
+    }
+
+    public String format(@Nonnull final StatementResult result) {
         // TODO: 6/22/16 Format nicely
         if (!result.hasNext()) {
-            return collectStatistics(result);
+            return statisticsCollector.collect(result);
         }
 
         StringBuilder sb = new StringBuilder();
@@ -39,46 +42,6 @@ public class PrettyPrinter {
             sb.append("\n").append(format(result.next()));
         }
         return sb.toString();
-    }
-
-    private static String collectStatistics(@Nonnull StatementResult result) {
-        List<String> statistics = new ArrayList<>();
-        ResultSummary consume = result.consume();
-        SummaryCounters counters = consume.counters();
-        if (counters.nodesCreated() != 0) {
-            statistics.add(String.format("Added %d nodes", counters.nodesCreated()));
-        }
-        if (counters.nodesDeleted() != 0) {
-            statistics.add(String.format("Deleted %d nodes", counters.nodesDeleted()));
-        }
-        if (counters.relationshipsCreated() != 0) {
-            statistics.add(String.format("Created %d relationships", counters.relationshipsCreated()));
-        }
-        if (counters.relationshipsDeleted() != 0) {
-            statistics.add(String.format("Deleted %d relationships", counters.relationshipsDeleted()));
-        }
-        if (counters.propertiesSet() != 0) {
-            statistics.add(String.format("Set %d properties", counters.propertiesSet()));
-        }
-        if (counters.labelsAdded() != 0) {
-            statistics.add(String.format("Added %d labels", counters.labelsAdded()));
-        }
-        if (counters.labelsRemoved() != 0) {
-            statistics.add(String.format("Removed %d labels", counters.labelsRemoved()));
-        }
-        if (counters.indexesAdded() != 0) {
-            statistics.add(String.format("Added %d indexes", counters.indexesAdded()));
-        }
-        if (counters.indexesRemoved() != 0) {
-            statistics.add(String.format("Removed %d indexes", counters.indexesRemoved()));
-        }
-        if (counters.constraintsAdded() != 0) {
-            statistics.add(String.format("Added %d constraints", counters.constraintsAdded()));
-        }
-        if (counters.constraintsRemoved() != 0) {
-            statistics.add(String.format("Removed %d constraints", counters.constraintsRemoved()));
-        }
-        return statistics.stream().collect(Collectors.joining(", "));
     }
 
     private static String format(@Nonnull final Record record) {

--- a/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/StatisticsCollector.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/StatisticsCollector.java
@@ -1,0 +1,52 @@
+package org.neo4j.shell.prettyprint;
+
+import org.neo4j.driver.v1.StatementResult;
+import org.neo4j.driver.v1.summary.ResultSummary;
+import org.neo4j.driver.v1.summary.SummaryCounters;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class StatisticsCollector {
+    public String collect(@Nonnull StatementResult result) {
+        List<String> statistics = new ArrayList<String>();
+        ResultSummary consume = result.consume();
+        SummaryCounters counters = consume.counters();
+        if (counters.nodesCreated() != 0) {
+            statistics.add(String.format("Added %d nodes", counters.nodesCreated()));
+        }
+        if (counters.nodesDeleted() != 0) {
+            statistics.add(String.format("Deleted %d nodes", counters.nodesDeleted()));
+        }
+        if (counters.relationshipsCreated() != 0) {
+            statistics.add(String.format("Created %d relationships", counters.relationshipsCreated()));
+        }
+        if (counters.relationshipsDeleted() != 0) {
+            statistics.add(String.format("Deleted %d relationships", counters.relationshipsDeleted()));
+        }
+        if (counters.propertiesSet() != 0) {
+            statistics.add(String.format("Set %d properties", counters.propertiesSet()));
+        }
+        if (counters.labelsAdded() != 0) {
+            statistics.add(String.format("Added %d labels", counters.labelsAdded()));
+        }
+        if (counters.labelsRemoved() != 0) {
+            statistics.add(String.format("Removed %d labels", counters.labelsRemoved()));
+        }
+        if (counters.indexesAdded() != 0) {
+            statistics.add(String.format("Added %d indexes", counters.indexesAdded()));
+        }
+        if (counters.indexesRemoved() != 0) {
+            statistics.add(String.format("Removed %d indexes", counters.indexesRemoved()));
+        }
+        if (counters.constraintsAdded() != 0) {
+            statistics.add(String.format("Added %d constraints", counters.constraintsAdded()));
+        }
+        if (counters.constraintsRemoved() != 0) {
+            statistics.add(String.format("Removed %d constraints", counters.constraintsRemoved()));
+        }
+        return statistics.stream().collect(Collectors.joining(", "));
+    }
+}

--- a/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/StatisticsCollector.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/StatisticsCollector.java
@@ -3,6 +3,7 @@ package org.neo4j.shell.prettyprint;
 import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.summary.ResultSummary;
 import org.neo4j.driver.v1.summary.SummaryCounters;
+import org.neo4j.shell.cli.CliArgHelper;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -10,7 +11,21 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class StatisticsCollector {
+    private CliArgHelper.Format format;
+
+    public StatisticsCollector(@Nonnull CliArgHelper.Format format) {
+        this.format = format;
+    }
+
     public String collect(@Nonnull StatementResult result) {
+        if (CliArgHelper.Format.VERBOSE == format) {
+            return collectStatistics(result);
+        } else {
+            return "";
+        }
+    }
+
+    private String collectStatistics(@Nonnull StatementResult result) {
         List<String> statistics = new ArrayList<String>();
         ResultSummary consume = result.consume();
         SummaryCounters counters = consume.counters();

--- a/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
@@ -23,11 +23,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Matchers.anyMapOf;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.contains;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 
 public class CypherShellTest {
@@ -51,7 +47,7 @@ public class CypherShellTest {
     @Test
     public void verifyDelegationOfConnectionMethods() throws CommandException {
         ConnectionConfig cc = new ConnectionConfig("", 1, "", "");
-        CypherShell shell = new CypherShell(logger, mockedBoltStateHandler);
+        CypherShell shell = new CypherShell(logger, mockedBoltStateHandler, CliArgHelper.Format.VERBOSE);
 
         shell.connect(cc);
         verify(mockedBoltStateHandler).connect(cc);
@@ -62,7 +58,7 @@ public class CypherShellTest {
 
     @Test
     public void verifyDelegationOfTransactionMethods() throws CommandException {
-        CypherShell shell = new CypherShell(logger, mockedBoltStateHandler);
+        CypherShell shell = new CypherShell(logger, mockedBoltStateHandler, CliArgHelper.Format.VERBOSE);
 
         shell.beginTransaction();
         verify(mockedBoltStateHandler).beginTransaction();
@@ -207,7 +203,7 @@ public class CypherShellTest {
         BoltStateHandler bh = mockedBoltStateHandler;
         doReturn(runner).when(bh).getStatementRunner();
 
-        CypherShell shell = new CypherShell(logger, bh);
+        CypherShell shell = new CypherShell(logger, bh, CliArgHelper.Format.VERBOSE);
 
         // when
         shell.set("bob", "99");

--- a/cypher-shell/src/test/java/org/neo4j/shell/cli/AddressArgPatternTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/cli/AddressArgPatternTest.java
@@ -11,7 +11,7 @@ public class AddressArgPatternTest {
 
     @Test
     public void testUserPassProtocolHostPort() {
-        Matcher m = CliArgHelper.addressArgPattern.matcher("   bolt://bob1:pass@localhost:123");
+        Matcher m = CliArgHelper.ADDRESS_ARG_PATTERN.matcher("   bolt://bob1:pass@localhost:123");
         assertTrue("Expected a match: " + "   bolt://bob1:pass@:123", m.matches());
         assertEquals("123", m.group("port"));
         assertEquals("bob1", m.group("username"));
@@ -19,7 +19,7 @@ public class AddressArgPatternTest {
         assertEquals("bolt://", m.group("protocol"));
         assertEquals("localhost", m.group("host"));
 
-        Matcher m1 = CliArgHelper.addressArgPattern.matcher("bolt://bob1:h@rdp@ss:w0rd@99.99.99.99:1  ");
+        Matcher m1 = CliArgHelper.ADDRESS_ARG_PATTERN.matcher("bolt://bob1:h@rdp@ss:w0rd@99.99.99.99:1  ");
         assertTrue("Expected a match: " + "bolt://bob1h@rdp@ss:w0rd1  ", m1.matches());
         assertEquals("1", m1.group("port"));
         assertEquals("bob1", m1.group("username"));
@@ -27,7 +27,7 @@ public class AddressArgPatternTest {
         assertEquals("bolt://", m1.group("protocol"));
         assertEquals("99.99.99.99", m1.group("host"));
 
-        Matcher m2 = CliArgHelper.addressArgPattern.matcher("bolt://bob1:h@rdp@ss:w0rd@99.99.99.99:1");
+        Matcher m2 = CliArgHelper.ADDRESS_ARG_PATTERN.matcher("bolt://bob1:h@rdp@ss:w0rd@99.99.99.99:1");
         assertTrue("Expected a match: " + "bolt://bob1h@rdp@ss:w0rd1", m2.matches());
         assertEquals("1", m2.group("port"));
         assertEquals("bob1", m2.group("username"));
@@ -125,7 +125,7 @@ public class AddressArgPatternTest {
 
     private void verifyUserPassHostPort(String user, String pass, String host, String port) {
         String args = user + ":" + pass + "@" + host + ":" + port;
-        Matcher m = CliArgHelper.addressArgPattern.matcher(args);
+        Matcher m = CliArgHelper.ADDRESS_ARG_PATTERN.matcher(args);
         assertTrue("Expected a match: " + args, m.matches());
         assertEquals(host.trim(), m.group("host"));
         assertEquals(port.trim(), m.group("port"));
@@ -136,7 +136,7 @@ public class AddressArgPatternTest {
 
     private void verifyUserPassPort(String user, String pass, String port) {
         String args = user + ":" + pass + "@:" + port;
-        Matcher m = CliArgHelper.addressArgPattern.matcher(args);
+        Matcher m = CliArgHelper.ADDRESS_ARG_PATTERN.matcher(args);
         assertTrue("Expected a match: " + args, m.matches());
         assertEquals(port.trim(), m.group("port"));
         assertEquals(user.trim(), m.group("username"));
@@ -148,7 +148,7 @@ public class AddressArgPatternTest {
 
     private void verifyUserPassProtocolPort(String protocol, String user, String pass, String port) {
         String args = protocol + user + ":" + pass + "@" + ":" + port;
-        Matcher m = CliArgHelper.addressArgPattern.matcher(args);
+        Matcher m = CliArgHelper.ADDRESS_ARG_PATTERN.matcher(args);
         assertTrue("Expected a match: " + args, m.matches());
         assertEquals(port.trim(), m.group("port"));
         assertEquals(user.trim(), m.group("username"));
@@ -160,7 +160,7 @@ public class AddressArgPatternTest {
 
     private void verifyUserPassProtocolHost(String protocol, String user, String pass, String host) {
         String args = protocol + user + ":" + pass + "@" + host;
-        Matcher m = CliArgHelper.addressArgPattern.matcher(args);
+        Matcher m = CliArgHelper.ADDRESS_ARG_PATTERN.matcher(args);
         assertTrue("Expected a match: " + args, m.matches());
         assertEquals(host.trim(), m.group("host"));
         assertEquals(user.trim(), m.group("username"));
@@ -172,7 +172,7 @@ public class AddressArgPatternTest {
 
     private void verifyUserPassHost(String user, String pass, String host) {
         String args = user + ":" + pass + "@" + host;
-        Matcher m = CliArgHelper.addressArgPattern.matcher(args);
+        Matcher m = CliArgHelper.ADDRESS_ARG_PATTERN.matcher(args);
         assertTrue("Expected a match: " + args, m.matches());
         assertEquals(host.trim(), m.group("host"));
         assertEquals(user.trim(), m.group("username"));
@@ -184,7 +184,7 @@ public class AddressArgPatternTest {
 
     private void verifyProtocolHostPort(String protocol, String host, String port) {
         String args = protocol + host + ":" + port;
-        Matcher m = CliArgHelper.addressArgPattern.matcher(args);
+        Matcher m = CliArgHelper.ADDRESS_ARG_PATTERN.matcher(args);
         assertTrue("Expected a match: " + args, m.matches());
         assertEquals(host.trim(), m.group("host"));
         assertEquals(port.trim(), m.group("port"));
@@ -196,7 +196,7 @@ public class AddressArgPatternTest {
 
     private void verifyHostPort(String host, String port) {
         String args = host + ":" + port;
-        Matcher m = CliArgHelper.addressArgPattern.matcher(args);
+        Matcher m = CliArgHelper.ADDRESS_ARG_PATTERN.matcher(args);
         assertTrue("Expected a match: " + args, m.matches());
         assertEquals(host.trim(), m.group("host"));
         assertEquals(port.trim(), m.group("port"));
@@ -208,7 +208,7 @@ public class AddressArgPatternTest {
 
     private void verifyProtocolPort(String protocol, String port) {
         String args = protocol + ":" + port;
-        Matcher m = CliArgHelper.addressArgPattern.matcher(args);
+        Matcher m = CliArgHelper.ADDRESS_ARG_PATTERN.matcher(args);
         assertTrue("Expected a match: " + args, m.matches());
         assertEquals(port.trim(), m.group("port"));
         assertEquals(protocol.trim(), m.group("protocol"));
@@ -219,7 +219,7 @@ public class AddressArgPatternTest {
     }
 
     private void verifySinglePort(String args) {
-        Matcher m = CliArgHelper.addressArgPattern.matcher(args);
+        Matcher m = CliArgHelper.ADDRESS_ARG_PATTERN.matcher(args);
         assertTrue("Expected a match: " + args, m.matches());
         assertEquals(args.trim().substring(1), m.group("port"));
 
@@ -230,7 +230,7 @@ public class AddressArgPatternTest {
     }
 
     private void verifySingleHost(String args) {
-        Matcher m = CliArgHelper.addressArgPattern.matcher(args);
+        Matcher m = CliArgHelper.ADDRESS_ARG_PATTERN.matcher(args);
         assertTrue("Expected a match: " + args, m.matches());
         assertEquals(args.trim(), m.group("host"));
         assertNull("Did not expect match for protocol group", m.group("protocol"));
@@ -241,7 +241,7 @@ public class AddressArgPatternTest {
 
     private void verifyProtocolHost(String protocol, String host) {
         String args = protocol + host;
-        Matcher m = CliArgHelper.addressArgPattern.matcher(args);
+        Matcher m = CliArgHelper.ADDRESS_ARG_PATTERN.matcher(args);
         assertTrue("Expected a match: " + args, m.matches());
         assertEquals(protocol.trim(), m.group("protocol"));
         assertEquals(host.trim(), m.group("host"));

--- a/cypher-shell/src/test/java/org/neo4j/shell/cli/CliArgHelperTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/cli/CliArgHelperTest.java
@@ -2,6 +2,8 @@ package org.neo4j.shell.cli;
 
 import org.junit.Test;
 
+import java.util.Optional;
+
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.shell.test.Util.asArray;
 
@@ -30,5 +32,11 @@ public class CliArgHelperTest {
         String text = "Single string";
         assertEquals("Did not parse cypher string", text,
                 CliArgHelper.parse(asArray(text)).getCypher().get());
+    }
+
+    @Test
+    public void parseFormatAsArgument() {
+        String text = "-a 192.168.1.1 -p 123 --format plain";
+        assertEquals(Optional.of("plain"), CliArgHelper.parse(text.split(" ")).getCypher());
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/cli/CliArgHelperTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/cli/CliArgHelperTest.java
@@ -2,8 +2,10 @@ package org.neo4j.shell.cli;
 
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Optional;
 
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.shell.test.Util.asArray;
 
@@ -35,8 +37,12 @@ public class CliArgHelperTest {
     }
 
     @Test
-    public void parseFormatAsArgument() {
-        String text = "-a 192.168.1.1 -p 123 --format plain";
-        assertEquals(Optional.of("plain"), CliArgHelper.parse(text.split(" ")).getCypher());
+    public void parseArgumentsAndQuery() {
+        String query = "\"match (n) return n\"";
+        ArrayList<String> strings = new ArrayList<>();
+        strings.addAll(asList("-a 192.168.1.1 -p 123 --format plain".split(" ")));
+        strings.add(query);
+        assertEquals(Optional.of(query),
+                CliArgHelper.parse(strings.toArray(new String[strings.size()])).getCypher());
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/PrettyPrinterTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/PrettyPrinterTest.java
@@ -25,7 +25,7 @@ public class PrettyPrinterTest {
         when(summaryCounters.nodesCreated()).thenReturn(10);
 
         // when
-        String actual = PrettyPrinter.format(result);
+        String actual = new PrettyPrinter().format(result);
 
         // then
         assertThat(actual, is("Added 10 nodes, Added 1 labels"));

--- a/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/PrettyPrinterTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/PrettyPrinterTest.java
@@ -1,0 +1,33 @@
+package org.neo4j.shell.prettyprint;
+
+import org.junit.Test;
+import org.neo4j.driver.v1.StatementResult;
+import org.neo4j.driver.v1.summary.ResultSummary;
+import org.neo4j.driver.v1.summary.SummaryCounters;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PrettyPrinterTest {
+    @Test
+    public void returnStatisticsForEmptyRecords() throws Exception {
+        // given
+        StatementResult result = mock(StatementResult.class);
+        ResultSummary resultSummary = mock(ResultSummary.class);
+        SummaryCounters summaryCounters = mock(SummaryCounters.class);
+
+        when(result.hasNext()).thenReturn(false);
+        when(result.consume()).thenReturn(resultSummary);
+        when(resultSummary.counters()).thenReturn(summaryCounters);
+        when(summaryCounters.labelsAdded()).thenReturn(1);
+        when(summaryCounters.nodesCreated()).thenReturn(10);
+
+        // when
+        String actual = PrettyPrinter.format(result);
+
+        // then
+        assertThat(actual, is("Added 10 nodes, Added 1 labels"));
+    }
+}

--- a/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/StatisticsCollectorTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/StatisticsCollectorTest.java
@@ -11,24 +11,37 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class PrettyPrinterTest {
+public class StatisticsCollectorTest {
+
     @Test
-    public void returnStatisticsForEmptyRecords() throws Exception {
+    public void returnEmptyStringForPlainFormatting() throws Exception {
+        // given
+        StatementResult result = mock(StatementResult.class);
+
+        // when
+        String actual = new StatisticsCollector(CliArgHelper.Format.PLAIN).collect(result);
+
+        // then
+        assertThat(actual, is(""));
+    }
+
+    @Test
+    public void returnStatisticsForDefaultFormatting() throws Exception {
         // given
         StatementResult result = mock(StatementResult.class);
         ResultSummary resultSummary = mock(ResultSummary.class);
         SummaryCounters summaryCounters = mock(SummaryCounters.class);
 
-        when(result.hasNext()).thenReturn(false);
         when(result.consume()).thenReturn(resultSummary);
         when(resultSummary.counters()).thenReturn(summaryCounters);
         when(summaryCounters.labelsAdded()).thenReturn(1);
         when(summaryCounters.nodesCreated()).thenReturn(10);
 
         // when
-        String actual = new PrettyPrinter(CliArgHelper.Format.VERBOSE).format(result);
+        String actual = new StatisticsCollector(CliArgHelper.Format.VERBOSE).collect(result);
 
         // then
         assertThat(actual, is("Added 10 nodes, Added 1 labels"));
     }
+
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/test/OfflineTestShell.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/test/OfflineTestShell.java
@@ -2,6 +2,7 @@ package org.neo4j.shell.test;
 
 
 import org.neo4j.shell.CypherShell;
+import org.neo4j.shell.cli.CliArgHelper;
 import org.neo4j.shell.log.Logger;
 import org.neo4j.shell.state.OfflineBoltStateHandler;
 
@@ -13,6 +14,6 @@ import org.neo4j.shell.state.OfflineBoltStateHandler;
 public class OfflineTestShell extends CypherShell {
 
     public OfflineTestShell(Logger logger) {
-        super(logger, new OfflineBoltStateHandler());
+        super(logger, new OfflineBoltStateHandler(), CliArgHelper.Format.VERBOSE);
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/test/bolt/FakeResultSummary.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/test/bolt/FakeResultSummary.java
@@ -1,5 +1,6 @@
 package org.neo4j.shell.test.bolt;
 
+import org.neo4j.driver.internal.summary.InternalSummaryCounters;
 import org.neo4j.driver.v1.Statement;
 import org.neo4j.driver.v1.summary.*;
 import org.neo4j.shell.test.Util;
@@ -17,7 +18,7 @@ class FakeResultSummary implements ResultSummary {
 
     @Override
     public SummaryCounters counters() {
-        throw new Util.NotImplementedYetException("Not implemented yet");
+        return InternalSummaryCounters.EMPTY_STATS;
     }
 
     @Override


### PR DESCRIPTION
This pull request imitates the browser behaviour of displaying statistics when no `RETURN` is used in the query.

For VERBOSE(default) format
`CREATE (:TestPerson {name: "Jane Smith"})`

would display

`Added 1 nodes, Set 1 properties, Added 1 labels`

Agreed, the message isn't *pretty* enough, but I am considering adding that as an enhanced output.

`CREATE (jane :TestPerson {name: "Jane Smith"}) RETURN jane`

would display

`jane`
`{name: "Jane Smith"}`
`Added 1 nodes, Set 1 properties, Added 1 labels`