### PR TITLE
Package cypher-shell as an uber jar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,13 @@ zip: out/temp/cypher-shell/bin/cypher-shell ## Build zip distribution file in 'o
 out/temp/cypher-shell/bin/cypher-shell: out build
 	rm -rf out/temp
 	mkdir -p out/temp
-	cp -r cypher-shell/build/installShadow/cypher-shell out/temp/cypher-shell
+	cp -r cypher-shell/build/install/cypher-shell out/temp/cypher-shell
 
 run: build ## Build and run cypher-shell with no arguments
-	cypher-shell/build/installShadow/cypher-shell/bin/cypher-shell
+	cypher-shell/build/install/cypher-shell/cypher-shell
 
 build: ## Build and test cypher-shell
-	./gradlew installShadowApp
+	./gradlew installDist
 
 test: ## Run all unit tests
 	./gradlew check pitest

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help dist clean zip
+.PHONY: help build clean zip
 
 help: ## Print this help text
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -8,16 +8,16 @@ zip: out/temp/cypher-shell/bin/cypher-shell ## Build zip distribution file in 'o
 	mv out/temp/cypher-shell.zip out/cypher-shell.zip
 	rm -rf out/temp
 
-out/temp/cypher-shell/bin/cypher-shell: out dist
+out/temp/cypher-shell/bin/cypher-shell: out build
 	rm -rf out/temp
 	mkdir -p out/temp
-	cp -r cypher-shell/build/install/cypher-shell out/temp/cypher-shell
+	cp -r cypher-shell/build/installShadow/cypher-shell out/temp/cypher-shell
 
-run: dist ## Build and run cypher-shell with no arguments
-	cypher-shell/build/install/cypher-shell/bin/cypher-shell
+run: build ## Build and run cypher-shell with no arguments
+	cypher-shell/build/installShadow/cypher-shell/bin/cypher-shell
 
-dist: ## Build and test cypher-shell
-	./gradlew installDist
+build: ## Build and test cypher-shell
+	./gradlew installShadowApp
 
 test: ## Run all unit tests
 	./gradlew check pitest

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 Use `make help` (`gradlew tasks`) to list possible tasks. But you
 probably want either
 
--  `make build` (`gradlew installShadowApp`) which will build an
+-  `make build` (`gradlew installDist`) which will build an
    uber-jar and runnable script for you at
-   `cypher-shell/build/installShadow/cypher-shell`
+   `cypher-shell/build/install/cypher-shell`
 
 - `make zip` which builds an uber-jar with runnable script and
    packages it up for you as: `out/cypher-shell.zip`

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 ## How to build
 
-Use `make help` (`gradlew tasks`) to list possible tasks. But you probably want either
+Use `make help` (`gradlew tasks`) to list possible tasks. But you
+probably want either
 
-*  `make dist` (`gradlew installDist`)
-   which will build a runnable script for you at `cypher-shell/build/install/cypher-shell`
+-  `make build` (`gradlew installShadowApp`) which will build an
+   uber-jar and runnable script for you at
+   `cypher-shell/build/installShadow/cypher-shell`
 
-* `make zip`
-   which builds a runnable script and packages it up for you as: `out/neo4j-shell.zip`
-
-You can then just run the executable under the `bin/` sub-directory.
+- `make zip` which builds an uber-jar with runnable script and
+   packages it up for you as: `out/cypher-shell.zip`
 
 ## How to run, the fast way
 
@@ -29,10 +29,24 @@ make run
 
 Neo4j server with bolt driver configured.
 
-Authenticated by username `neo4j` password `neo`
+If authentication is required, it is assumed to be username `neo4j`
+and password `neo`.
 
 #### To run
 
-Integration tests are usually skipped when you run `make test` (`gradlew test`)
+Integration tests are usually skipped when you run `make test`
+(`gradlew test`)
 
-Use `make integration-test` (`gradlew integrationTest`) to specifically run integration tests.
+Use `make integration-test` (`gradlew integrationTest`) to
+specifically run integration tests.
+
+#### How to run the fast way
+
+This clears any previously known neo4j hosts, starts a throw-away
+instance of neo4j, and runs the integration tests against it.
+
+```sh
+rm -rf ~/.neo4j/known_hosts
+docker run --detach -p 7687:7687 -e NEO4J_AUTH=none neo4j:3.0
+make integration-test
+```

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ allprojects {
 
 subprojects {
     apply plugin: 'java'
-    apply plugin: 'application'
+    apply plugin: 'distribution'
     apply plugin: 'com.github.johnrengelman.shadow'
     apply from: "$rootProject.projectDir/gradle/integration-test.gradle"
     apply plugin: 'pmd'

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
+        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.3'
         classpath 'info.solidsoft.gradle.pitest:gradle-pitest-plugin:1.1.9'
     }
 }
@@ -23,11 +24,13 @@ allprojects {
 }
 
 subprojects {
+    apply plugin: 'java'
+    apply plugin: 'application'
+    apply plugin: 'com.github.johnrengelman.shadow'
     apply from: "$rootProject.projectDir/gradle/integration-test.gradle"
     apply plugin: 'pmd'
     apply plugin: 'jacoco'
     apply plugin: 'info.solidsoft.pitest'
-
 
     jacocoTestReport {
         reports {

--- a/cypher-shell/build.gradle
+++ b/cypher-shell/build.gradle
@@ -1,6 +1,3 @@
-apply plugin: 'java'
-apply plugin: 'application'
-
 mainClassName = 'org.neo4j.shell.Main'
 applicationName = 'cypher-shell'
 

--- a/cypher-shell/build.gradle
+++ b/cypher-shell/build.gradle
@@ -1,3 +1,9 @@
+jar {
+  manifest {
+    attributes 'Main-Class': 'org.neo4j.shell.Main'
+  }
+}
+
 distributions {
   main {
     baseName = 'cypher-shell'

--- a/cypher-shell/build.gradle
+++ b/cypher-shell/build.gradle
@@ -1,5 +1,12 @@
-mainClassName = 'org.neo4j.shell.Main'
-applicationName = 'cypher-shell'
+distributions {
+  main {
+    baseName = 'cypher-shell'
+    contents {
+      from {'src/dist'}
+      from shadowJar
+    }
+  }
+}
 
 dependencies {
     compile "net.sourceforge.argparse4j:argparse4j:$argparse4jVersion"

--- a/cypher-shell/src/dist/cypher-shell
+++ b/cypher-shell/src/dist/cypher-shell
@@ -67,14 +67,12 @@ _show_java_help() {
 
 build_classpath() {
   APP_HOME="$(cd "$(dirname "$0")" && pwd)"
-  CLASSPATH="$(find "$APP_HOME" -name "cypher-shell-*-all.jar" )"
+  JARPATH="$(find "$APP_HOME" -name "cypher-shell-*-all.jar" )"
 }
 
 check_java
 build_classpath
 
 exec "$JAVA_CMD" ${JAVA_OPTS:-} \
-  -classpath "$CLASSPATH" \
-  -Dfile.encoding=UTF-8 \
-  org.neo4j.shell.Main \
+  -jar "$JARPATH" \
   "$@"

--- a/cypher-shell/src/dist/cypher-shell
+++ b/cypher-shell/src/dist/cypher-shell
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+set -euo pipefail
+[[ "${TRACE:-}" ]] && set -x
+
+check_java() {
+  _find_java_cmd
+
+  version_command=("${JAVA_CMD}" "-version")
+  [[ -n "${JAVA_MEMORY_OPTS:-}" ]] && version_command+=("${JAVA_MEMORY_OPTS[@]}")
+
+  JAVA_VERSION=$("${version_command[@]}" 2>&1 | awk -F '"' '/version/ {print $2}')
+  if [[ "${JAVA_VERSION}" < "1.8" ]]; then
+    echo "ERROR! Java version ${JAVA_VERSION} is not supported. "
+    _show_java_help
+    exit 1
+  fi
+}
+
+_find_java_cmd() {
+  [[ "${JAVA_CMD:-}" ]] && return
+  detect_os
+  _find_java_home
+
+  if [[ "${JAVA_HOME:-}" ]] ; then
+    JAVA_CMD="${JAVA_HOME}/bin/java"
+  else
+    if [ "${DIST_OS}" != "macosx" ] ; then
+      # Don't use default java on Darwin because it displays a misleading dialog box
+      JAVA_CMD="$(which java || true)"
+    fi
+  fi
+
+  if [[ ! "${JAVA_CMD:-}" ]]; then
+    echo "ERROR: Unable to find Java executable."
+    _show_java_help
+    exit 1
+  fi
+}
+
+detect_os() {
+  if uname -s | grep -q Darwin; then
+    DIST_OS="macosx"
+  elif [[ -e /etc/gentoo-release ]]; then
+    DIST_OS="gentoo"
+  else
+    DIST_OS="other"
+  fi
+}
+
+_find_java_home() {
+  [[ "${JAVA_HOME:-}" ]] && return
+
+  case "${DIST_OS}" in
+    "macosx")
+      JAVA_HOME="$(/usr/libexec/java_home -v 1.8)"
+      ;;
+    "gentoo")
+      JAVA_HOME="$(java-config --jre-home)"
+      ;;
+  esac
+}
+
+_show_java_help() {
+  echo "* Please use Oracle(R) Java(TM) 8 or OpenJDK(TM) 8."
+}
+
+build_classpath() {
+  APP_HOME="$(cd "$(dirname "$0")" && pwd)"
+  CLASSPATH="$(find "$APP_HOME" -name "cypher-shell-*-all.jar" )"
+}
+
+check_java
+build_classpath
+
+exec "$JAVA_CMD" ${JAVA_OPTS:-} \
+  -classpath "$CLASSPATH" \
+  -Dfile.encoding=UTF-8 \
+  org.neo4j.shell.Main \
+  "$@"

--- a/cypher-shell/src/dist/cypher-shell.bat
+++ b/cypher-shell/src/dist/cypher-shell.bat
@@ -1,0 +1,91 @@
+@if "%DEBUG%" == "" @echo off
+@rem ##########################################################################
+@rem
+@rem  cypher-shell startup script for Windows
+@rem
+@rem ##########################################################################
+
+@rem Set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" setlocal
+
+set DIRNAME=%~dp0
+if "%DIRNAME%" == "" set DIRNAME=.
+set APP_BASE_NAME=%~n0
+set NEO4J_HOME=%DIRNAME%..
+
+@rem Add default JVM options here. You can also use JAVA_OPTS and CYPHER_SHELL_OPTS to pass JVM options to this script.
+set DEFAULT_JVM_OPTS=
+
+@rem Find java.exe
+if defined JAVA_HOME goto findJavaFromJavaHome
+
+set JAVA_EXE=java.exe
+%JAVA_EXE% -version >NUL 2>&1
+if "%ERRORLEVEL%" == "0" goto init
+
+echo.
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:findJavaFromJavaHome
+set JAVA_HOME=%JAVA_HOME:"=%
+set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+
+if exist "%JAVA_EXE%" goto init
+
+echo.
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:init
+@rem Get command-line arguments, handling Windows variants
+
+if not "%OS%" == "Windows_NT" goto win9xME_args
+if "%@eval[2+2]" == "4" goto 4NT_args
+
+:win9xME_args
+@rem Slurp the command line arguments.
+set CMD_LINE_ARGS=
+set _SKIP=2
+
+:win9xME_args_slurp
+if "x%~1" == "x" goto execute
+
+set CMD_LINE_ARGS=%*
+goto execute
+
+:4NT_args
+@rem Get arguments from the 4NT Shell from JP Software
+set CMD_LINE_ARGS=%$
+
+:execute
+@rem Setup the command line
+
+dir cypher-shell-*-all.jar /b/s>temp
+set /p CLASSPATH=<temp
+
+@rem Execute cypher-shell
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %CYPHER_SHELL_OPTS%  -classpath "%CLASSPATH%" org.neo4j.shell.Main %CMD_LINE_ARGS%
+
+:end
+@rem End local scope for the variables with windows NT shell
+if "%ERRORLEVEL%"=="0" goto mainEnd
+
+:fail
+rem Set variable CYPHER_SHELL_EXIT_CONSOLE if you need the _script_ return code instead of
+rem the _cmd.exe /c_ return code!
+if  not "" == "%CYPHER_SHELL_EXIT_CONSOLE%" exit 1
+exit /b 1
+
+:mainEnd
+if "%OS%"=="Windows_NT" endlocal
+
+:omega

--- a/cypher-shell/src/dist/cypher-shell.bat
+++ b/cypher-shell/src/dist/cypher-shell.bat
@@ -70,10 +70,10 @@ set CMD_LINE_ARGS=%$
 @rem Setup the command line
 
 dir cypher-shell-*-all.jar /b/s>temp
-set /p CLASSPATH=<temp
+set /p JARPATH=<temp
 
 @rem Execute cypher-shell
-"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %CYPHER_SHELL_OPTS%  -classpath "%CLASSPATH%" org.neo4j.shell.Main %CMD_LINE_ARGS%
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %CYPHER_SHELL_OPTS%  -jar "%JARPATH%" %CMD_LINE_ARGS%
 
 :end
 @rem End local scope for the variables with windows NT shell


### PR DESCRIPTION
By packaging the cypher-shell as an uber-jar we accomplish several things:

1. We avoid conflicting libraries when it is packaged with neo4j (or anything else)
2. Because we avoid conflicts, we don't have to place the jars/scripts anywhere special
3. Because we don't have to move the scripts/jars, we can keep using the generated scripts from the application plugin.
4. Because we can keep using the generated scripts, I don't have to write powershell for windows.
5. :tada: 

