### PR TITLE
Print a welcome message

### DIFF
--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellIntegrationTest.java
@@ -9,6 +9,7 @@ import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.neo4j.shell.ConnectionConfig;
 import org.neo4j.shell.CypherShell;
+import org.neo4j.shell.cli.Format;
 import org.neo4j.shell.exception.CommandException;
 import org.neo4j.shell.log.Logger;
 
@@ -19,6 +20,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -28,13 +30,20 @@ public class CypherShellIntegrationTest {
     public final ExpectedException thrown = ExpectedException.none();
 
     private Logger logger = mock(Logger.class);
-    private CypherShell shell = new CypherShell(logger);
-    private Command rollbackCommand = new Rollback(shell);
-    private Command commitCommand = new Commit(shell);
-    private Command beginCommand = new Begin(shell);
+    private Command rollbackCommand;
+    private Command commitCommand;
+    private Command beginCommand ;
+    private CypherShell shell;
 
     @Before
     public void setUp() throws Exception {
+        doReturn(Format.VERBOSE).when(logger).getFormat();
+
+        shell = new CypherShell(logger);
+        rollbackCommand = new Rollback(shell);
+        commitCommand = new Commit(shell);
+        beginCommand = new Begin(shell);
+
         shell.connect(new ConnectionConfig("localhost", 7687, "neo4j", "neo"));
     }
 

--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellIntegrationTest.java
@@ -9,7 +9,6 @@ import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.neo4j.shell.ConnectionConfig;
 import org.neo4j.shell.CypherShell;
-import org.neo4j.shell.cli.Format;
 import org.neo4j.shell.exception.CommandException;
 import org.neo4j.shell.log.Logger;
 
@@ -20,14 +19,16 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class CypherShellIntegrationTest {
     @Rule
     public final ExpectedException thrown = ExpectedException.none();
 
     private Logger logger = mock(Logger.class);
-    private CypherShell shell = new CypherShell(logger, Format.VERBOSE);
+    private CypherShell shell = new CypherShell(logger);
     private Command rollbackCommand = new Rollback(shell);
     private Command commitCommand = new Commit(shell);
     private Command beginCommand = new Begin(shell);

--- a/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
@@ -1,7 +1,6 @@
 package org.neo4j.shell;
 
 import org.neo4j.driver.v1.StatementResult;
-import org.neo4j.shell.cli.Format;
 import org.neo4j.shell.commands.Command;
 import org.neo4j.shell.commands.CommandExecutable;
 import org.neo4j.shell.commands.CommandHelper;
@@ -32,8 +31,8 @@ public class CypherShell implements StatementExecuter, Connector, TransactionHan
     protected CommandHelper commandHelper;
     protected final Map<String, Object> queryParams = new HashMap<>();
 
-    public CypherShell(@Nonnull Logger logger, @Nonnull Format format) {
-        this(logger, new BoltStateHandler(), new PrettyPrinter(format));
+    public CypherShell(@Nonnull Logger logger) {
+        this(logger, new BoltStateHandler(), new PrettyPrinter(logger.getFormat()));
     }
 
     protected CypherShell(@Nonnull Logger logger,
@@ -171,7 +170,7 @@ public class CypherShell implements StatementExecuter, Connector, TransactionHan
         Runtime.getRuntime().addShutdownHook(new Thread() {
             @Override
             public void run() {
-                logger.printOut(AnsiFormattedText.s().colorRed().append("Bye!").formattedString());
+                logger.printIfVerbose(AnsiFormattedText.s().colorRed().append("Bye!").formattedString());
                 reset();
             }
         });

--- a/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
@@ -170,7 +170,7 @@ public class CypherShell implements StatementExecuter, Connector, TransactionHan
         Runtime.getRuntime().addShutdownHook(new Thread() {
             @Override
             public void run() {
-                logger.printIfVerbose(AnsiFormattedText.s().colorRed().append("Bye!").formattedString());
+                logger.printIfVerbose(AnsiFormattedText.s().append("Bye!").formattedString());
                 reset();
             }
         });

--- a/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
@@ -170,7 +170,7 @@ public class CypherShell implements StatementExecuter, Connector, TransactionHan
         Runtime.getRuntime().addShutdownHook(new Thread() {
             @Override
             public void run() {
-                logger.printIfVerbose(AnsiFormattedText.s().append("Bye!").formattedString());
+                logger.printIfVerbose(AnsiFormattedText.s().append("\nBye!").formattedString());
                 reset();
             }
         });

--- a/cypher-shell/src/main/java/org/neo4j/shell/Main.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/Main.java
@@ -3,6 +3,7 @@ package org.neo4j.shell;
 import org.neo4j.shell.cli.CliArgHelper;
 import org.neo4j.shell.cli.CliArgs;
 import org.neo4j.shell.commands.CommandHelper;
+import org.neo4j.shell.commands.Help;
 import org.neo4j.shell.log.AnsiFormattedText;
 import org.neo4j.shell.log.AnsiLogger;
 import org.neo4j.shell.log.Logger;
@@ -57,7 +58,7 @@ public class Main {
                 .append(" as user ")
                 .bold().append(connectionConfig.username()).boldOff()
                 .append(".\nType ")
-                .bold().append(":help").boldOff()
+                .bold().append(Help.COMMAND_NAME).boldOff()
                 .append(" for a list of available commands.")
                 .formattedString());
     }

--- a/cypher-shell/src/main/java/org/neo4j/shell/Main.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/Main.java
@@ -27,7 +27,9 @@ public class Main {
 
         Logger logger = new AnsiLogger();
         try {
-            CypherShell shell = new CypherShell(logger, cliArgs.getFormat());
+            logger.setFormat(cliArgs.getFormat());
+
+            CypherShell shell = new CypherShell(logger);
 
             ShellRunner shellRunner = ShellRunner.getShellRunner(cliArgs, shell, logger);
 

--- a/cypher-shell/src/main/java/org/neo4j/shell/Main.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/Main.java
@@ -3,6 +3,7 @@ package org.neo4j.shell;
 import org.neo4j.shell.cli.CliArgHelper;
 import org.neo4j.shell.cli.CliArgs;
 import org.neo4j.shell.commands.CommandHelper;
+import org.neo4j.shell.log.AnsiFormattedText;
 import org.neo4j.shell.log.AnsiLogger;
 import org.neo4j.shell.log.Logger;
 
@@ -38,6 +39,8 @@ public class Main {
             shell.setCommandHelper(commandHelper);
             shell.connect(connectionConfig);
 
+            printWelcomeMessage(logger, connectionConfig);
+
             int code = shellRunner.runUntilEnd();
             System.exit(code);
         } catch (Throwable e) {
@@ -46,4 +49,16 @@ public class Main {
         }
     }
 
+    private static void printWelcomeMessage(@Nonnull Logger logger,
+                                            @Nonnull ConnectionConfig connectionConfig) {
+        logger.printIfVerbose(AnsiFormattedText
+                .from("Connected to Neo4j at ")
+                .bold().append(connectionConfig.driverUrl()).boldOff()
+                .append(" as user ")
+                .bold().append(connectionConfig.username()).boldOff()
+                .append(".\nType ")
+                .bold().append(":help").boldOff()
+                .append(" for a list of available commands.")
+                .formattedString());
+    }
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/Main.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/Main.java
@@ -52,11 +52,16 @@ public class Main {
 
     private static void printWelcomeMessage(@Nonnull Logger logger,
                                             @Nonnull ConnectionConfig connectionConfig) {
-        logger.printIfVerbose(AnsiFormattedText
-                .from("Connected to Neo4j at ")
-                .bold().append(connectionConfig.driverUrl()).boldOff()
-                .append(" as user ")
-                .bold().append(connectionConfig.username()).boldOff()
+        AnsiFormattedText welcomeMessage = AnsiFormattedText.from("Connected to Neo4j at ")
+                .bold().append(connectionConfig.driverUrl()).boldOff();
+
+        if (!connectionConfig.username().isEmpty()) {
+            welcomeMessage = welcomeMessage
+                    .append(" as user ")
+                    .bold().append(connectionConfig.username()).boldOff();
+        }
+
+        logger.printIfVerbose(welcomeMessage
                 .append(".\nType ")
                 .bold().append(Help.COMMAND_NAME).boldOff()
                 .append(" for a list of available commands.")

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/Format.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/Format.java
@@ -1,8 +1,11 @@
 package org.neo4j.shell.cli;
 
 public enum Format {
+    // Intended for human consumption
     VERBOSE,
+    // Intended for machine consumption (nothing except data is printed
     PLAIN;
+    // TODO JSON, strictly intended for machine consumption with data formatted in JSON
 
     public static Format parse(String format) {
         if (format.equalsIgnoreCase(PLAIN.name())) {

--- a/cypher-shell/src/main/java/org/neo4j/shell/log/AnsiLogger.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/log/AnsiLogger.java
@@ -2,6 +2,7 @@ package org.neo4j.shell.log;
 
 import org.fusesource.jansi.Ansi;
 import org.fusesource.jansi.AnsiConsole;
+import org.neo4j.shell.cli.Format;
 
 import javax.annotation.Nonnull;
 import java.io.PrintStream;
@@ -16,12 +17,14 @@ import static org.fusesource.jansi.internal.CLibrary.isatty;
 public class AnsiLogger implements Logger {
     private final PrintStream out;
     private final PrintStream err;
+    private Format format;
 
     public AnsiLogger() {
-        this(System.out, System.err);
+        this(Format.VERBOSE, System.out, System.err);
     }
 
-    public AnsiLogger(@Nonnull PrintStream out, @Nonnull PrintStream err) {
+    public AnsiLogger(@Nonnull Format format, @Nonnull PrintStream out, @Nonnull PrintStream err) {
+        this.format = format;
         this.out = out;
         this.err = err;
 
@@ -43,6 +46,17 @@ public class AnsiLogger implements Logger {
     @Override
     public PrintStream getErrorStream() {
         return err;
+    }
+
+    @Override
+    public void setFormat(@Nonnull Format format) {
+        this.format = format;
+    }
+
+    @Nonnull
+    @Override
+    public Format getFormat() {
+        return format;
     }
 
     @Override

--- a/cypher-shell/src/main/java/org/neo4j/shell/log/Logger.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/log/Logger.java
@@ -1,16 +1,69 @@
 package org.neo4j.shell.log;
 
+import org.neo4j.shell.cli.Format;
+
 import javax.annotation.Nonnull;
 import java.io.PrintStream;
 
 public interface Logger {
+    /**
+     *
+     * @return the output stream
+     */
     @Nonnull
     PrintStream getOutputStream();
 
-    void printError(@Nonnull String s);
-
-    void printOut(@Nonnull String s);
-
+    /**
+     *
+     * @return the error stream
+     */
     @Nonnull
     PrintStream getErrorStream();
+
+    /**
+     * Print the designated text to configured error stream.
+     * @param text to print to the error stream
+     */
+    void printError(@Nonnull String text);
+
+    /**
+     * Print the designated text to configured output stream.
+     * @param text to print to the output stream
+     */
+    void printOut(@Nonnull String text);
+
+    /**
+     * Set the output format on the logger
+     * @param format to set
+     */
+    void setFormat(@Nonnull Format format);
+
+    /**
+     *
+     * @return the current format of the logger
+     */
+    @Nonnull
+    Format getFormat();
+
+    /**
+     * Convenience method which only prints the given text to the output stream if the format set
+     * is {@link Format#VERBOSE}.
+     * @param text to print to the output stream
+     */
+    default void printIfVerbose(@Nonnull String text) {
+        if (Format.VERBOSE.equals(getFormat())) {
+            printOut(text);
+        }
+    }
+
+    /**
+     * Convenience method which only prints the given text to the output stream if the format set
+     * is {@link Format#PLAIN}.
+     * @param text to print to the output stream
+     */
+    default void printIfPlain(@Nonnull String text) {
+        if (Format.PLAIN.equals(getFormat())) {
+            printOut(text);
+        }
+    }
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/PrettyPrinter.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/PrettyPrinter.java
@@ -27,24 +27,27 @@ public class PrettyPrinter {
 
     public String format(@Nonnull final StatementResult result) {
         // TODO: 6/22/16 Format nicely
-        if (!result.hasNext()) {
-            return statisticsCollector.collect(result);
-        }
-
         StringBuilder sb = new StringBuilder();
-        for (String key : result.keys()) {
-            if (sb.length() > 0) {
-                sb.append(" | ");
+        if (result.hasNext()) {
+            // TODO respect format
+            for (String key : result.keys()) {
+                if (sb.length() > 0) {
+                    sb.append(" | ");
+                }
+                sb.append(key);
             }
-            sb.append(key);
+
+            while (result.hasNext()) {
+                sb.append("\n").append(format(result.next()));
+            }
         }
 
-        while (result.hasNext()) {
-            sb.append("\n").append(format(result.next()));
-        }
         String statistics = statisticsCollector.collect(result);
         if (!statistics.isEmpty()) {
-            sb.append("\n").append(statistics);
+            if (sb.length() > 0) {
+                sb.append("\n");
+            }
+            sb.append(statistics);
         }
         return sb.toString();
     }

--- a/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
@@ -23,8 +23,13 @@ import static junit.framework.TestCase.assertTrue;
 import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.mockito.Matchers.anyMap;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.contains;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class CypherShellTest {
     @Rule

--- a/cypher-shell/src/test/java/org/neo4j/shell/log/AnsiLoggerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/log/AnsiLoggerTest.java
@@ -2,12 +2,14 @@ package org.neo4j.shell.log;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.neo4j.shell.cli.Format;
 
 import java.io.PrintStream;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 
 public class AnsiLoggerTest {
@@ -20,7 +22,7 @@ public class AnsiLoggerTest {
     public void setup() {
         out = mock(PrintStream.class);
         err = mock(PrintStream.class);
-        logger = new AnsiLogger(out, err);
+        logger = new AnsiLogger(Format.VERBOSE, out, err);
     }
 
     @Test
@@ -69,5 +71,27 @@ public class AnsiLoggerTest {
         verify(err).println("bob");
         verify(err).println("nob");
         verify(err).println("cod");
+    }
+
+    @Test
+    public void printIfVerbose() throws Exception {
+        logger = new AnsiLogger(Format.VERBOSE, out, err);
+
+        logger.printIfVerbose("foo");
+        logger.printIfPlain("bar");
+
+        verify(out).println("foo");
+        verifyNoMoreInteractions(out);
+    }
+
+    @Test
+    public void printIfPlain() throws Exception {
+        logger = new AnsiLogger(Format.PLAIN, out, err);
+
+        logger.printIfVerbose("foo");
+        logger.printIfPlain("bar");
+
+        verify(out).println("bar");
+        verifyNoMoreInteractions(out);
     }
 }


### PR DESCRIPTION
Also minor refactoring around logger and format to allow for convenient format-dependant messages

Examples (hitting Ctrl-D to exit in both cases):

```
$ cypher-shell -a neo4j:neo@localhost
Connected to Neo4j at bolt://localhost:7687 as user neo4j.
Type :help for a list of available commands.
neo4j> 
Bye!
```

```
$ cypher-shell -a neo4j:neo@localhost --format=plain
neo4j> 
```