### PR TITLE
Fix cypher-shell.bat

### DIFF
--- a/cypher-shell/src/dist/cypher-shell.bat
+++ b/cypher-shell/src/dist/cypher-shell.bat
@@ -69,11 +69,12 @@ set CMD_LINE_ARGS=%$
 :execute
 @rem Setup the command line
 
-dir cypher-shell-*-all.jar /b/s>temp
-set /p JARPATH=<temp
+SETLOCAL EnableDelayedExpansion
+SET CYPHER_SHELL_JAR=
+FOR /f "delims=" %%a in ('dir "%NEO4J_HOME%\cypher-shell-*-all.jar" /s/b') do set CYPHER_SHELL_JAR=!CYPHER_SHELL_JAR!%%a
 
 @rem Execute cypher-shell
-"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %CYPHER_SHELL_OPTS%  -jar "%JARPATH%" %CMD_LINE_ARGS%
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %CYPHER_SHELL_OPTS%  -jar "%CYPHER_SHELL_JAR%" %CMD_LINE_ARGS%
 
 :end
 @rem End local scope for the variables with windows NT shell


### PR DESCRIPTION
Previously cypher-shell.bat would recursively search from the current directory
to find the cypher-shell jat files.  However if the user was, for example, at
the root of the system drive, it would search the entire drive which would take
far too long.  Instead, this commit changes the search so that it recursively
searches from the same directory of the cypher-shell.bat.  This would support
both a standalone and integrated into Neo4j situation.

Previously the cypher-shell.bat would use locate the cyper-shell jar file using
an intermediate temp file.  This commit changes the location code to use the
`FOR /F` statement to parse a fileset and create a proces level environment
variable which is later used in the java invocation.