### PR TITLE
Add a tyrekicking test for the shell script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,46 +1,56 @@
-.PHONY: help build clean zip test integration-test tyrekicking-test
+.PHONY: help build clean zip run untested-zip test integration-test tyrekicking-test mutation-test
 
 help: ## Print this help text
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-run: build ## Build and run cypher-shell with no arguments
+run: cypher-shell/build/install/cypher-shell/cypher-shell ## Build and run cypher-shell with no arguments
 	cypher-shell/build/install/cypher-shell/cypher-shell
 
-build: ## Build and test cypher-shell
-	./gradlew installDist
-
-test: ## Run all unit tests
-	./gradlew check pitest
-
-integration-test: ## Run all integration tests
-	./gradlew integrationTest
-
-tyrekicking-test: tmp/cypher-shell.zip tmp/.tests-pass ## Test that the shell script can actually start
-
-clean: ## Clean out-directories
-	rm -rf out
-	rm -rf tmp
-	./gradlew clean
-
-zip: out/cypher-shell.zip ## Build and test zip distribution file in 'out/'
+zip: out/cypher-shell.zip ## Build and run all tests on zip distribution file in 'out/'
 
 untested-zip: tmp/cypher-shell.zip ## Build (but don't test) zip distribution file in 'tmp/'
 
-out/cypher-shell.zip: tmp/cypher-shell.zip tmp/.tests-pass
-	mkdir -p out
-	cp $< $@
+build: cypher-shell/build/install/cypher-shell/cypher-shell ## Build cypher-shell
+
+test: cypher-shell/build/test-results/binary/test/results.bin ## Run all unit tests
+
+integration-test: cypher-shell/build/test-results/binary/integrationTest/results.bin ## Run all integration tests
+
+tyrekicking-test: tmp/.tests-pass ## Test that the shell script can actually start
+
+mutation-test: cypher-shell/build/reports/pitest/index.html ## Generate a mutation testing report
+
+%/integrationTest/results.bin:
+	./gradlew integrationTest
+
+%/test/results.bin:
+	./gradlew check
+
+%/install/cypher-shell/cypher-shell:
+	./gradlew installDist
+
+%/reports/pitest/index.html:
+	./gradlew pitest
 
 tmp/.tests-pass: tmp/cypher-shell.zip tyrekicking.sh
 	cp tyrekicking.sh tmp/
 	cd tmp && bash tyrekicking.sh
 	touch $@
 
-tmp/cypher-shell.zip: tmp/temp/cypher-shell/bin/cypher-shell ## Build (but don't test) zip distribution
+tmp/cypher-shell.zip: tmp/temp/cypher-shell/cypher-shell
 	cd tmp/temp && zip -r cypher-shell.zip cypher-shell
 	mv tmp/temp/cypher-shell.zip tmp/cypher-shell.zip
-	rm -rf tmp/temp
 
-tmp/temp/cypher-shell/bin/cypher-shell: build
+tmp/temp/cypher-shell/cypher-shell: cypher-shell/build/install/cypher-shell/cypher-shell
 	rm -rf tmp
 	mkdir -p tmp/temp
 	cp -r cypher-shell/build/install/cypher-shell tmp/temp/cypher-shell
+
+out/cypher-shell.zip: tmp/cypher-shell.zip test integration-test tyrekicking-test
+	mkdir -p out
+	cp $< $@
+
+clean: ## Clean build directories
+	rm -rf out
+	rm -rf tmp
+	./gradlew clean

--- a/README.md
+++ b/README.md
@@ -8,7 +8,12 @@ probably want either
    `cypher-shell/build/install/cypher-shell`
 
 - `make zip` which builds an uber-jar with runnable script and
-   packages it up for you as: `out/cypher-shell.zip`
+   packages it up for you as: `out/cypher-shell.zip` Note that this
+   will run a test on the script which requires a instance of neo4j
+   (see Integration tests below).
+
+- `make untested-zip` which builds the same zip file but doesn't test
+  it. It will be placed in `tmp/cypher-shell.zip`.
 
 ## How to run, the fast way
 

--- a/tyrekicking.sh
+++ b/tyrekicking.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -eu
+# Should be run in the out folder, containing cypher-shell.zip
+
+function prepare {
+  unzip cypher-shell.zip
+}
+
+function prepare-bundle {
+  mkdir -p cypher-shell/tools
+  mv cypher-shell/*.jar cypher-shell/tools
+}
+
+function testscript {
+  if cypher-shell/cypher-shell "RETURN 1;"; then
+    echo "$1 Success!"
+  else
+    echo "$1 Failure!"
+    exit 1
+  fi
+}
+
+prepare
+## Standalone test
+testscript "Standalone"
+## Fake bundling test
+prepare-bundle
+testscript "Bundling"


### PR DESCRIPTION
```
$ make help
help                           Print this help text
run                            Build and run cypher-shell with no arguments
build                          Build and test cypher-shell
test                           Run all unit tests
integration-test               Run all integration tests
tyrekicking-test               Test that the shell script can actually start
clean                          Clean out-directories
zip                            Build and test zip distribution file in 'out/'
untested-zip                   Build (but don't test) zip distribution file in 'tmp/'
```