### PR TITLE
Optional encryption

### DIFF
--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellIntegrationTest.java
@@ -44,7 +44,7 @@ public class CypherShellIntegrationTest {
         commitCommand = new Commit(shell);
         beginCommand = new Begin(shell);
 
-        shell.connect(new ConnectionConfig("localhost", 7687, "neo4j", "neo"));
+        shell.connect(new ConnectionConfig("localhost", 7687, "neo4j", "neo", true));
     }
 
     @After
@@ -83,7 +83,7 @@ public class CypherShellIntegrationTest {
         thrown.expect(CommandException.class);
         thrown.expectMessage("Already connected");
 
-        ConnectionConfig config = new ConnectionConfig("localhost", 7687, "neo4j", "neo");
+        ConnectionConfig config = new ConnectionConfig("localhost", 7687, "neo4j", "neo", true);
         assertTrue("Shell should already be connected", shell.isConnected());
         shell.connect(config);
     }

--- a/cypher-shell/src/main/java/org/neo4j/shell/ConnectionConfig.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/ConnectionConfig.java
@@ -1,5 +1,7 @@
 package org.neo4j.shell;
 
+import org.neo4j.driver.v1.Config;
+
 import javax.annotation.Nonnull;
 
 public class ConnectionConfig {
@@ -10,12 +12,15 @@ public class ConnectionConfig {
     private final String username;
     @Nonnull
     private final String password;
+    @Nonnull
+    private final Config.EncryptionLevel encryption;
 
-    public ConnectionConfig(@Nonnull String host, int port, @Nonnull String username, @Nonnull String password) {
+    public ConnectionConfig(@Nonnull String host, int port, @Nonnull String username, @Nonnull String password, boolean encryption) {
         this.host = host;
         this.port = port;
         this.username = username;
         this.password = password;
+        this.encryption = encryption ? Config.EncryptionLevel.REQUIRED: Config.EncryptionLevel.NONE;
     }
 
     public String host() {
@@ -36,5 +41,9 @@ public class ConnectionConfig {
 
     public String driverUrl() {
         return String.format("bolt://%s:%d", host(), port());
+    }
+
+    public Config.EncryptionLevel encryption() {
+        return encryption;
     }
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/Main.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/Main.java
@@ -31,7 +31,8 @@ public class Main {
         ConnectionConfig connectionConfig = new ConnectionConfig(cliArgs.getHost(),
                 cliArgs.getPort(),
                 cliArgs.getUsername(),
-                cliArgs.getPassword());
+                cliArgs.getPassword(),
+                cliArgs.getEncryption());
 
         Logger logger = new AnsiLogger();
         try {

--- a/cypher-shell/src/main/java/org/neo4j/shell/TriFunction.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/TriFunction.java
@@ -1,0 +1,6 @@
+package org.neo4j.shell;
+
+@FunctionalInterface
+public interface TriFunction<IN1, IN2, IN3, OUT> {
+    OUT apply(IN1 in1, IN2 in2, IN3 in3);
+}

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgHelper.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgHelper.java
@@ -3,6 +3,7 @@ package org.neo4j.shell.cli;
 import net.sourceforge.argparse4j.ArgumentParsers;
 import net.sourceforge.argparse4j.impl.action.StoreConstArgumentAction;
 import net.sourceforge.argparse4j.impl.choice.CollectionArgumentChoice;
+import net.sourceforge.argparse4j.impl.type.BooleanArgumentType;
 import net.sourceforge.argparse4j.inf.ArgumentGroup;
 import net.sourceforge.argparse4j.inf.ArgumentParser;
 import net.sourceforge.argparse4j.inf.ArgumentParserException;
@@ -27,7 +28,6 @@ public class CliArgHelper {
             Pattern.compile("\\s*(?<protocol>[a-zA-Z]+://)?((?<username>\\w+):(?<password>[^\\s]+)@)?(?<host>[\\d\\.\\w]+)?(:(?<port>\\d+))?\\s*");
 
     /**
-     *
      * @param args to parse
      * @return null in case of error, commandline arguments otherwise
      */
@@ -79,6 +79,8 @@ public class CliArgHelper {
         //Set Output format
         cliArgs.setFormat(Format.parse(ns.get("format")));
 
+        cliArgs.setEncryption(ns.getBoolean("encryption"));
+
         return cliArgs;
     }
 
@@ -112,6 +114,11 @@ public class CliArgHelper {
         connGroup.addArgument("-p", "--password")
                 .setDefault("")
                 .help("password to connect with");
+        connGroup.addArgument("--encryption")
+                .help("whether the connection to Neo4j should be encrypted; must be consistent with Neo4j's " +
+                        "configuration")
+                .type(new BooleanArgumentType())
+                .setDefault(true);
 
         MutuallyExclusiveGroup failGroup = parser.addMutuallyExclusiveGroup();
         failGroup.addArgument("--fail-fast")
@@ -135,6 +142,7 @@ public class CliArgHelper {
         parser.addArgument("cypher")
                 .nargs("?")
                 .help("an optional string of cypher to execute and then exit");
+
         return parser;
     }
 

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgs.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgs.java
@@ -12,6 +12,7 @@ public class CliArgs {
     private FailBehavior failBehavior = FailBehavior.FAIL_FAST;
     private Format format = Format.VERBOSE;
     private Optional<String> cypher = Optional.empty();
+    private boolean encryption;
 
     /**
      * Set the host to the primary value, or if null, the fallback value.
@@ -62,6 +63,13 @@ public class CliArgs {
         this.cypher = Optional.ofNullable(cypher);
     }
 
+    /**
+     * Set whether the connection should be encrypted
+     */
+    public void setEncryption(boolean encryption) {
+        this.encryption = encryption;
+    }
+
     @Nonnull
     public String getHost() {
         return host;
@@ -95,5 +103,9 @@ public class CliArgs {
     @Nonnull
     public Format getFormat() {
         return format;
+    }
+
+    public boolean getEncryption() {
+        return encryption;
     }
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
@@ -184,7 +184,9 @@ public class BoltStateHandler implements TransactionHandler, Connector {
     }
 
     private Driver getDriver(@Nonnull ConnectionConfig connectionConfig, @Nullable AuthToken authToken) {
-        return driverProvider.apply(connectionConfig.driverUrl(),
-                authToken, Config.build().withLogging(new ConsoleLogging(Level.OFF)).toConfig());
+        Config config = Config.build()
+                .withLogging(new ConsoleLogging(Level.OFF))
+                .withEncryptionLevel(connectionConfig.encryption()).toConfig();
+        return driverProvider.apply(connectionConfig.driverUrl(), authToken, config);
     }
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
@@ -13,6 +13,7 @@ import org.neo4j.driver.v1.Transaction;
 import org.neo4j.shell.ConnectionConfig;
 import org.neo4j.shell.Connector;
 import org.neo4j.shell.TransactionHandler;
+import org.neo4j.shell.TriFunction;
 import org.neo4j.shell.exception.CommandException;
 
 import javax.annotation.Nonnull;
@@ -25,9 +26,18 @@ import java.util.logging.Level;
  * Handles interactions with the driver
  */
 public class BoltStateHandler implements TransactionHandler, Connector {
+    private final TriFunction<String, AuthToken, Config, Driver> driverProvider;
     protected Driver driver;
     protected Session session;
     protected Transaction tx = null;
+
+    public BoltStateHandler() {
+        this(GraphDatabase::driver);
+    }
+
+    BoltStateHandler(TriFunction<String, AuthToken, Config, Driver> driverProvider) {
+        this.driverProvider = driverProvider;
+    }
 
     @Override
     public void beginTransaction() throws CommandException {
@@ -102,7 +112,7 @@ public class BoltStateHandler implements TransactionHandler, Connector {
             try {
                 silentDisconnect();
             } catch (Exception e) {// NOPMD
-            // This is to ensure we are able to show the original message by exception to to the user
+                // This is to ensure we are able to show the original message by exception to to the user
             }
             throw t;
         }
@@ -110,7 +120,7 @@ public class BoltStateHandler implements TransactionHandler, Connector {
 
     @Nonnull
     public Optional<BoltResult> runCypher(@Nonnull String cypher,
-                                               @Nonnull Map<String, Object> queryParams) throws CommandException {
+                                          @Nonnull Map<String, Object> queryParams) throws CommandException {
         StatementRunner statementRunner = getStatementRunner();
         StatementResult statementResult = statementRunner.run(cypher, queryParams);
 
@@ -120,18 +130,6 @@ public class BoltStateHandler implements TransactionHandler, Connector {
 
         // calling list()/consume() is what actually executes cypher on the server
         return Optional.of(new BoltResult(statementResult.list(), statementResult.consume()));
-    }
-
-    /**
-     * Get a driver to connect with
-     *
-     * @param connectionConfig
-     * @param authToken
-     * @return
-     */
-    protected Driver getDriver(@Nonnull ConnectionConfig connectionConfig, @Nullable AuthToken authToken) {
-        return GraphDatabase.driver(connectionConfig.driverUrl(),
-                authToken, Config.build().withLogging(new ConsoleLogging(Level.OFF)).toConfig());
     }
 
     /**
@@ -183,5 +181,10 @@ public class BoltStateHandler implements TransactionHandler, Connector {
             return tx;
         }
         return session;
+    }
+
+    private Driver getDriver(@Nonnull ConnectionConfig connectionConfig, @Nullable AuthToken authToken) {
+        return driverProvider.apply(connectionConfig.driverUrl(),
+                authToken, Config.build().withLogging(new ConsoleLogging(Level.OFF)).toConfig());
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/ConnectionConfigTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/ConnectionConfigTest.java
@@ -1,11 +1,12 @@
 package org.neo4j.shell;
 
 import org.junit.Test;
+import org.neo4j.driver.v1.Config;
 
 import static org.junit.Assert.assertEquals;
 
 public class ConnectionConfigTest {
-    ConnectionConfig config = new ConnectionConfig("localhost", 1, "bob", "pass");
+    ConnectionConfig config = new ConnectionConfig("localhost", 1, "bob", "pass", false);
 
     @Test
     public void host() throws Exception {
@@ -32,4 +33,9 @@ public class ConnectionConfigTest {
         assertEquals("bolt://localhost:1", config.driverUrl());
     }
 
+    @Test
+    public void encryption() {
+        assertEquals(Config.EncryptionLevel.REQUIRED, new ConnectionConfig("", -1, "", "", true).encryption());
+        assertEquals(Config.EncryptionLevel.NONE, new ConnectionConfig("", -1, "", "", false).encryption());
+    }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
@@ -56,7 +56,7 @@ public class CypherShellTest {
 
     @Test
     public void verifyDelegationOfConnectionMethods() throws CommandException {
-        ConnectionConfig cc = new ConnectionConfig("", 1, "", "");
+        ConnectionConfig cc = new ConnectionConfig("", 1, "", "", false);
         CypherShell shell = new CypherShell(logger, mockedBoltStateHandler, mockedPrettyPrinter);
 
         shell.connect(cc);

--- a/cypher-shell/src/test/java/org/neo4j/shell/cli/CliArgHelperTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/cli/CliArgHelperTest.java
@@ -115,4 +115,15 @@ public class CliArgHelperTest {
         assertTrue("expected error detail: " + bout.toString(),
                 bout.toString().contains("\n  Address should be of the form:"));
     }
+
+    @Test
+    public void defaultsEncryptionToTrue() {
+        assertEquals(true, CliArgHelper.parse().getEncryption());
+    }
+
+    @Test
+    public void allowsEncryptionToBeTurnedOnOrOff() {
+        assertEquals(true, CliArgHelper.parse("--encryption", "true").getEncryption());
+        assertEquals(false, CliArgHelper.parse("--encryption", "false").getEncryption());
+    }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/state/BoltStateHandlerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/state/BoltStateHandlerTest.java
@@ -4,7 +4,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.neo4j.driver.v1.AuthToken;
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.StatementResult;
@@ -15,7 +14,6 @@ import org.neo4j.shell.log.Logger;
 import org.neo4j.shell.test.bolt.FakeSession;
 import org.neo4j.shell.test.bolt.FakeTransaction;
 
-import javax.annotation.Nonnull;
 import java.util.HashMap;
 
 import static org.junit.Assert.assertEquals;
@@ -204,7 +202,7 @@ public class BoltStateHandlerTest {
 
         Session session = boltStateHandler.session;
         assertNotNull(session);
-        assertNotNull(boltStateHandler.fakeDriver);
+        assertNotNull(boltStateHandler.driver);
 
         assertTrue(boltStateHandler.session.isOpen());
 
@@ -219,11 +217,8 @@ public class BoltStateHandlerTest {
      * Bolt state with faked bolt interactions
      */
     private static class OfflineBoltStateHandler extends BoltStateHandler {
-
-        private final Driver fakeDriver;
-
         public OfflineBoltStateHandler(Driver driver) {
-            this.fakeDriver = driver;
+            super((uri, authToken, config) -> driver);
         }
 
         public Transaction getCurrentTransaction() {
@@ -232,11 +227,6 @@ public class BoltStateHandlerTest {
 
         public void connect() throws CommandException {
             connect(new ConnectionConfig("", 1, "", ""));
-        }
-
-        @Override
-        protected Driver getDriver(@Nonnull ConnectionConfig connectionConfig, AuthToken authToken) {
-            return fakeDriver;
         }
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/state/BoltStateHandlerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/state/BoltStateHandlerTest.java
@@ -4,13 +4,17 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.neo4j.driver.v1.AuthToken;
+import org.neo4j.driver.v1.Config;
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.Transaction;
 import org.neo4j.shell.ConnectionConfig;
+import org.neo4j.shell.TriFunction;
 import org.neo4j.shell.exception.CommandException;
 import org.neo4j.shell.log.Logger;
+import org.neo4j.shell.test.bolt.FakeDriver;
 import org.neo4j.shell.test.bolt.FakeSession;
 import org.neo4j.shell.test.bolt.FakeTransaction;
 
@@ -152,7 +156,7 @@ public class BoltStateHandlerTest {
         thrown.expect(CommandException.class);
         thrown.expectMessage("Specified username but no password");
 
-        boltStateHandler.connect(new ConnectionConfig("localhost", 1, "user", ""));
+        boltStateHandler.connect(new ConnectionConfig("localhost", 1, "user", "", false));
     }
 
     @Test
@@ -160,7 +164,7 @@ public class BoltStateHandlerTest {
         thrown.expect(CommandException.class);
         thrown.expectMessage("Specified password but no username");
 
-        boltStateHandler.connect(new ConnectionConfig("localhost", 1, "", "pass"));
+        boltStateHandler.connect(new ConnectionConfig("localhost", 1, "", "pass", false));
     }
 
     @Test
@@ -213,6 +217,24 @@ public class BoltStateHandlerTest {
         assertFalse(session.isOpen());
     }
 
+    @Test
+    public void turnOffEncryptionIfRequested() throws CommandException {
+        RecordingDriverProvider provider = new RecordingDriverProvider();
+        BoltStateHandler handler = new BoltStateHandler(provider);
+        ConnectionConfig config = new ConnectionConfig("", -1, "", "", false);
+        handler.connect(config);
+        assertEquals(Config.EncryptionLevel.NONE, provider.config.encryptionLevel());
+    }
+
+    @Test
+    public void turnOnEncryptionIfRequested() throws CommandException {
+        RecordingDriverProvider provider = new RecordingDriverProvider();
+        BoltStateHandler handler = new BoltStateHandler(provider);
+        ConnectionConfig config = new ConnectionConfig("", -1, "", "", true);
+        handler.connect(config);
+        assertEquals(Config.EncryptionLevel.REQUIRED, provider.config.encryptionLevel());
+    }
+
     /**
      * Bolt state with faked bolt interactions
      */
@@ -226,7 +248,17 @@ public class BoltStateHandlerTest {
         }
 
         public void connect() throws CommandException {
-            connect(new ConnectionConfig("", 1, "", ""));
+            connect(new ConnectionConfig("", 1, "", "", false));
+        }
+    }
+
+    private class RecordingDriverProvider implements TriFunction<String, AuthToken, Config, Driver> {
+        public Config config;
+
+        @Override
+        public Driver apply(String uri, AuthToken authToken, Config config) {
+            this.config = config;
+            return new FakeDriver();
         }
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/test/bolt/FakeDriver.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/test/bolt/FakeDriver.java
@@ -1,0 +1,16 @@
+package org.neo4j.shell.test.bolt;
+
+import org.neo4j.driver.v1.Driver;
+import org.neo4j.driver.v1.Session;
+import org.neo4j.driver.v1.exceptions.Neo4jException;
+
+public class FakeDriver implements Driver {
+    @Override
+    public Session session() {
+        return new FakeSession();
+    }
+
+    @Override
+    public void close() throws Neo4jException {
+    }
+}


### PR DESCRIPTION
Allows the `cypher-shell` user to choose whether the connection with Neo4j is encrypted.

```
> cypher-shell --help
usage: cypher-shell [-h] [-a ADDRESS] [-u USERNAME] [-p PASSWORD] [--encryption {true,false}] [--format {verbose,plain}] [--fail-fast | --fail-at-end] [cypher]

<snip> 

connection arguments:
  <snip>
  --encryption {true,false}
                         whether the connection to Neo4j should be encrypted; must be consistent with Neo4j's configuration (default: true)
```