### PR TITLE
Slim cypher help

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/commands/Help.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/commands/Help.java
@@ -17,6 +17,7 @@ public class Help implements Command {
     public static final String COMMAND_NAME = ":help";
     private final Logger logger;
     private final CommandHelper commandHelper;
+    public static String CYPHER_REFCARD_LINK = "https://neo4j.com/docs/developer-manual/3.1-beta/cypher/";
 
     public Help(@Nonnull final Logger shell, @Nonnull final CommandHelper commandHelper) {
         this.logger = shell;
@@ -95,21 +96,26 @@ public class Help implements Command {
 
         allCommands.stream().forEach(cmd -> logger.printOut(
                 AnsiFormattedText.from("  ")
-                                 .bold().append(String.format("%-" + leftColWidth + "s", cmd.getName()))
-                                 .boldOff().append(" " + cmd.getDescription())
-                                 .formattedString()));
+                        .bold().append(String.format("%-" + leftColWidth + "s", cmd.getName()))
+                        .boldOff().append(" " + cmd.getDescription())
+                        .formattedString()));
 
         logger.printOut("\nFor help on a specific command type:");
         logger.printOut(AnsiFormattedText.from("    ")
-                                         .append(COMMAND_NAME)
-                                         .bold().append(" command")
-                                         .boldOff().append("\n").formattedString());
+                .append(COMMAND_NAME)
+                .bold().append(" command")
+                .boldOff().append("\n").formattedString());
+
+        logger.printOut("\nFor help on cypher please visit:");
+        logger.printOut(AnsiFormattedText.from("    ")
+                                         .append(CYPHER_REFCARD_LINK)
+                .append("\n").formattedString());
     }
 
     private int longestCmdLength(List<Command> allCommands) {
         String longestCommand = allCommands.stream()
-                                        .map(Command::getName)
-                                        .reduce("", (s1, s2) -> s1.length() > s2.length() ? s1 : s2);
+                .map(Command::getName)
+                .reduce("", (s1, s2) -> s1.length() > s2.length() ? s1 : s2);
         return longestCommand.length();
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/commands/HelpTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/commands/HelpTest.java
@@ -15,10 +15,7 @@ import java.util.List;
 
 import static junit.framework.TestCase.fail;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 public class HelpTest {
 
@@ -69,6 +66,8 @@ public class HelpTest {
         verify(logger).printOut("  @|BOLD bobby|@ description for bobby");
         verify(logger).printOut("\nFor help on a specific command type:");
         verify(logger).printOut("    :help@|BOLD  command|@\n");
+        verify(logger).printOut("\nFor help on cypher please visit:");
+        verify(logger).printOut("    " + Help.CYPHER_REFCARD_LINK + "\n");
     }
 
     @Test
@@ -81,7 +80,7 @@ public class HelpTest {
 
         // then
         verify(logger).printOut("\nusage: @|BOLD bob|@ usage for bob\n"
-                               + "\nhelp for bob\n");
+                + "\nhelp for bob\n");
     }
 
     @Test


### PR DESCRIPTION
```
neo4j> :help

Available commands:
  :begin    Open a transaction
  :commit   Commit the currently open transaction
  :exit     Exit the logger
  :help     Show this help message
  :history  Print a list of the last commands executed
  :params   Prints all currently set query parameters and their values
  :rollback Rollback the currently open transaction
  :set      Set the value of a query parameter

For help on a specific command type:
    :help command


For help on cypher please visit:
    https://neo4j.com/docs/developer-manual/3.1-beta/cypher/
```

We currently don't have a mechanism of finding out what version of the neo4j server the shell is connected to, in that case we can point to their `discovered_version` until then we can switch to pointing to `current`