### PR TITLE
prompts as per abk's request

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/InteractiveShellRunner.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/InteractiveShellRunner.java
@@ -28,8 +28,8 @@ import static org.neo4j.shell.exception.Helper.getFormattedMessage;
  */
 public class InteractiveShellRunner implements ShellRunner, SignalHandler {
     private final static AnsiFormattedText freshPrompt = AnsiFormattedText.s().bold().append("neo4j> ");
-    private final static AnsiFormattedText continuationPrompt = AnsiFormattedText.s().bold().append(".....> ");
-    private final static AnsiFormattedText transactionPrompt = AnsiFormattedText.s().bold().append("  trx> ");
+    private final static AnsiFormattedText continuationPrompt = AnsiFormattedText.s().bold().append("       ");
+    private final static AnsiFormattedText transactionPrompt = AnsiFormattedText.s().bold().append("neo4j# ");
     static final String INTERRUPT_SIGNAL = "INT";
 
     // Need to know if we are currently executing when catch Ctrl-C, needs to be atomic due to

--- a/cypher-shell/src/test/java/org/neo4j/shell/cli/InteractiveShellRunnerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/cli/InteractiveShellRunnerTest.java
@@ -260,7 +260,7 @@ public class InteractiveShellRunnerTest {
         prompt = runner.getPrompt();
 
         // then
-        assertEquals(".....> ", prompt.plainString());
+        assertEquals("       ", prompt.plainString());
     }
 
     @Test
@@ -274,21 +274,21 @@ public class InteractiveShellRunnerTest {
         AnsiFormattedText prompt = runner.getPrompt();
 
         // then
-        assertEquals("  trx> ", prompt.plainString());
+        assertEquals("neo4j# ", prompt.plainString());
 
         // when
         statementParser.parseMoreText("  \t \n   "); // whitespace
         prompt = runner.getPrompt();
 
         // then
-        assertEquals("  trx> ", prompt.plainString());
+        assertEquals("neo4j# ", prompt.plainString());
 
         // when
         statementParser.parseMoreText("bla bla"); // non whitespace
         prompt = runner.getPrompt();
 
         // then
-        assertEquals(".....> ", prompt.plainString());
+        assertEquals("       ", prompt.plainString());
     }
 
     @Test


### PR DESCRIPTION
Usually `neo4j>`

Multiline are indented
```
neo4j> match (n)
       return n;
n
{name: "Joe"}
neo4j>
```
Transactions end with `neo4j#`
```
neo4j> :begin
neo4j# create (:Person {name:"Jane"});
Added 1 nodes, Set 1 properties, Added 1 labels
neo4j# :commit
neo4j>
```
```
neo4j> :begin
neo4j# create (:Person {name:"James"});
Added 1 nodes, Set 1 properties, Added 1 labels
neo4j# :rollback
neo4j> match (n) return n;
n
{name: "Joe"}
{name: "Jane"}
neo4j>
```