### PR TITLE
Fallback to unformatted output in case JAnsi fails

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/ShellRunner.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/ShellRunner.java
@@ -50,9 +50,18 @@ public interface ShellRunner {
     }
 
     /**
+     * Checks if STDIN is a TTY. In case TTY checking is not possible (lack of libc), then the check falls back to
+     * the built in Java {@link System#console()} which checks if EITHER STDIN or STDOUT has been redirected.
+     *
      * @return true if the shell reading from a TTY, false otherwise (e.g., we are reading from a file)
      */
     static boolean isInputInteractive() {
-        return 1 == isatty(STDIN_FILENO);
+        try {
+            return 1 == isatty(STDIN_FILENO);
+        } catch (NoClassDefFoundError e) {
+            // system is not using libc (like Alpine Linux)
+            // Fallback to checking stdin OR stdout
+            return System.console() != null;
+        }
     }
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/log/AnsiLogger.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/log/AnsiLogger.java
@@ -28,10 +28,14 @@ public class AnsiLogger implements Logger {
         this.out = out;
         this.err = err;
 
-        if (isOutputInteractive()) {
-            Ansi.setEnabled(true);
-            AnsiConsole.systemInstall();
-        } else {
+        try {
+            if (isOutputInteractive()) {
+                Ansi.setEnabled(true);
+                AnsiConsole.systemInstall();
+            } else {
+                Ansi.setEnabled(false);
+            }
+        } catch (UnsatisfiedLinkError t) {
             Ansi.setEnabled(false);
         }
     }
@@ -71,6 +75,7 @@ public class AnsiLogger implements Logger {
 
     /**
      * @return true if the shell is outputting to a TTY, false otherwise (e.g., we are writing to a file)
+     * @throws java.lang.UnsatisfiedLinkError if system is not using libc (like Alpine Linux)
      */
     private static boolean isOutputInteractive() {
         return 1 == isatty(STDOUT_FILENO) && 1 == isatty(STDERR_FILENO);


### PR DESCRIPTION
JAnsi will fail on Alpine Linux due to its use of musl and not libc.
Thus JAnsi native components fail to load. This makes sure we fallback
to uncolored output when JAnsi fails.

In addition, when selecting appropriate runner, we fallback to the
built-in Java check which is not as good but will be correct most times.

To test this, you need to be in a situation where the native libraries fail to
load. Here is how to do it with docker.

- Build `cypher-shell` by doing `make clean build`
- Place the following file in the root of your clone and name it `Dockerfile`

```
FROM neo4j/neo4j-experimental:3.1.0-M08

COPY cypher-shell/build/install/cypher-shell/cypher-shell-1.0.0-SNAPSHOT-all.jar /var/lib/neo4j/bin/tools/
```

- Run `docker build -t alpineansi .`
- Run `docker run --rm -p 7474:7474 -p 7687:7687 -e NEO4J_AUTH=none alpineansi`
- Find the id of your container with `docker ps`
- Run bash inside your container `docker exec -it <CONTAINER-ID> /bin/bash`
- See that the shell runs properly: `bin/cypher-shell --debug`

Example output:

```
bin/cypher-shell                                                                                                       
Connected to Neo4j at bolt://localhost:7687.
Type :help for a list of available commands.
neo4j> 
```

and with debugging:

```
bin/cypher-shell  --debug
Formatted output disabled due to
java.lang.UnsatisfiedLinkError: Could not load library. Reasons: [no jansi in java.library.path, /tmp/libjansi-64-6812538292534463384.so: Error relocating /tmp/libjansi-64-6812538292534463384.so: ttyslot: symbol not found]
Connected to Neo4j at bolt://localhost:7687.
Type :help for a list of available commands.
neo4j> 
```
