### PR TITLE
Simple output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,3 +54,5 @@ clean: ## Clean build directories
 	rm -rf out
 	rm -rf tmp
 	./gradlew clean
+
+launch: clean build run

--- a/Makefile
+++ b/Makefile
@@ -55,4 +55,4 @@ clean: ## Clean build directories
 	rm -rf tmp
 	./gradlew clean
 
-launch: clean build run
+launch: clean build run ## Cleans working directory to build and run the cypher-shell

--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellIntegrationTest.java
@@ -75,7 +75,7 @@ public class CypherShellIntegrationTest {
         verify(logger, times(1)).printOut(captor.capture());
 
         List<String> result = captor.getAllValues();
-        assertThat(result.get(0), is("jane\n{name: \"Jane Smith\"}\nAdded 1 nodes, Set 1 properties, Added 1 labels"));
+        assertThat(result.get(0), is("jane\n{name: \"Jane Smith\",labels: [TestPerson]}\nAdded 1 nodes, Set 1 properties, Added 1 labels"));
     }
 
     @Test
@@ -105,7 +105,7 @@ public class CypherShellIntegrationTest {
         verify(logger, times(3)).printOut(captor.capture());
 
         List<String> result = captor.getAllValues();
-        assertThat(result.get(2), is("n\n{name: \"Jane Smith\"}"));
+        assertThat(result.get(2), is("n\n{name: \"Jane Smith\",labels: [TestPerson]}"));
     }
 
     @Test
@@ -121,7 +121,7 @@ public class CypherShellIntegrationTest {
         verify(logger, times(2)).printOut(captor.capture());
 
         List<String> result = captor.getAllValues();
-        assertThat(result.get(1), is("n\n{name: \"Joe Smith\"}"));
+        assertThat(result.get(1), is("n\n{name: \"Joe Smith\",labels: [TestPerson]}"));
     }
 
     @Test

--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellIntegrationTest.java
@@ -75,7 +75,8 @@ public class CypherShellIntegrationTest {
         verify(logger, times(1)).printOut(captor.capture());
 
         List<String> result = captor.getAllValues();
-        assertThat(result.get(0), is("jane\n{name: \"Jane Smith\",labels: [TestPerson]}\nAdded 1 nodes, Set 1 properties, Added 1 labels"));
+        assertThat(result.get(0), is("jane\n(:TestPerson {name: \"Jane Smith\"})\n" +
+                "Added 1 nodes, Set 1 properties, Added 1 labels"));
     }
 
     @Test
@@ -105,7 +106,7 @@ public class CypherShellIntegrationTest {
         verify(logger, times(3)).printOut(captor.capture());
 
         List<String> result = captor.getAllValues();
-        assertThat(result.get(2), is("n\n{name: \"Jane Smith\",labels: [TestPerson]}"));
+        assertThat(result.get(2), is("n\n(:TestPerson {name: \"Jane Smith\"})"));
     }
 
     @Test
@@ -121,7 +122,7 @@ public class CypherShellIntegrationTest {
         verify(logger, times(2)).printOut(captor.capture());
 
         List<String> result = captor.getAllValues();
-        assertThat(result.get(1), is("n\n{name: \"Joe Smith\",labels: [TestPerson]}"));
+        assertThat(result.get(1), is("n\n(:TestPerson {name: \"Joe Smith\"})"));
     }
 
     @Test

--- a/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/PrettyPrinter.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/PrettyPrinter.java
@@ -21,9 +21,10 @@ import java.util.stream.Collectors;
  */
 public class PrettyPrinter {
 
-    public static final String COMMA_SEPARATOR = ", ";
+    private static final String COMMA_SEPARATOR = ", ";
     private static final String COLON_SEPARATOR = ": ";
-    public static final String COLON = ":";
+    private static final String COLON = ":";
+    private static final String SPACE = " ";
     private StatisticsCollector statisticsCollector;
 
     public PrettyPrinter(@Nonnull Format format) {
@@ -34,7 +35,6 @@ public class PrettyPrinter {
         StringBuilder sb = new StringBuilder();
         List<Record> records = result.getRecords();
         if (!records.isEmpty()) {
-            // TODO respect format
             sb.append(records.get(0).keys().stream().collect(Collectors.joining(COMMA_SEPARATOR)));
             sb.append("\n");
             sb.append(records.stream().map(PrettyPrinter::format).collect(Collectors.joining("\n")));
@@ -110,8 +110,8 @@ public class PrettyPrinter {
         }
         StringBuilder sb = new StringBuilder("{");
         sb.append(
-                map.keySet().stream()
-                        .map(e -> e + COLON_SEPARATOR + map.get(e))
+                map.entrySet().stream()
+                        .map(e -> e.getKey() + COLON_SEPARATOR + e.getValue())
                         .collect(Collectors.joining(COMMA_SEPARATOR)));
         return sb.append("}").toString();
     }
@@ -125,7 +125,7 @@ public class PrettyPrinter {
         relationshipAsString.add(toString(relationship.asMap(PrettyPrinter::toString)));
 
         return "[" +
-                relationshipAsString.stream().filter(str -> isNotBlank(str)).collect(Collectors.joining(" ")) +
+                relationshipAsString.stream().filter(str -> isNotBlank(str)).collect(Collectors.joining(SPACE)) +
                 "]";
     }
 
@@ -138,7 +138,7 @@ public class PrettyPrinter {
         nodeAsString.add(toString(node.asMap(PrettyPrinter::toString)));
 
         return "(" +
-                nodeAsString.stream().filter(str -> isNotBlank(str)).collect(Collectors.joining(" ")) +
+                nodeAsString.stream().filter(str -> isNotBlank(str)).collect(Collectors.joining(SPACE)) +
                 ")";
     }
 

--- a/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/PrettyPrinterTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/PrettyPrinterTest.java
@@ -1,15 +1,26 @@
 package org.neo4j.shell.prettyprint;
 
 import org.junit.Test;
+import org.mockito.Matchers;
+import org.neo4j.driver.internal.types.InternalTypeSystem;
+import org.neo4j.driver.v1.Record;
+import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.summary.ResultSummary;
 import org.neo4j.driver.v1.summary.SummaryCounters;
+import org.neo4j.driver.v1.types.Node;
+import org.neo4j.driver.v1.types.Path;
+import org.neo4j.driver.v1.types.Relationship;
 import org.neo4j.shell.cli.Format;
 import org.neo4j.shell.state.BoltResult;
 
 import java.util.Collections;
+import java.util.HashMap;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableMap;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -32,5 +43,159 @@ public class PrettyPrinterTest {
 
         // then
         assertThat(actual, is("Added 10 nodes, Added 1 labels"));
+    }
+
+    @Test
+    public void prettyPrintList() throws Exception {
+        // given
+        BoltResult result = mock(BoltResult.class);
+
+        Record record1 = mock(Record.class);
+        Record record2 = mock(Record.class);
+        Value value1 = mock(Value.class);
+        Value value2 = mock(Value.class);
+
+
+        when(value1.type()).thenReturn(InternalTypeSystem.TYPE_SYSTEM.LIST());
+        when(value2.type()).thenReturn(InternalTypeSystem.TYPE_SYSTEM.LIST());
+
+        when(value1.asList(Matchers.anyObject())).thenReturn(asList("val1_1", "val1_2"));
+        when(value2.asList(Matchers.anyObject())).thenReturn(asList("val2_1"));
+
+        when(record1.keys()).thenReturn(asList("col1", "col2"));
+        when(record1.values()).thenReturn(asList(value1, value2));
+        when(record2.values()).thenReturn(asList(value2));
+
+        when(result.getRecords()).thenReturn(asList(record1, record2));
+
+        // when
+        String actual = new PrettyPrinter(Format.PLAIN).format(result);
+
+        // then
+        assertThat(actual, is("col1,col2\n[val1_1,val1_2],[val2_1]\n[val2_1]"));
+    }
+
+    @Test
+    public void prettyPrintNode() throws Exception {
+        // given
+        BoltResult result = mock(BoltResult.class);
+
+        Record record = mock(Record.class);
+        Value value = mock(Value.class);
+
+        Node node = mock(Node.class);
+        HashMap<String, Object> propertiesAsMap = new HashMap<>();
+        propertiesAsMap.put("prop1", "prop1_value");
+        propertiesAsMap.put("prop2", "prop2_value");
+
+        when(value.type()).thenReturn(InternalTypeSystem.TYPE_SYSTEM.NODE());
+
+        when(value.asNode()).thenReturn(node);
+        when(node.labels()).thenReturn(asList("label1", "label2"));
+        when(node.asMap(anyObject())).thenReturn(unmodifiableMap(propertiesAsMap));
+
+        when(record.keys()).thenReturn(asList("col1", "col2"));
+        when(record.values()).thenReturn(asList(value));
+
+        when(result.getRecords()).thenReturn(asList(record));
+
+        // when
+        String actual = new PrettyPrinter(Format.PLAIN).format(result);
+
+        // then
+        assertThat(actual, is("col1,col2\n" +
+                "{prop2: prop2_value,prop1: prop1_value,labels: [label1,label2]}"));
+    }
+
+    @Test
+    public void prettyPrintRelationships() throws Exception {
+        // given
+        BoltResult result = mock(BoltResult.class);
+
+        Record record = mock(Record.class);
+        Value value = mock(Value.class);
+
+        Relationship relationship = mock(Relationship.class);
+        HashMap<String, Object> propertiesAsMap = new HashMap<>();
+        propertiesAsMap.put("prop1", "prop1_value");
+        propertiesAsMap.put("prop2", "prop2_value");
+
+        when(value.type()).thenReturn(InternalTypeSystem.TYPE_SYSTEM.RELATIONSHIP());
+
+        when(value.asRelationship()).thenReturn(relationship);
+        when(relationship.type()).thenReturn("RELATIONSHIP_TYPE");
+        when(relationship.asMap(anyObject())).thenReturn(unmodifiableMap(propertiesAsMap));
+
+        when(record.keys()).thenReturn(asList("rel"));
+        when(record.values()).thenReturn(asList(value));
+
+        when(result.getRecords()).thenReturn(asList(record));
+
+        // when
+        String actual = new PrettyPrinter(Format.PLAIN).format(result);
+
+        // then
+        assertThat(actual, is("rel\n{prop2: prop2_value,prop1: prop1_value,type: RELATIONSHIP_TYPE}"));
+    }
+
+    @Test
+    public void prettyPrintPaths() throws Exception {
+        // given
+        BoltResult result = mock(BoltResult.class);
+
+        Record record = mock(Record.class);
+        Value value = mock(Value.class);
+
+        Node start = mock(Node.class);
+        HashMap<String, Object> startProperties = new HashMap<>();
+        startProperties.put("prop1", "prop1_value");
+        when(start.labels()).thenReturn(asList("start"));
+
+        Node middle = mock(Node.class);
+        when(middle.labels()).thenReturn(asList("middle"));
+
+        Node end = mock(Node.class);
+        HashMap<String, Object> endProperties = new HashMap<>();
+        endProperties.put("prop2", "prop2_value");
+        when(end.labels()).thenReturn(asList("end"));
+
+        Path path = mock(Path.class);
+        when(path.start()).thenReturn(start);
+
+        Relationship relationship = mock(Relationship.class);
+        when(relationship.type()).thenReturn("RELATIONSHIP_TYPE");
+
+
+        Path.Segment segment1 = mock(Path.Segment.class);
+        when(segment1.start()).thenReturn(start);
+        when(segment1.end()).thenReturn(middle);
+        when(segment1.relationship()).thenReturn(relationship);
+
+        Path.Segment segment2 = mock(Path.Segment.class);
+        when(segment2.start()).thenReturn(middle);
+        when(segment2.end()).thenReturn(end);
+        when(segment2.relationship()).thenReturn(relationship);
+
+        when(value.type()).thenReturn(InternalTypeSystem.TYPE_SYSTEM.PATH());
+        when(value.asPath()).thenReturn(path);
+        when(path.iterator()).thenReturn(asList(segment1, segment2).iterator());
+        when(start.asMap(anyObject())).thenReturn(unmodifiableMap(startProperties));
+        when(end.asMap(anyObject())).thenReturn(unmodifiableMap(endProperties));
+
+        when(record.keys()).thenReturn(asList("path"));
+        when(record.values()).thenReturn(asList(value));
+
+        when(result.getRecords()).thenReturn(asList(record));
+
+        // when
+        String actual = new PrettyPrinter(Format.PLAIN).format(result);
+
+        // then
+        assertThat(actual, is("path\n" +
+                "[{prop1: prop1_value,labels: [start]}," +
+                "{type: RELATIONSHIP_TYPE}," +
+                "{labels: [middle]}," +
+                "{type: RELATIONSHIP_TYPE}," +
+                "{prop2: prop2_value,labels: [end]}]"));
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/PrettyPrinterTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/PrettyPrinterTest.java
@@ -72,7 +72,7 @@ public class PrettyPrinterTest {
         String actual = new PrettyPrinter(Format.PLAIN).format(result);
 
         // then
-        assertThat(actual, is("col1,col2\n[val1_1,val1_2],[val2_1]\n[val2_1]"));
+        assertThat(actual, is("col1, col2\n[val1_1, val1_2], [val2_1]\n[val2_1]"));
     }
 
     @Test
@@ -103,8 +103,8 @@ public class PrettyPrinterTest {
         String actual = new PrettyPrinter(Format.PLAIN).format(result);
 
         // then
-        assertThat(actual, is("col1,col2\n" +
-                "{prop2: prop2_value,prop1: prop1_value,labels: [label1,label2]}"));
+        assertThat(actual, is("col1, col2\n" +
+                "(:label1:label2 {prop2: prop2_value, prop1: prop1_value})"));
     }
 
     @Test
@@ -135,7 +135,7 @@ public class PrettyPrinterTest {
         String actual = new PrettyPrinter(Format.PLAIN).format(result);
 
         // then
-        assertThat(actual, is("rel\n{prop2: prop2_value,prop1: prop1_value,type: RELATIONSHIP_TYPE}"));
+        assertThat(actual, is("rel\n[:RELATIONSHIP_TYPE {prop2: prop2_value, prop1: prop1_value}]"));
     }
 
     @Test
@@ -192,10 +192,12 @@ public class PrettyPrinterTest {
 
         // then
         assertThat(actual, is("path\n" +
-                "[{prop1: prop1_value,labels: [start]}," +
-                "{type: RELATIONSHIP_TYPE}," +
-                "{labels: [middle]}," +
-                "{type: RELATIONSHIP_TYPE}," +
-                "{prop2: prop2_value,labels: [end]}]"));
+                "[" +
+                "(:start {prop1: prop1_value}), " +
+                "[:RELATIONSHIP_TYPE], " +
+                "(:middle), " +
+                "[:RELATIONSHIP_TYPE], " +
+                "(:end {prop2: prop2_value})" +
+                "]"));
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/PrettyPrinterTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/PrettyPrinterTest.java
@@ -139,6 +139,51 @@ public class PrettyPrinterTest {
     }
 
     @Test
+    public void printRelationshipsAndNodesWithEscapingForSpecialCharacters() throws Exception {
+        BoltResult result = mock(BoltResult.class);
+
+        Record record = mock(Record.class);
+        Value relVal = mock(Value.class);
+        Value nodeVal = mock(Value.class);
+
+        Relationship relationship = mock(Relationship.class);
+        HashMap<String, Object> relProp = new HashMap<>();
+        relProp.put("prop1", "\"prop1, value\"");
+        relProp.put("prop2", "prop2_value");
+
+        Node node = mock(Node.class);
+        HashMap<String, Object> nodeProp = new HashMap<>();
+        nodeProp.put("prop1", "\"prop1:value\"");
+        nodeProp.put("prop2", "\"\"");
+
+
+        when(relVal.type()).thenReturn(InternalTypeSystem.TYPE_SYSTEM.RELATIONSHIP());
+        when(nodeVal.type()).thenReturn(InternalTypeSystem.TYPE_SYSTEM.NODE());
+
+        when(relVal.asRelationship()).thenReturn(relationship);
+        when(relationship.type()).thenReturn("RELATIONSHIP,TYPE");
+        when(relationship.asMap(anyObject())).thenReturn(unmodifiableMap(relProp));
+
+
+        when(nodeVal.asNode()).thenReturn(node);
+        when(node.labels()).thenReturn(asList("label 1", "label2"));
+        when(node.asMap(anyObject())).thenReturn(unmodifiableMap(nodeProp));
+
+
+        when(record.keys()).thenReturn(asList("rel", "node"));
+        when(record.values()).thenReturn(asList(relVal, nodeVal));
+
+        when(result.getRecords()).thenReturn(asList(record));
+
+        // when
+        String actual = new PrettyPrinter(Format.PLAIN).format(result);
+
+        // then
+        assertThat(actual, is("rel, node\n[:`RELATIONSHIP,TYPE` {prop2: prop2_value, prop1: \"prop1, value\"}], " +
+                "(:`label 1`:label2 {prop2: \"\", prop1: \"prop1:value\"})"));
+    }
+
+    @Test
     public void prettyPrintPaths() throws Exception {
         // given
         BoltResult result = mock(BoltResult.class);


### PR DESCRIPTION
Better output from cypher-shell

* Nodes and Relationships

```
neo4j> MATCH (p:Person)-[r:WORKS_AT]->(d:Dept) RETURN p,d,r LIMIT 2;
p, d, r
(:Person:Entity {name: "Frank"}), (:Dept {name: "IT-Department"}), [:WORKS_AT {hoursPerWeek: 40}]
(:Person:Entity {name: "Bruce"}), (:Dept {name: "IT-Department"}), [:WORKS_AT {hoursPerWeek: 40}]
neo4j>

```

* Paths
```
neo4j> MATCH p=(a:Person)-[:WORKS_AT]->(d)<-[:WORKS_AT]-(b:Person) WHERE a.name = "Daniel" RETURN p LIMIT 2;
p
[(:Person {name: "Daniel"}), [:WORKS_AT], (:Org {name: "GraphIT"}), [:WORKS_AT], (:Person {name: "Gabriele"})]
[(:Person {name: "Daniel"}), [:WORKS_AT], (:Org {name: "GraphIT"}), [:WORKS_AT], (:Person {name: "Jerry"})]
neo4j>
```

* Lists
```
neo4j> RETURN [1,2,3];
neo4j> RETURN [1,2,3];
[1,2,3]
[1, 2, 3]

```

Also included in this PR: Ability to run `make launch` now runs gradle clean, installs and connects to a running instance of neo4j.