### PR TITLE
Better handling when missing username and password

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/ConnectionConfig.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/ConnectionConfig.java
@@ -15,12 +15,25 @@ public class ConnectionConfig {
     @Nonnull
     private final Config.EncryptionLevel encryption;
 
-    public ConnectionConfig(@Nonnull String host, int port, @Nonnull String username, @Nonnull String password, boolean encryption) {
+    public ConnectionConfig(@Nonnull String host, int port, @Nonnull String username, @Nonnull String password,
+                            boolean encryption) {
         this.host = host;
         this.port = port;
-        this.username = username;
-        this.password = password;
-        this.encryption = encryption ? Config.EncryptionLevel.REQUIRED: Config.EncryptionLevel.NONE;
+        this.username = fallbackToEnvVariable(username, "NEO4J_USERNAME");
+        this.password = fallbackToEnvVariable(password, "NEO4J_PASSWORD");
+        this.encryption = encryption ? Config.EncryptionLevel.REQUIRED : Config.EncryptionLevel.NONE;
+    }
+
+    /**
+     * @return preferredValue if not empty, else the contents of the fallback environment variable
+     */
+    @Nonnull
+    static String fallbackToEnvVariable(@Nonnull String preferredValue, @Nonnull String fallbackEnvVar) {
+        String result = System.getenv(fallbackEnvVar);
+        if (result == null || !preferredValue.isEmpty()) {
+            result = preferredValue;
+        }
+        return result;
     }
 
     public String host() {

--- a/cypher-shell/src/main/java/org/neo4j/shell/ConnectionConfig.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/ConnectionConfig.java
@@ -9,11 +9,11 @@ public class ConnectionConfig {
     private final String host;
     private final int port;
     @Nonnull
-    private final String username;
-    @Nonnull
-    private final String password;
-    @Nonnull
     private final Config.EncryptionLevel encryption;
+    @Nonnull
+    private String username;
+    @Nonnull
+    private String password;
 
     public ConnectionConfig(@Nonnull String host, int port, @Nonnull String username, @Nonnull String password,
                             boolean encryption) {
@@ -58,5 +58,13 @@ public class ConnectionConfig {
 
     public Config.EncryptionLevel encryption() {
         return encryption;
+    }
+
+    public void setUsername(@Nonnull String username) {
+        this.username = username;
+    }
+
+    public void setPassword(@Nonnull String password) {
+        this.password = password;
     }
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/Main.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/Main.java
@@ -1,16 +1,26 @@
 package org.neo4j.shell;
 
+import jline.console.ConsoleReader;
+import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.shell.cli.CliArgHelper;
 import org.neo4j.shell.cli.CliArgs;
 import org.neo4j.shell.commands.CommandHelper;
 import org.neo4j.shell.commands.Help;
+import org.neo4j.shell.exception.CommandException;
 import org.neo4j.shell.log.AnsiFormattedText;
 import org.neo4j.shell.log.AnsiLogger;
 import org.neo4j.shell.log.Logger;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.InputStream;
+import java.io.PrintStream;
 
 public class Main {
+
+
+    private final InputStream in;
+    private final PrintStream out;
 
     public static void main(String[] args) {
         CliArgs cliArgs = CliArgHelper.parse(args);
@@ -25,10 +35,22 @@ public class Main {
         main.startShell(cliArgs);
     }
 
+    Main() {
+        this(System.in, System.out);
+    }
+
+    /**
+     * For testing purposes
+     */
+    Main(final InputStream in, final PrintStream out) {
+        this.in = in;
+        this.out = out;
+    }
+
     private static void printWelcomeMessage(@Nonnull Logger logger,
                                             @Nonnull ConnectionConfig connectionConfig) {
         AnsiFormattedText welcomeMessage = AnsiFormattedText.from("Connected to Neo4j at ")
-                .bold().append(connectionConfig.driverUrl()).boldOff();
+                                                            .bold().append(connectionConfig.driverUrl()).boldOff();
 
         if (!connectionConfig.username().isEmpty()) {
             welcomeMessage = welcomeMessage
@@ -55,13 +77,14 @@ public class Main {
             logger.setFormat(cliArgs.getFormat());
 
             CypherShell shell = new CypherShell(logger);
+            connectInteractively(shell, connectionConfig);
 
+            // Construct shellrunner after connecting, due to interrupt handling
             ShellRunner shellRunner = ShellRunner.getShellRunner(cliArgs, shell, logger);
 
             CommandHelper commandHelper = new CommandHelper(logger, shellRunner.getHistorian(), shell);
 
             shell.setCommandHelper(commandHelper);
-            shell.connect(connectionConfig);
 
             printWelcomeMessage(logger, connectionConfig);
 
@@ -71,5 +94,51 @@ public class Main {
             logger.printError(e);
             System.exit(1);
         }
+    }
+
+    /**
+     * Connect the shell to the server, and try to handle missing passwords and such
+     */
+    void connectInteractively(@Nonnull CypherShell shell, @Nonnull ConnectionConfig connectionConfig)
+            throws Exception {
+        try {
+            shell.connect(connectionConfig);
+        } catch (ClientException e) {
+            if (e.getMessage() == null || !e.getMessage().contains("Missing username")) {
+                throw e;
+            }
+            // else need to prompt for username and password
+            if (connectionConfig.username().isEmpty()) {
+                connectionConfig.setUsername(promptForText("username: ", null));
+            }
+            if (connectionConfig.password().isEmpty()) {
+                connectionConfig.setPassword(promptForText("password: ", '*'));
+            }
+            // try again
+            shell.connect(connectionConfig);
+        }
+    }
+
+    /**
+     * @param prompt
+     *         to display to the user
+     * @param mask
+     *         single character to display instead of what the user is typing, use null if text is not secret
+     * @return the text which was entered
+     * @throws Exception
+     *         in case of errors
+     */
+    @Nonnull
+    private String promptForText(@Nonnull String prompt, @Nullable Character mask) throws Exception {
+        String line;
+        ConsoleReader consoleReader = new ConsoleReader(in, out);
+        line = consoleReader.readLine(prompt, mask);
+        consoleReader.close();
+
+        if (line == null) {
+            throw new CommandException("No text could be read, exiting...");
+        }
+
+        return line;
     }
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgHelper.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgHelper.java
@@ -113,10 +113,10 @@ public class CliArgHelper {
                 .setDefault("localhost:7687");
         connGroup.addArgument("-u", "--username")
                 .setDefault("")
-                .help("username to connect as");
+                .help("username to connect as. Can also be specified using environment variable NEO4J_USERNAME");
         connGroup.addArgument("-p", "--password")
                 .setDefault("")
-                .help("password to connect with");
+                .help("password to connect with. Can also be specified using environment variable NEO4J_PASSWORD");
         connGroup.addArgument("--encryption")
                 .help("whether the connection to Neo4j should be encrypted; must be consistent with Neo4j's " +
                         "configuration")

--- a/cypher-shell/src/main/java/org/neo4j/shell/log/AnsiLogger.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/log/AnsiLogger.java
@@ -2,6 +2,7 @@ package org.neo4j.shell.log;
 
 import org.fusesource.jansi.Ansi;
 import org.fusesource.jansi.AnsiConsole;
+import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.shell.cli.Format;
 import org.neo4j.shell.exception.AnsiFormattedException;
 
@@ -123,6 +124,13 @@ public class AnsiLogger implements Logger {
 
             if (cause instanceof AnsiFormattedException) {
                 msg = msg.append(((AnsiFormattedException) cause).getFormattedMessage());
+            } else if (cause instanceof ClientException &&
+                    cause.getMessage() != null && cause.getMessage().contains("Missing username")) {
+                // Username and password was not specified
+                msg = msg.append(cause.getMessage())
+                         .append("\nPlease specify --username, and optionally --password, as argument(s)")
+                         .append("\nor as environment variable(s), NEO4J_USERNAME, and NEO4J_PASSWORD respectively.")
+                         .append("\nSee --help for more info.");
             } else {
                 if (cause.getMessage() != null) {
                     msg = msg.append(cause.getMessage());

--- a/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
@@ -93,14 +93,10 @@ public class BoltStateHandler implements TransactionHandler, Connector {
         }
 
         final AuthToken authToken;
-        if (connectionConfig.username().isEmpty() && connectionConfig.password().isEmpty()) {
-            authToken = null;
-        } else if (!connectionConfig.username().isEmpty() && !connectionConfig.password().isEmpty()) {
+        if (!connectionConfig.username().isEmpty() && !connectionConfig.password().isEmpty()) {
             authToken = AuthTokens.basic(connectionConfig.username(), connectionConfig.password());
-        } else if (connectionConfig.username().isEmpty()) {
-            throw new CommandException("Specified password but no username");
         } else {
-            throw new CommandException("Specified username but no password");
+            authToken = null;
         }
 
         try {

--- a/cypher-shell/src/test/java/org/neo4j/shell/MainTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/MainTest.java
@@ -1,0 +1,140 @@
+package org.neo4j.shell;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.neo4j.driver.v1.exceptions.ClientException;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class MainTest {
+
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    private CypherShell shell;
+    private ConnectionConfig connectionConfig;
+    private PrintStream out;
+
+    @Before
+    public void setup() {
+        out = mock(PrintStream.class);
+        shell = mock(CypherShell.class);
+        connectionConfig = mock(ConnectionConfig.class);
+
+        doReturn("").when(connectionConfig).username();
+        doReturn("").when(connectionConfig).password();
+    }
+
+    @Test
+    public void connectInteractivelyNonEndedStringFails() throws Exception {
+        String inputString = "no newline";
+        InputStream inputStream = new ByteArrayInputStream(inputString.getBytes());
+
+        doThrow(new ClientException("Missing username and password")).when(shell).connect(connectionConfig);
+
+        thrown.expectMessage("No text could be read, exiting");
+
+        Main main = new Main(inputStream, out);
+        main.connectInteractively(shell, connectionConfig);
+        verify(shell, times(1)).connect(connectionConfig);
+    }
+
+    @Test
+    public void connectInteractivelyNullMessageDoesNotPrompt() throws Exception {
+        doThrow(new ClientException(null)).when(shell).connect(connectionConfig);
+
+        thrown.expect(ClientException.class);
+
+        Main main = new Main(mock(InputStream.class), out);
+        main.connectInteractively(shell, connectionConfig);
+        verify(shell, times(1)).connect(connectionConfig);
+    }
+
+    @Test
+    public void connectInteractivelyUnrelatedErrorDoesNotPrompt() throws Exception {
+        doThrow(new RuntimeException("bla")).when(shell).connect(connectionConfig);
+
+        thrown.expect(RuntimeException.class);
+        thrown.expectMessage("bla");
+
+        Main main = new Main(mock(InputStream.class), out);
+        main.connectInteractively(shell, connectionConfig);
+        verify(shell, times(1)).connect(connectionConfig);
+    }
+
+    @Test
+    public void connectInteractivelyPromptsForBothIfNone() throws Exception {
+        doThrow(new ClientException("Missing username and password")).doNothing().when(shell).connect(connectionConfig);
+
+        String inputString = "bob\nsecret\n";
+        InputStream inputStream = new ByteArrayInputStream(inputString.getBytes());
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintStream ps = new PrintStream(baos);
+
+        Main main = new Main(inputStream, ps);
+        main.connectInteractively(shell, connectionConfig);
+
+        String out = new String(baos.toByteArray(), StandardCharsets.UTF_8);
+
+        assertEquals(out, "username: bob\r\npassword: ******\r\n");
+        verify(connectionConfig).setUsername("bob");
+        verify(connectionConfig).setPassword("secret");
+        verify(shell, times(2)).connect(connectionConfig);
+    }
+
+    @Test
+    public void connectInteractivelyPromptsForUserIfPassExists() throws Exception {
+        doThrow(new ClientException("Missing username and password")).doNothing().when(shell).connect(connectionConfig);
+        doReturn("secret").when(connectionConfig).password();
+
+        String inputString = "bob\n";
+        InputStream inputStream = new ByteArrayInputStream(inputString.getBytes());
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintStream ps = new PrintStream(baos);
+
+        Main main = new Main(inputStream, ps);
+        main.connectInteractively(shell, connectionConfig);
+
+        String out = new String(baos.toByteArray(), StandardCharsets.UTF_8);
+
+        assertEquals(out, "username: bob\r\n");
+        verify(connectionConfig).setUsername("bob");
+        verify(shell, times(2)).connect(connectionConfig);
+    }
+
+    @Test
+    public void connectInteractivelyPromptsForPassIfUserExists() throws Exception {
+        doThrow(new ClientException("Missing username and password")).doNothing().when(shell).connect(connectionConfig);
+        doReturn("bob").when(connectionConfig).username();
+
+        String inputString = "secret\n";
+        InputStream inputStream = new ByteArrayInputStream(inputString.getBytes());
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintStream ps = new PrintStream(baos);
+
+        Main main = new Main(inputStream, ps);
+        main.connectInteractively(shell, connectionConfig);
+
+        String out = new String(baos.toByteArray(), StandardCharsets.UTF_8);
+
+        assertEquals(out, "password: ******\r\n");
+        verify(connectionConfig).setPassword("secret");
+        verify(shell, times(2)).connect(connectionConfig);
+    }
+}

--- a/cypher-shell/src/test/java/org/neo4j/shell/state/BoltStateHandlerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/state/BoltStateHandlerTest.java
@@ -139,22 +139,6 @@ public class BoltStateHandlerTest {
     }
 
     @Test
-    public void onlyUserWillThrow() throws CommandException {
-        thrown.expect(CommandException.class);
-        thrown.expectMessage("Specified username but no password");
-
-        boltStateHandler.connect(new ConnectionConfig("localhost", 1, "user", "", false));
-    }
-
-    @Test
-    public void onlyPassWillThrow() throws CommandException {
-        thrown.expect(CommandException.class);
-        thrown.expectMessage("Specified password but no username");
-
-        boltStateHandler.connect(new ConnectionConfig("localhost", 1, "", "pass", false));
-    }
-
-    @Test
     public void canOnlyConnectOnce() throws CommandException {
         thrown.expect(CommandException.class);
         thrown.expectMessage("Already connected");


### PR DESCRIPTION
Example:

```
NEO4J_USERNAME=neo4j cypher-shell/build/install/cypher-shell/cypher-shell
password: ***
Connected to Neo4j at bolt://localhost:7687 as user neo4j.
Type :help for a list of available commands.
neo4j> 
```

and

```
NEO4J_PASSWORD=bob cypher-shell/build/install/cypher-shell/cypher-shell
username: neo4j
Connected to Neo4j at bolt://localhost:7687 as user neo4j.
Type :help for a list of available commands.
```

Updated help text

```
usage: cypher-shell [-h] [-a ADDRESS] [-u USERNAME] [-p PASSWORD] [--encryption {true,false}] [--format {verbose,plain}] [--fail-fast | --fail-at-end] [cypher]

A command line shell where you can execute Cypher against an instance of Neo4j

positional arguments:
  cypher                 an optional string of cypher to execute and then exit

optional arguments:
  -h, --help             show this help message and exit
  --fail-fast            exit and report failure on first error when reading from file (this is the default behavior)
  --fail-at-end          exit and report failures at end of input when reading from file
  --format {verbose,plain}
                         desired output format, verbose(default) displays statistics, plain only displays data (default: verbose)

connection arguments:
  -a ADDRESS, --address ADDRESS
                         address and port to connect to (default: localhost:7687)
  -u USERNAME, --username USERNAME
                         username to connect as. Can also be specified using environment variable NEO4J_USERNAME (default: )
  -p PASSWORD, --password PASSWORD
                         password to connect with. Can also be specified using environment variable NEO4J_PASSWORD (default: )
  --encryption {true,false}
                         whether the connection to Neo4j should be encrypted; must be consistent with Neo4j's configuration (default: true)
```