### PR TITLE
Display arrows as part of path

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/PrettyPrinter.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/PrettyPrinter.java
@@ -93,13 +93,13 @@ public class PrettyPrinter {
 
         path.iterator().forEachRemaining(segment -> {
             if (segment.relationship() != null) {
-                list.add(relationshipAsString(segment.relationship()));
+                list.add("-" + relationshipAsString(segment.relationship()) + "->");
             }
             if (segment.end() != null) {
                 list.add(nodeAsString(segment.end()));
             }
         });
-        return listAsString(list);
+        return list.stream().collect(Collectors.joining());
     }
 
     private String listAsString(List<String> list) {
@@ -121,16 +121,11 @@ public class PrettyPrinter {
     }
 
     private String relationshipAsString(Relationship relationship) {
-
-        String type = COLON + escapeIfNeeded(relationship.type());
-
         List<String> relationshipAsString = new ArrayList<>();
-        relationshipAsString.add(type);
+        relationshipAsString.add(COLON + escapeIfNeeded(relationship.type()));
         relationshipAsString.add(mapAsString(relationship.asMap(this::formatValue)));
 
-        return "[" +
-                relationshipAsString.stream().filter(str -> isNotBlank(str)).collect(Collectors.joining(SPACE)) +
-                "]";
+        return "[" + joinWithSpace(relationshipAsString) + "]";
     }
 
     private String nodeAsString(@Nonnull final Node node) {
@@ -138,15 +133,17 @@ public class PrettyPrinter {
         nodeAsString.add(collectNodeLabels(node));
         nodeAsString.add(mapAsString(node.asMap(this::formatValue)));
 
-        return "(" +
-                nodeAsString.stream().filter(str -> isNotBlank(str)).collect(Collectors.joining(SPACE)) +
-                ")";
+        return "(" + joinWithSpace(nodeAsString) + ")";
     }
 
     private String collectNodeLabels(@Nonnull Node node) {
         StringBuilder sb = new StringBuilder();
         node.labels().forEach(label -> sb.append(COLON).append(escapeIfNeeded(label)));
         return sb.toString();
+    }
+
+    private String joinWithSpace(List<String> strings) {
+        return strings.stream().filter(str -> isNotBlank(str)).collect(Collectors.joining(SPACE));
     }
 
     private static boolean isNotBlank(String string) {

--- a/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/PrettyPrinter.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/PrettyPrinter.java
@@ -86,19 +86,25 @@ public class PrettyPrinter {
 
     private String pathAsString(Path path) {
         List<String> list = new LinkedList<>();
-
-        if (path.start() != null) {
-            list.add(nodeAsString(path.start()));
+        Node lastTraversed = path.start();
+        if (lastTraversed != null) {
+            list.add(nodeAsString(lastTraversed));
         }
 
-        path.iterator().forEachRemaining(segment -> {
-            if (segment.relationship() != null) {
-                list.add("-" + relationshipAsString(segment.relationship()) + "->");
-            }
-            if (segment.end() != null) {
+        for (Path.Segment segment : path) {
+            Relationship relationship = segment.relationship();
+            if (relationship.startNodeId() == lastTraversed.id()) {
+                //-[:r]->
+                list.add("-" + relationshipAsString(relationship) + "->");
                 list.add(nodeAsString(segment.end()));
+                lastTraversed = segment.start();
+            } else {
+                list.add("<-" + relationshipAsString(relationship) + "-");
+                list.add(nodeAsString(segment.end()));
+                lastTraversed = segment.end();
             }
-        });
+        }
+
         return list.stream().collect(Collectors.joining());
     }
 

--- a/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/PrettyPrinterTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/PrettyPrinterTest.java
@@ -237,12 +237,7 @@ public class PrettyPrinterTest {
 
         // then
         assertThat(actual, is("path\n" +
-                "[" +
-                "(:start {prop1: prop1_value}), " +
-                "[:RELATIONSHIP_TYPE], " +
-                "(:middle), " +
-                "[:RELATIONSHIP_TYPE], " +
-                "(:end {prop2: prop2_value})" +
-                "]"));
+                "(:start {prop1: prop1_value})-[:RELATIONSHIP_TYPE]->" +
+                "(:middle)-[:RELATIONSHIP_TYPE]->(:end {prop2: prop2_value})"));
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/PrettyPrinterTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/PrettyPrinterTest.java
@@ -195,20 +195,24 @@ public class PrettyPrinterTest {
         HashMap<String, Object> startProperties = new HashMap<>();
         startProperties.put("prop1", "prop1_value");
         when(start.labels()).thenReturn(asList("start"));
+        when(start.id()).thenReturn(1l);
 
         Node middle = mock(Node.class);
         when(middle.labels()).thenReturn(asList("middle"));
+        when(middle.id()).thenReturn(2l);
 
         Node end = mock(Node.class);
         HashMap<String, Object> endProperties = new HashMap<>();
         endProperties.put("prop2", "prop2_value");
         when(end.labels()).thenReturn(asList("end"));
+        when(end.id()).thenReturn(3l);
 
         Path path = mock(Path.class);
         when(path.start()).thenReturn(start);
 
         Relationship relationship = mock(Relationship.class);
         when(relationship.type()).thenReturn("RELATIONSHIP_TYPE");
+        when(relationship.startNodeId()).thenReturn(1l).thenReturn(3l);
 
 
         Path.Segment segment1 = mock(Path.Segment.class);
@@ -238,6 +242,116 @@ public class PrettyPrinterTest {
         // then
         assertThat(actual, is("path\n" +
                 "(:start {prop1: prop1_value})-[:RELATIONSHIP_TYPE]->" +
-                "(:middle)-[:RELATIONSHIP_TYPE]->(:end {prop2: prop2_value})"));
+                "(:middle)<-[:RELATIONSHIP_TYPE]-(:end {prop2: prop2_value})"));
+    }
+
+    @Test
+    public void prettyPrintSingleNodePath() throws Exception {
+        // given
+        BoltResult result = mock(BoltResult.class);
+
+        Record record = mock(Record.class);
+        Value value = mock(Value.class);
+
+        Node start = mock(Node.class);
+        when(start.labels()).thenReturn(asList("start"));
+        when(start.id()).thenReturn(1l);
+
+        Node end = mock(Node.class);
+        when(end.labels()).thenReturn(asList("end"));
+        when(end.id()).thenReturn(2l);
+
+        Path path = mock(Path.class);
+        when(path.start()).thenReturn(start);
+
+        Relationship relationship = mock(Relationship.class);
+        when(relationship.type()).thenReturn("RELATIONSHIP_TYPE");
+        when(relationship.startNodeId()).thenReturn(1l);
+
+
+        Path.Segment segment1 = mock(Path.Segment.class);
+        when(segment1.start()).thenReturn(start);
+        when(segment1.end()).thenReturn(end);
+        when(segment1.relationship()).thenReturn(relationship);
+
+        when(value.type()).thenReturn(InternalTypeSystem.TYPE_SYSTEM.PATH());
+        when(value.asPath()).thenReturn(path);
+        when(path.iterator()).thenReturn(asList(segment1).iterator());
+
+        when(record.keys()).thenReturn(asList("path"));
+        when(record.values()).thenReturn(asList(value));
+
+        when(result.getRecords()).thenReturn(asList(record));
+
+        // when
+        String actual = new PrettyPrinter(Format.PLAIN).format(result);
+
+        // then
+        assertThat(actual, is("path\n(:start)-[:RELATIONSHIP_TYPE]->(:end)"));
+    }
+
+    @Test
+    public void prettyPrintThreeSegmentPath() throws Exception {
+        // given
+        BoltResult result = mock(BoltResult.class);
+
+        Record record = mock(Record.class);
+        Value value = mock(Value.class);
+
+        Node start = mock(Node.class);
+        when(start.labels()).thenReturn(asList("start"));
+        when(start.id()).thenReturn(1l);
+
+        Node second = mock(Node.class);
+        when(second.labels()).thenReturn(asList("second"));
+        when(second.id()).thenReturn(2l);
+
+        Node third = mock(Node.class);
+        when(third.labels()).thenReturn(asList("third"));
+        when(third.id()).thenReturn(3l);
+
+        Node end = mock(Node.class);
+        when(end.labels()).thenReturn(asList("end"));
+        when(end.id()).thenReturn(4l);
+
+        Path path = mock(Path.class);
+        when(path.start()).thenReturn(start);
+
+        Relationship relationship = mock(Relationship.class);
+        when(relationship.type()).thenReturn("RELATIONSHIP_TYPE");
+        when(relationship.startNodeId()).thenReturn(1l).thenReturn(3l).thenReturn(3l);
+
+
+        Path.Segment segment1 = mock(Path.Segment.class);
+        when(segment1.start()).thenReturn(start);
+        when(segment1.end()).thenReturn(second);
+        when(segment1.relationship()).thenReturn(relationship);
+
+        Path.Segment segment2 = mock(Path.Segment.class);
+        when(segment2.start()).thenReturn(second);
+        when(segment2.end()).thenReturn(third);
+        when(segment2.relationship()).thenReturn(relationship);
+
+        Path.Segment segment3 = mock(Path.Segment.class);
+        when(segment3.start()).thenReturn(third);
+        when(segment3.end()).thenReturn(end);
+        when(segment3.relationship()).thenReturn(relationship);
+
+        when(value.type()).thenReturn(InternalTypeSystem.TYPE_SYSTEM.PATH());
+        when(value.asPath()).thenReturn(path);
+        when(path.iterator()).thenReturn(asList(segment1, segment2, segment3).iterator());
+
+        when(record.keys()).thenReturn(asList("path"));
+        when(record.values()).thenReturn(asList(value));
+
+        when(result.getRecords()).thenReturn(asList(record));
+
+        // when
+        String actual = new PrettyPrinter(Format.PLAIN).format(result);
+
+        // then
+        assertThat(actual, is("path\n" +
+                "(:start)-[:RELATIONSHIP_TYPE]->" +
+                "(:second)<-[:RELATIONSHIP_TYPE]-(:third)-[:RELATIONSHIP_TYPE]->(:end)"));
     }
 }


### PR DESCRIPTION
Paths have the direction of relationships.
```
neo4j> MATCH p=(a:Person)-[:WORKS_AT]->(d)<-[:WORKS_AT]-(b:Person)-[:HAS_MEMBER]-(de:Project) RETURN p LIMIT 1;
p
(:Person:Entity {name: "Evan"})-[:WORKS_AT {hoursPerWeek: 40}]->(:Dept {name: "Mobile Apps"})<-[:WORKS_AT {hoursPerWeek: 40}]-(:Person:Entity {name: "Emma"})<-[:HAS_MEMBER {role: "scrum master"}]-(:Project {name: "Project X"})
neo4j>
```