### PR TITLE
updated regex to not escape unicode characters.

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/PrettyPrinter.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/PrettyPrinter.java
@@ -28,7 +28,7 @@ public class PrettyPrinter {
     private static final String COLON = ":";
     private static final String SPACE = " ";
     public static final String BACKTICK = "`";
-    private static final Pattern ALPHA_NUMERIC = Pattern.compile("^[a-zA-Z0-9_]*$");
+    private static final Pattern ALPHA_NUMERIC = Pattern.compile("^[\\p{L}_][\\p{L}0-9_]*");
     private StatisticsCollector statisticsCollector;
 
     public PrettyPrinter(@Nonnull Format format) {

--- a/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/PrettyPrinterTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/PrettyPrinterTest.java
@@ -154,7 +154,8 @@ public class PrettyPrinterTest {
         Node node = mock(Node.class);
         HashMap<String, Object> nodeProp = new HashMap<>();
         nodeProp.put("prop1", "\"prop1:value\"");
-        nodeProp.put("prop2", "\"\"");
+        nodeProp.put("1prop2", "\"\"");
+        nodeProp.put("ä", "not-escaped");
 
 
         when(relVal.type()).thenReturn(InternalTypeSystem.TYPE_SYSTEM.RELATIONSHIP());
@@ -180,7 +181,7 @@ public class PrettyPrinterTest {
 
         // then
         assertThat(actual, is("rel, node\n[:`RELATIONSHIP,TYPE` {prop2: prop2_value, prop1: \"prop1, value\"}], " +
-                "(:`label 1`:label2 {prop2: \"\", prop1: \"prop1:value\"})"));
+                "(:`label 1`:label2 {prop1: \"prop1:value\", `1prop2`: \"\", ä: not-escaped})"));
     }
 
     @Test


### PR DESCRIPTION
Cypher does not escape labels created with UNICODE characters. Fixing cypher-shell to do the same.
```
neo4j> match (n:ä) return n;
n
(:ä)
```