### PR TITLE
Fix transaction handling on session reset

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
@@ -154,8 +154,10 @@ public class BoltStateHandler implements TransactionHandler, Connector {
             session.reset();
 
             // Clear current state
-            // Bolt has already rolled back the transaction so we should not close it ourselves
             if (isTransactionOpen()) {
+                // Bolt has already rolled back the transaction but it doesn't close it properly
+                tx.failure();
+                tx.close();
                 tx = null;
             }
         }

--- a/cypher-shell/src/test/java/org/neo4j/shell/state/BoltStateHandlerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/state/BoltStateHandlerTest.java
@@ -175,6 +175,8 @@ public class BoltStateHandlerTest {
 
         // then
         verify(sessionMock).reset();
+        verify(transactionMock).failure();
+        verify(transactionMock).close();
     }
 
     @Test


### PR DESCRIPTION
Bolt rolls back transactions, but does not properly close them.

## Before

No new transaction can be started after a reset

```
neo4j> :begin
neo4j# MATCH p=()-[*]-() RETURN COUNT(p);
The transaction has been terminated. Retry your operation in a new transaction, and you should see a successful result. Explicitly terminated by the user. 
neo4j> :rollback
There is no open transaction to rollback
neo4j> :begin
You cannot begin a transaction on a session with an open transaction; either run from within the transaction or use a different session.
neo4j> 
```

## After (fixed)

Note that a new transaction CAN be started

```
neo4j> :begin
neo4j# MATCH p=()-[*]-() RETURN COUNT(p);
The transaction has been terminated. Retry your operation in a new transaction, and you should see a successful result. Explicitly terminated by the user. 
neo4j> :begin
neo4j# MATCH p=()-[*]-() RETURN COUNT(p);
The transaction has been terminated. Retry your operation in a new transaction, and you should see a successful result. Explicitly terminated by the user. 
neo4j> 
```