### PR TITLE
pinning java driver to 1.1-20160919.122818-1.jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ subprojects {
 ext {
     argparse4jVersion = '0.7.0'
     junitVersion = '4.12'
-    neo4jJavaVersion = '1.1-SNAPSHOT'
+    neo4jJavaVersion = '1.1-20160919.122818-1'
     findbugsVersion = '3.0.0'
     jansiVersion = '1.13'
     jlineVersion = '2.14.2'

--- a/cypher-shell/src/test/java/org/neo4j/shell/test/bolt/FakeDriver.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/test/bolt/FakeDriver.java
@@ -1,5 +1,6 @@
 package org.neo4j.shell.test.bolt;
 
+import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.exceptions.Neo4jException;
@@ -13,6 +14,11 @@ public class FakeDriver implements Driver {
     @Override
     public Session session() {
         return new FakeSession();
+    }
+
+    @Override
+    public Session session(AccessMode mode) {
+        return null;
     }
 
     @Override


### PR DESCRIPTION
There were few build failures because of changes in java driver and we are depending on their SNAPSHOT version. 

I have pinned it to a specific version which will be changed to a milestone version once a `1.1.0-M02`  release is done.