### PR TITLE
suppress exceptions in silent disconnect.

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
@@ -107,8 +107,8 @@ public class BoltStateHandler implements TransactionHandler, Connector {
         } catch (Throwable t) {
             try {
                 silentDisconnect();
-            } catch (Exception e) {// NOPMD
-                // This is to ensure we are able to show the original message by exception to to the user
+            } catch (Exception e) {
+                t.addSuppressed(e);
             }
             throw t;
         }


### PR DESCRIPTION
When you try and disconnect after an exception

You will now be reported the original error.
```
$ cypher-shell
username: neo4j
password: *****
Connected to Neo4j at bolt://localhost:7687 as user neo4j.
Type :help for a list of available commands.
neo4j> CALL apoc.meta.graph;
There is no procedure with the name `apoc.meta.graph` registered for this database instance. Please ensure you've spelled the procedure name correctly and that the procedure is properly deployed.
neo4j> match (n:asdsd) return n;
The credentials you provided were valid, but must be changed before you can use this instance. If this is the first time you are using Neo4j, this is to ensure you are not using the default credentials in production. If you are not using default credentials, you are getting this message because an administrator requires a password change.
Changing your password is easy to do via the Neo4j Browser.
If you are connecting via a shell or programmatically via a driver, just issue a `CALL dbms.changePassword('new password')` statement in the current session, and then restart your driver with the new password configured.
neo4j>
```