### PR TITLE
added user friendly interrupt message and welcome message.

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/Main.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/Main.java
@@ -64,7 +64,7 @@ public class Main {
                 .append(" for a list of available commands or ")
                 .bold().append(Exit.COMMAND_NAME).boldOff()
                 .append(" to exit the shell.")
-                .append(" Note that Cypher queries must end with a ")
+                .append("\nNote that Cypher queries must end with a ")
                 .bold().append("semicolon.").boldOff()
                 .formattedString());
     }

--- a/cypher-shell/src/main/java/org/neo4j/shell/Main.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/Main.java
@@ -5,6 +5,7 @@ import org.neo4j.driver.v1.exceptions.ClientException;
 import org.neo4j.shell.cli.CliArgHelper;
 import org.neo4j.shell.cli.CliArgs;
 import org.neo4j.shell.commands.CommandHelper;
+import org.neo4j.shell.commands.Exit;
 import org.neo4j.shell.commands.Help;
 import org.neo4j.shell.exception.CommandException;
 import org.neo4j.shell.log.AnsiFormattedText;
@@ -60,7 +61,11 @@ public class Main {
         logger.printIfVerbose(welcomeMessage
                 .append(".\nType ")
                 .bold().append(Help.COMMAND_NAME).boldOff()
-                .append(" for a list of available commands.")
+                .append(" for a list of available commands or ")
+                .bold().append(Exit.COMMAND_NAME).boldOff()
+                .append(" to exit the shell.")
+                .append(" Note that Cypher queries must end with a ")
+                .bold().append("semicolon.").boldOff()
                 .formattedString());
     }
 

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/InteractiveShellRunner.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/InteractiveShellRunner.java
@@ -5,6 +5,7 @@ import org.neo4j.shell.Historian;
 import org.neo4j.shell.ShellRunner;
 import org.neo4j.shell.StatementExecuter;
 import org.neo4j.shell.TransactionHandler;
+import org.neo4j.shell.commands.Exit;
 import org.neo4j.shell.exception.ExitException;
 import org.neo4j.shell.exception.NoMoreInputException;
 import org.neo4j.shell.log.AnsiFormattedText;
@@ -154,7 +155,14 @@ public class InteractiveShellRunner implements ShellRunner, SignalHandler {
             executer.reset();
         } else {
             // Print a literal newline here to get around us being in the middle of the prompt
-            logger.printError(AnsiFormattedText.s().colorRed().append("\nKeyboardInterrupt").formattedString());
+            logger.printError(
+                    AnsiFormattedText.s().colorRed()
+                            .append("\n" + "Interrupted (Note that Cypher queries must end with a ")
+                            .bold().append("semicolon. ").boldOff()
+                            .append("Type ")
+                            .bold().append(Exit.COMMAND_NAME).append(" ").boldOff()
+                            .append("to exit the shell.")
+                            .formattedString());
             // Clear any text which has been inputted
             resetPrompt();
         }

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/InteractiveShellRunner.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/InteractiveShellRunner.java
@@ -157,11 +157,11 @@ public class InteractiveShellRunner implements ShellRunner, SignalHandler {
             // Print a literal newline here to get around us being in the middle of the prompt
             logger.printError(
                     AnsiFormattedText.s().colorRed()
-                            .append("\n" + "Interrupted (Note that Cypher queries must end with a ")
+                            .append("\nInterrupted (Note that Cypher queries must end with a ")
                             .bold().append("semicolon. ").boldOff()
                             .append("Type ")
                             .bold().append(Exit.COMMAND_NAME).append(" ").boldOff()
-                            .append("to exit the shell.")
+                            .append("to exit the shell.)")
                             .formattedString());
             // Clear any text which has been inputted
             resetPrompt();

--- a/cypher-shell/src/test/java/org/neo4j/shell/cli/InteractiveShellRunnerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/cli/InteractiveShellRunnerTest.java
@@ -348,7 +348,10 @@ public class InteractiveShellRunnerTest {
 
         // then
         verifyNoMoreInteractions(cmdExecuter);
-        verify(logger).printError("@|RED \nKeyboardInterrupt|@");
+        verify(logger).printError("@|RED \nInterrupted (Note that Cypher queries must end with a |@" +
+                "@|RED,BOLD semicolon. |@" +
+                "@|RED Type |@@|RED,BOLD :exit|@@|RED,BOLD  |@" +
+                "@|RED to exit the shell.|@");
     }
 
     @Test

--- a/cypher-shell/src/test/java/org/neo4j/shell/cli/InteractiveShellRunnerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/cli/InteractiveShellRunnerTest.java
@@ -351,7 +351,7 @@ public class InteractiveShellRunnerTest {
         verify(logger).printError("@|RED \nInterrupted (Note that Cypher queries must end with a |@" +
                 "@|RED,BOLD semicolon. |@" +
                 "@|RED Type |@@|RED,BOLD :exit|@@|RED,BOLD  |@" +
-                "@|RED to exit the shell.|@");
+                "@|RED to exit the shell.)|@");
     }
 
     @Test


### PR DESCRIPTION
The welcome message and keyboard interrupt now says that queries end with *semicolon* and *:exit* to exit the shell.

```
username: neo4j
password: ***
Connected to Neo4j at bolt://localhost:7687 as user neo4j.
Type :help for a list of available commands or :exit to exit the shell.
Note that Cypher queries must end with a semicolon.
neo4j>
Interrupted (Note that Cypher queries must end with a semicolon. Type :exit to exit the shell.)
neo4j>
```