### PR TITLE
Added version of connected Neo4j to welcome message

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/Connector.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/Connector.java
@@ -10,7 +10,6 @@ import javax.annotation.Nonnull;
 public interface Connector {
 
     /**
-     *
      * @return true if connected, false otherwise
      */
     boolean isConnected();
@@ -20,4 +19,13 @@ public interface Connector {
      * @throws CommandException if connection failed
      */
     void connect(@Nonnull ConnectionConfig connectionConfig) throws CommandException;
+
+    /**
+     * Returns the version of Neo4j which the shell is connected to. If the version is before 3.1.0-M09, or we are not
+     * connected yet, this returns the empty string.
+     *
+     * @return the version of neo4j (like '3.1.0') if connected and available, an empty string otherwise
+     */
+    @Nonnull
+    String getServerVersion();
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
@@ -123,6 +123,12 @@ public class CypherShell implements StatementExecuter, Connector, TransactionHan
         boltStateHandler.connect(connectionConfig);
     }
 
+    @Nonnull
+    @Override
+    public String getServerVersion() {
+        return boltStateHandler.getServerVersion();
+    }
+
     @Override
     public void beginTransaction() throws CommandException {
         boltStateHandler.beginTransaction();

--- a/cypher-shell/src/main/java/org/neo4j/shell/Main.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/Main.java
@@ -48,8 +48,15 @@ public class Main {
     }
 
     private static void printWelcomeMessage(@Nonnull Logger logger,
-                                            @Nonnull ConnectionConfig connectionConfig) {
-        AnsiFormattedText welcomeMessage = AnsiFormattedText.from("Connected to Neo4j at ")
+                                            @Nonnull ConnectionConfig connectionConfig,
+                                            @Nonnull String serverVersion) {
+        String neo4j = "Neo4j";
+        if (!serverVersion.isEmpty()) {
+            neo4j += " " + serverVersion;
+        }
+        AnsiFormattedText welcomeMessage = AnsiFormattedText.from("Connected to ")
+                                                            .append(neo4j)
+                                                            .append(" at ")
                                                             .bold().append(connectionConfig.driverUrl()).boldOff();
 
         if (!connectionConfig.username().isEmpty()) {
@@ -90,7 +97,7 @@ public class Main {
 
             shell.setCommandHelper(commandHelper);
 
-            printWelcomeMessage(logger, connectionConfig);
+            printWelcomeMessage(logger, connectionConfig, shell.getServerVersion());
 
             int code = shellRunner.runUntilEnd();
             System.exit(code);

--- a/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
@@ -115,6 +115,24 @@ public class BoltStateHandler implements TransactionHandler, Connector {
     }
 
     @Nonnull
+    @Override
+    public String getServerVersion() {
+        if (isConnected()) {
+            String version = session.server();
+            if (version == null) {
+                // On versions before 3.1.0-M09
+                version = "";
+            }
+            if (version.startsWith("Neo4j/")) {
+                // Want to return '3.1.0' and not 'Neo4j/3.1.0'
+                version = version.substring(6);
+            }
+            return version;
+        }
+        return "";
+    }
+
+    @Nonnull
     public Optional<BoltResult> runCypher(@Nonnull String cypher,
                                           @Nonnull Map<String, Object> queryParams) throws CommandException {
         StatementRunner statementRunner = getStatementRunner();
@@ -181,8 +199,8 @@ public class BoltStateHandler implements TransactionHandler, Connector {
 
     private Driver getDriver(@Nonnull ConnectionConfig connectionConfig, @Nullable AuthToken authToken) {
         Config config = Config.build()
-                .withLogging(new ConsoleLogging(Level.OFF))
-                .withEncryptionLevel(connectionConfig.encryption()).toConfig();
+                              .withLogging(new ConsoleLogging(Level.OFF))
+                              .withEncryptionLevel(connectionConfig.encryption()).toConfig();
         return driverProvider.apply(connectionConfig.driverUrl(), authToken, config);
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
@@ -75,6 +75,22 @@ public class CypherShellTest {
     }
 
     @Test
+    public void verifyDelegationOfGetServerVersionMethod() throws CommandException {
+        CypherShell shell = new CypherShell(logger, mockedBoltStateHandler, mockedPrettyPrinter);
+
+        shell.getServerVersion();
+        verify(mockedBoltStateHandler).getServerVersion();
+    }
+
+    @Test
+    public void verifyDelegationOfIsTransactionOpenMethod() throws CommandException {
+        CypherShell shell = new CypherShell(logger, mockedBoltStateHandler, mockedPrettyPrinter);
+
+        shell.isTransactionOpen();
+        verify(mockedBoltStateHandler).isTransactionOpen();
+    }
+
+    @Test
     public void verifyDelegationOfTransactionMethods() throws CommandException {
         CypherShell shell = new CypherShell(logger, mockedBoltStateHandler, mockedPrettyPrinter);
 


### PR DESCRIPTION
Before, on all versions:

```
Connected to Neo4j at bolt://localhost:7687.
Type :help for a list of available commands or :exit to exit the shell.
Note that Cypher queries must end with a semicolon.
neo4j>
```

After, on 3.1.0-M09 and above:

```
Connected to Neo4j 3.1.0-M09 at bolt://localhost:7687.
Type :help for a list of available commands or :exit to exit the shell.
Note that Cypher queries must end with a semicolon.
neo4j>
```