### PR TITLE
Fixed lack of interactive detection on Windows

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/ShellRunner.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/ShellRunner.java
@@ -1,11 +1,17 @@
 package org.neo4j.shell;
 
-import org.neo4j.shell.cli.*;
+import org.neo4j.shell.cli.CliArgs;
+import org.neo4j.shell.cli.FileHistorian;
+import org.neo4j.shell.cli.InteractiveShellRunner;
+import org.neo4j.shell.cli.NonInteractiveShellRunner;
+import org.neo4j.shell.cli.StringShellRunner;
 import org.neo4j.shell.log.Logger;
 import org.neo4j.shell.parser.ShellStatementParser;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.IOException;
+import java.util.Optional;
 
 import static org.fusesource.jansi.internal.CLibrary.STDIN_FILENO;
 import static org.fusesource.jansi.internal.CLibrary.isatty;
@@ -19,7 +25,6 @@ public interface ShellRunner {
     int runUntilEnd();
 
     /**
-     *
      * @return an object which can provide the history of commands executed
      */
     @Nonnull
@@ -40,7 +45,7 @@ public interface ShellRunner {
                                       @Nonnull Logger logger) throws IOException {
         if (cliArgs.getCypher().isPresent()) {
             return new StringShellRunner(cliArgs, cypherShell, logger);
-        } else if (isInputInteractive()) {
+        } else if (shouldBeInteractive(cliArgs)) {
             return new InteractiveShellRunner(cypherShell, cypherShell, logger, new ShellStatementParser(),
                     System.in, FileHistorian.getDefaultHistoryFile());
         } else {
@@ -50,18 +55,35 @@ public interface ShellRunner {
     }
 
     /**
+     * @param cliArgs
+     * @return true if an interactive shellrunner should be used, false otherwise
+     */
+    static boolean shouldBeInteractive(@Nonnull CliArgs cliArgs) {
+        if (cliArgs.getNonInteractive()) {
+            return false;
+        }
+
+        return isInputInteractive(System.getProperty("os.name")).orElse(true);
+    }
+
+    /**
      * Checks if STDIN is a TTY. In case TTY checking is not possible (lack of libc), then the check falls back to
      * the built in Java {@link System#console()} which checks if EITHER STDIN or STDOUT has been redirected.
      *
-     * @return true if the shell reading from a TTY, false otherwise (e.g., we are reading from a file)
+     * @return true if the shell reading from a TTY, false otherwise (e.g., we are reading from a file). If on windows,
+     * no result is returned.
      */
-    static boolean isInputInteractive() {
+    static Optional<Boolean> isInputInteractive(@Nullable final String osName) {
+        if (osName != null && osName.toLowerCase().contains("windows")) {
+            // System.console is always null on windows
+            return Optional.empty();
+        }
         try {
-            return 1 == isatty(STDIN_FILENO);
+            return Optional.of(1 == isatty(STDIN_FILENO));
         } catch (NoClassDefFoundError e) {
             // system is not using libc (like Alpine Linux)
             // Fallback to checking stdin OR stdout
-            return System.console() != null;
+            return Optional.of(System.console() != null);
         }
     }
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgHelper.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgHelper.java
@@ -84,6 +84,8 @@ public class CliArgHelper {
 
         cliArgs.setDebugMode(ns.getBoolean("debug"));
 
+        cliArgs.setNonInteractive(ns.getBoolean("force-non-interactive"));
+
         return cliArgs;
     }
 
@@ -145,6 +147,11 @@ public class CliArgHelper {
         parser.addArgument("--debug")
                 .help("print additional debug information")
                 .action(new StoreTrueArgumentAction());
+
+        parser.addArgument("--non-interactive")
+                .help("force non-interactive mode, only useful if auto-detection fails (like on Windows)")
+                .dest("force-non-interactive")
+              .action(new StoreTrueArgumentAction());
 
         parser.addArgument("cypher")
                 .nargs("?")

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgs.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgs.java
@@ -14,6 +14,7 @@ public class CliArgs {
     private Optional<String> cypher = Optional.empty();
     private boolean encryption;
     private boolean debugMode;
+    private boolean nonInteractive = false;
 
     /**
      * Set the host to the primary value, or if null, the fallback value.
@@ -72,6 +73,13 @@ public class CliArgs {
     }
 
     /**
+     * Force the shell to use non-interactive mode. Only useful on systems where auto-detection fails, such as Windows.
+     */
+    public void setNonInteractive(boolean nonInteractive) {
+        this.nonInteractive = nonInteractive;
+    }
+
+    /**
      * Enable/disable debug mode
      */
     void setDebugMode(boolean enabled) {
@@ -119,5 +127,9 @@ public class CliArgs {
 
     public boolean getDebugMode() {
         return debugMode;
+    }
+
+    public boolean getNonInteractive() {
+        return nonInteractive;
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/ShellRunnerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/ShellRunnerTest.java
@@ -1,0 +1,52 @@
+package org.neo4j.shell;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.neo4j.shell.cli.CliArgs;
+import org.neo4j.shell.cli.InteractiveShellRunner;
+import org.neo4j.shell.cli.NonInteractiveShellRunner;
+import org.neo4j.shell.log.Logger;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+import static org.mockito.Mockito.mock;
+import static org.neo4j.shell.ShellRunner.getShellRunner;
+import static org.neo4j.shell.ShellRunner.isInputInteractive;
+
+public class ShellRunnerTest {
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void isInputInteractiveThrowsOnWindows() throws Exception {
+        assertFalse("No result should be returned on Windows",
+                isInputInteractive("Windows 7").isPresent());
+    }
+
+    @Test
+    public void isInputInteractiveDoesNotThrowOnNonWindows() throws Exception {
+        assertTrue(isInputInteractive(null).isPresent());
+        assertTrue(isInputInteractive("").isPresent());
+        assertTrue(isInputInteractive("Linux").isPresent());
+        assertTrue(isInputInteractive("BeOS").isPresent());
+    }
+
+    @Test
+    public void inputIsInteractiveByDefaultOnWindows() throws Exception {
+        assumeTrue(System.getProperty("os.name", "").toLowerCase().contains("windows"));
+        ShellRunner runner = getShellRunner(new CliArgs(), mock(CypherShell.class), mock(Logger.class));
+        assertTrue("Should be interactive shell runner by default on windows",
+                runner instanceof InteractiveShellRunner);
+    }
+
+    @Test
+    public void inputIsNonInteractiveIfForced() throws Exception {
+        CliArgs args = new CliArgs();
+        args.setNonInteractive(true);
+        ShellRunner runner = getShellRunner(args, mock(CypherShell.class), mock(Logger.class));
+        assertTrue("Should be non-interactive shell runner when forced",
+                runner instanceof NonInteractiveShellRunner);
+    }
+}

--- a/cypher-shell/src/test/java/org/neo4j/shell/cli/CliArgHelperTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/cli/CliArgHelperTest.java
@@ -27,6 +27,18 @@ public class CliArgHelperTest {
     }
 
     @Test
+    public void testForceNonInteractiveIsNotDefault() {
+        assertFalse("Force non-interactive should not be the default mode",
+                CliArgHelper.parse(asArray()).getNonInteractive());
+    }
+
+    @Test
+    public void testForceNonInteractiveIsParsed() {
+        assertTrue("Force non-interactive should have been parsed to true",
+                CliArgHelper.parse(asArray("--non-interactive")).getNonInteractive());
+    }
+
+    @Test
     public void testDebugIsNotDefault() {
         assertFalse("Debug should not be the default mode",
                 CliArgHelper.parse(asArray()).getDebugMode());

--- a/cypher-shell/src/test/java/org/neo4j/shell/cli/FileHistorianTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/cli/FileHistorianTest.java
@@ -17,6 +17,7 @@ import java.nio.file.Paths;
 import static java.lang.System.getProperty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.contains;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -46,11 +47,11 @@ public class FileHistorianTest {
     @Test
     public void noHistoryFileGivesMemoryHistory() throws Exception {
         Historian historian = FileHistorian.setupHistory(reader, logger,
-                new File("/temp/aasbzs/asfaz/asdfasvzx/asfdasdf/asdfasd"));
+                Paths.get("temp", "aasbzs", "asfaz").toFile());
 
         assertNotNull(historian);
 
-        verify(logger).printError("Could not load history file. Falling back to session-based history.\n" +
-                "Failed to create directory for history: /temp/aasbzs/asfaz/asdfasvzx/asfdasdf");
+        verify(logger).printError(contains("Could not load history file. Falling back to session-based history.\n" +
+                "Failed to create directory for history"));
     }
 }


### PR DESCRIPTION
Updated help text follows

```text
usage: cypher-shell [-h] [-a ADDRESS] [-u USERNAME] [-p PASSWORD]
                    [--encryption {true,false}] [--format {verbose,plain}]
                    [--debug] [--non-interactive] [--fail-fast |
                    --fail-at-end] [cypher]

A command line shell where  you  can  execute  Cypher against an instance of
Neo4j

positional arguments:
  cypher                 an optional string of  cypher  to  execute and then
                         exit

optional arguments:
  -h, --help             show this help message and exit
  --fail-fast            exit  and  report  failure   on  first  error  when
                         reading from file (this is the default behavior)
  --fail-at-end          exit and  report  failures  at  end  of  input when
                         reading from file
  --format {verbose,plain}
                         desired output  format,  verbose(default)  displays
                         statistics,  plain  only  displays  data  (default:
                         verbose)
  --debug                print additional debug information (default: false)
  --non-interactive      force non-interactive mode,  only  useful  if auto-
                         detection fails (like on Windows) (default: false)

connection arguments:
  -a ADDRESS, --address ADDRESS
                         address and port to connect to (default: localhost:
                         7687)
  -u USERNAME, --username USERNAME
                         username to  connect  as.  Can  also  be  specified
                         using    environment     variable    NEO4J_USERNAME
                         (default: )
  -p PASSWORD, --password PASSWORD
                         password to connect  with.  Can  also  be specified
                         using    environment     variable    NEO4J_PASSWORD
                         (default: )
  --encryption {true,false}
                         whether  the   connection   to   Neo4j   should  be
                         encrypted;  must   be   consistent   with   Neo4j's
                         configuration (default: true)

```

changelog: Fixed lack of interactive detection on Windows

- Now always uses interactive mode on Windows by default
- If non-interactive mode is desired (for scripting) then a new flag `--non-interactive` has been added