### PR TITLE
support for colon form of :param command.

### DIFF
--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellIntegrationTest.java
@@ -178,8 +178,5 @@ public class CypherShellIntegrationTest {
         List<String> queryResult = captor.getAllValues();
         assertThat(queryResult.get(0), is("{ bob }\n" + randomLong));
         assertEquals(randomLong, shell.getAll().get("bob"));
-
-        shell.remove("bob");
-        assertTrue(shell.getAll().isEmpty());
     }
 }

--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellIntegrationTest.java
@@ -162,7 +162,7 @@ public class CypherShellIntegrationTest {
     }
 
     @Test
-    public void setAndListVariables() throws CommandException {
+    public void paramsAndListVariables() throws CommandException {
         assertTrue(shell.getAll().isEmpty());
 
         long randomLong = System.currentTimeMillis();

--- a/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
@@ -173,12 +173,6 @@ public class CypherShell implements StatementExecuter, Connector, TransactionHan
         return queryParams;
     }
 
-    @Override
-    @Nonnull
-    public Optional remove(@Nonnull String name) {
-        return Optional.ofNullable(queryParams.remove(name));
-    }
-
     public void setCommandHelper(@Nonnull CommandHelper commandHelper) {
         this.commandHelper = commandHelper;
     }

--- a/cypher-shell/src/main/java/org/neo4j/shell/VariableHolder.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/VariableHolder.java
@@ -22,10 +22,4 @@ public interface VariableHolder {
      */
     @Nonnull
     Map<String, Object> getAll();
-
-    /**
-     *
-     * @param name of variable to delete
-     */
-    Optional remove(@Nonnull String name);
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/commands/Param.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/commands/Param.java
@@ -16,7 +16,7 @@ import java.util.regex.Pattern;
  */
 public class Param implements Command {
     // Match arguments such as "(key) (value with possible spaces)" where key and value are any strings
-    private static final Pattern argPattern = Pattern.compile("^\\s*(?<key>[^\\s]+)\\s+(?<value>.+)$");
+    private static final Pattern argPattern = Pattern.compile("^\\s*(?<key>.+?):?\\s+(?<value>.+)$");
     public static final String COMMAND_NAME = ":param";
     private final VariableHolder variableHolder;
 

--- a/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
@@ -144,9 +144,6 @@ public class CypherShellTest {
         Optional result = offlineTestShell.set("bob", "99");
         assertEquals("99", result.get());
         assertEquals("99", offlineTestShell.getAll().get("bob"));
-
-        offlineTestShell.remove("bob");
-        assertTrue(offlineTestShell.getAll().isEmpty());
     }
 
     @Test
@@ -230,13 +227,6 @@ public class CypherShellTest {
         if (!(shellRunner instanceof StringShellRunner)) {
             fail("Expected a different runner than: " + shellRunner.getClass().getSimpleName());
         }
-    }
-
-    @Test
-    public void unsetAlreadyClearedValue() throws CommandException {
-        // when
-        // then
-        assertFalse("Expected param to be unset", offlineTestShell.remove("unknown var").isPresent());
     }
 
     @Test

--- a/cypher-shell/src/test/java/org/neo4j/shell/commands/ParamTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/commands/ParamTest.java
@@ -51,9 +51,31 @@ public class ParamTest {
     }
 
     @Test
+    public void setValueWithSpecialCharacters() throws CommandException {
+        cmd.execute("bob#   9");
+
+        verify(mockShell).set("bob#", "9");
+    }
+
+    @Test
     public void shouldNotSplitOnSpace() throws CommandException {
         cmd.execute("bob 'one two'");
         verify(mockShell).set("bob", "'one two'");
+    }
+
+    @Test
+    public void shouldAcceptColonFormOfParams() throws CommandException {
+        cmd.execute("bob: one");
+        verify(mockShell).set("bob", "one");
+    }
+
+    @Test
+    public void shouldAcceptForTwoColonsFormOfParams() throws CommandException {
+        cmd.execute("bob:: one");
+        verify(mockShell).set("bob:", "one");
+
+        cmd.execute("t:om two");
+        verify(mockShell).set("t:om", "two");
     }
 
     @Test


### PR DESCRIPTION
:param should accept both of these syntaxes (with and without a colon).

```
neo4j> :param foo 1
neo4j> return {foo};
{foo}
1
neo4j> :param bar: 2
neo4j> return {bar};
{bar}
2
```

For special scenarios such as parameter name containing special characters. We let the server handle it:

```
neo4j> :param g:: 10
Invalid input ':': expected an identifier character, ',', ORDER, SKIP, LIMIT, LOAD CSV, START, MATCH, UNWIND, MERGE, CREATE, SET, DELETE, REMOVE, FOREACH, WITH, CALL, RETURN, UNION, ';' or end of input (line 1, column 15 (offset: 14))
"RETURN 10 as g:"
               ^
neo4j> :param g:h 10
Invalid input ':': expected an identifier character, ',', ORDER, SKIP, LIMIT, LOAD CSV, START, MATCH, UNWIND, MERGE, CREATE, SET, DELETE, REMOVE, FOREACH, WITH, CALL, RETURN, UNION, ';' or end of input (line 1, column 15 (offset: 14))
"RETURN 10 as g:h"
```