### PR TITLE
rescape backticks

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/CypherVariablesFormatter.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/CypherVariablesFormatter.java
@@ -1,0 +1,20 @@
+package org.neo4j.shell.prettyprint;
+
+import javax.annotation.Nonnull;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class CypherVariablesFormatter {
+    private static final String BACKTICK = "`";
+    private static final Pattern ALPHA_NUMERIC = Pattern.compile("^[\\p{L}_][\\p{L}0-9_]*");
+
+    @Nonnull
+    public static String escape(@Nonnull String string) {
+        Matcher alphaNumericMatcher = ALPHA_NUMERIC.matcher(string);
+        if (!alphaNumericMatcher.matches()) {
+            String reEscapeBackTicks = string.replaceAll(BACKTICK, BACKTICK + BACKTICK);
+            return BACKTICK + reEscapeBackTicks + BACKTICK;
+        }
+        return string;
+    }
+}

--- a/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/PrettyPrinter.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/PrettyPrinter.java
@@ -14,22 +14,19 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
+import static org.neo4j.shell.prettyprint.CypherVariablesFormatter.escape;
 
 /**
  * Print the result from neo4j in a intelligible fashion.
  */
 public class PrettyPrinter {
     private static final String COMMA_SEPARATOR = ", ";
-
     private static final String COLON_SEPARATOR = ": ";
     private static final String COLON = ":";
     private static final String SPACE = " ";
-    public static final String BACKTICK = "`";
-    private static final Pattern ALPHA_NUMERIC = Pattern.compile("^[\\p{L}_][\\p{L}0-9_]*");
-    private StatisticsCollector statisticsCollector;
+    private final StatisticsCollector statisticsCollector;
 
     public PrettyPrinter(@Nonnull Format format) {
         this.statisticsCollector = new StatisticsCollector(format);
@@ -121,14 +118,14 @@ public class PrettyPrinter {
         StringBuilder sb = new StringBuilder("{");
         sb.append(
                 map.entrySet().stream()
-                        .map(e -> escapeIfNeeded(e.getKey()) + COLON_SEPARATOR + e.getValue())
+                        .map(e -> escape(e.getKey()) + COLON_SEPARATOR + e.getValue())
                         .collect(Collectors.joining(COMMA_SEPARATOR)));
         return sb.append("}").toString();
     }
 
     private String relationshipAsString(Relationship relationship) {
         List<String> relationshipAsString = new ArrayList<>();
-        relationshipAsString.add(COLON + escapeIfNeeded(relationship.type()));
+        relationshipAsString.add(COLON + escape(relationship.type()));
         relationshipAsString.add(mapAsString(relationship.asMap(this::formatValue)));
 
         return "[" + joinWithSpace(relationshipAsString) + "]";
@@ -144,7 +141,7 @@ public class PrettyPrinter {
 
     private String collectNodeLabels(@Nonnull Node node) {
         StringBuilder sb = new StringBuilder();
-        node.labels().forEach(label -> sb.append(COLON).append(escapeIfNeeded(label)));
+        node.labels().forEach(label -> sb.append(COLON).append(escape(label)));
         return sb.toString();
     }
 
@@ -155,13 +152,4 @@ public class PrettyPrinter {
     private static boolean isNotBlank(String string) {
         return string != null && !string.trim().isEmpty();
     }
-
-    private String escapeIfNeeded(String string) {
-        Matcher matcher = ALPHA_NUMERIC.matcher(string);
-        if (!matcher.matches()) {
-            return BACKTICK + string + BACKTICK;
-        }
-        return string;
-    }
-
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/CypherVariablesFormatterTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/CypherVariablesFormatterTest.java
@@ -1,0 +1,22 @@
+package org.neo4j.shell.prettyprint;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class CypherVariablesFormatterTest {
+
+    private final CypherVariablesFormatter formatter = new CypherVariablesFormatter();
+
+    @Test
+    public void formatNonAlphanumericStrings() throws Exception {
+        assertThat(formatter.escape("abc12_A"), is("abc12_A"));
+        assertThat(formatter.escape("\0"), is("`\0`"));
+        assertThat(formatter.escape("\n"), is("`\n`"));
+        assertThat(formatter.escape("comma, separated"), is("`comma, separated`"));
+        assertThat(formatter.escape("escaped content `back ticks #"), is("`escaped content ``back ticks #`"));
+        assertThat(formatter.escape("escaped content two `back `ticks"),
+                is("`escaped content two ``back ``ticks`"));
+    }
+}

--- a/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/PrettyPrinterTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/PrettyPrinterTest.java
@@ -25,6 +25,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class PrettyPrinterTest {
+
+    private final PrettyPrinter plainPrinter = new PrettyPrinter(Format.PLAIN);
+    private final PrettyPrinter verbosePrinter = new PrettyPrinter(Format.VERBOSE);
+
     @Test
     public void returnStatisticsForEmptyRecords() throws Exception {
         // given
@@ -39,7 +43,7 @@ public class PrettyPrinterTest {
         when(summaryCounters.nodesCreated()).thenReturn(10);
 
         // when
-        String actual = new PrettyPrinter(Format.VERBOSE).format(result);
+        String actual = verbosePrinter.format(result);
 
         // then
         assertThat(actual, is("Added 10 nodes, Added 1 labels"));
@@ -69,7 +73,7 @@ public class PrettyPrinterTest {
         when(result.getRecords()).thenReturn(asList(record1, record2));
 
         // when
-        String actual = new PrettyPrinter(Format.PLAIN).format(result);
+        String actual = plainPrinter.format(result);
 
         // then
         assertThat(actual, is("col1, col2\n[val1_1, val1_2], [val2_1]\n[val2_1]"));
@@ -100,7 +104,7 @@ public class PrettyPrinterTest {
         when(result.getRecords()).thenReturn(asList(record));
 
         // when
-        String actual = new PrettyPrinter(Format.PLAIN).format(result);
+        String actual = plainPrinter.format(result);
 
         // then
         assertThat(actual, is("col1, col2\n" +
@@ -132,7 +136,7 @@ public class PrettyPrinterTest {
         when(result.getRecords()).thenReturn(asList(record));
 
         // when
-        String actual = new PrettyPrinter(Format.PLAIN).format(result);
+        String actual = plainPrinter.format(result);
 
         // then
         assertThat(actual, is("rel\n[:RELATIONSHIP_TYPE {prop2: prop2_value, prop1: prop1_value}]"));
@@ -167,7 +171,7 @@ public class PrettyPrinterTest {
 
 
         when(nodeVal.asNode()).thenReturn(node);
-        when(node.labels()).thenReturn(asList("label 1", "label2"));
+        when(node.labels()).thenReturn(asList("label `1", "label2"));
         when(node.asMap(anyObject())).thenReturn(unmodifiableMap(nodeProp));
 
 
@@ -177,11 +181,11 @@ public class PrettyPrinterTest {
         when(result.getRecords()).thenReturn(asList(record));
 
         // when
-        String actual = new PrettyPrinter(Format.PLAIN).format(result);
+        String actual = plainPrinter.format(result);
 
         // then
         assertThat(actual, is("rel, node\n[:`RELATIONSHIP,TYPE` {prop2: prop2_value, prop1: \"prop1, value\"}], " +
-                "(:`label 1`:label2 {prop1: \"prop1:value\", `1prop2`: \"\", ä: not-escaped})"));
+                "(:`label ``1`:label2 {prop1: \"prop1:value\", `1prop2`: \"\", ä: not-escaped})"));
     }
 
     @Test
@@ -238,7 +242,7 @@ public class PrettyPrinterTest {
         when(result.getRecords()).thenReturn(asList(record));
 
         // when
-        String actual = new PrettyPrinter(Format.PLAIN).format(result);
+        String actual = plainPrinter.format(result);
 
         // then
         assertThat(actual, is("path\n" +
@@ -285,7 +289,7 @@ public class PrettyPrinterTest {
         when(result.getRecords()).thenReturn(asList(record));
 
         // when
-        String actual = new PrettyPrinter(Format.PLAIN).format(result);
+        String actual = plainPrinter.format(result);
 
         // then
         assertThat(actual, is("path\n(:start)-[:RELATIONSHIP_TYPE]->(:end)"));
@@ -348,7 +352,7 @@ public class PrettyPrinterTest {
         when(result.getRecords()).thenReturn(asList(record));
 
         // when
-        String actual = new PrettyPrinter(Format.PLAIN).format(result);
+        String actual = plainPrinter.format(result);
 
         // then
         assertThat(actual, is("path\n" +


### PR DESCRIPTION
Rescape backticks during pretty printing.

```
neo4j> create (n:`Label with ``space`) return n;
n
(:`Label with ``space`)
Added 1 nodes, Added 1 labels
neo4j>
```