### PR TITLE
Add version to Cypher-Shell

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,9 @@ subprojects {
 }
 
 ext {
+    // Only match tags starting with a number to avoid neo4j-xxx changelog tags
+    gitVersion = 'git describe --tags --match [0-9]*'.execute([], project.rootDir).text.trim()
+
     argparse4jVersion = '0.7.0'
     junitVersion = '4.12'
     neo4jJavaVersion = '1.1.0-M05'

--- a/cypher-shell/build.gradle
+++ b/cypher-shell/build.gradle
@@ -1,3 +1,18 @@
+version = gitVersion
+
+task generateBuildProperties {
+  def outputDir = file("${buildDir}/resources/main")
+  doFirst {
+    outputDir.exists() || outputDir.mkdirs()
+    def propFile = new File(outputDir, "build.properties")
+    def props = new Properties()
+    props.setProperty("version", gitVersion)
+    props.store(propFile.newWriter(), null)
+  }
+}
+
+processResources.dependsOn generateBuildProperties
+
 jar {
   manifest {
     attributes 'Main-Class': 'org.neo4j.shell.Main'

--- a/cypher-shell/src/main/java/org/neo4j/shell/Main.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/Main.java
@@ -2,6 +2,7 @@ package org.neo4j.shell;
 
 import jline.console.ConsoleReader;
 import org.neo4j.driver.v1.exceptions.ClientException;
+import org.neo4j.shell.build.Build;
 import org.neo4j.shell.cli.CliArgHelper;
 import org.neo4j.shell.cli.CliArgs;
 import org.neo4j.shell.commands.CommandHelper;
@@ -75,6 +76,11 @@ public class Main {
     }
 
     void startShell(@Nonnull CliArgs cliArgs) {
+        if (cliArgs.getVersion()) {
+            out.println("Cypher-Shell " + Build.version());
+            return;
+        }
+
         ConnectionConfig connectionConfig = new ConnectionConfig(cliArgs.getHost(),
                 cliArgs.getPort(),
                 cliArgs.getUsername(),

--- a/cypher-shell/src/main/java/org/neo4j/shell/build/Build.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/build/Build.java
@@ -23,7 +23,8 @@ public class Build {
             props = new Properties();
             try (InputStream stream = Build.class.getClassLoader().getResourceAsStream("build.properties")) {
                 props.load(stream);
-            } catch (IOException ignored) {
+            } catch (IOException e) {
+                System.err.println("Could not read build properties: " + e.getMessage());
             }
         }
 

--- a/cypher-shell/src/main/java/org/neo4j/shell/build/Build.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/build/Build.java
@@ -1,0 +1,40 @@
+package org.neo4j.shell.build;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+/**
+ * This class provides access to build time variables
+ */
+public class Build {
+
+    private static Properties props = null;
+
+    /**
+     * Reads the build generated properties file the first time it is called.
+     *
+     * @return build properties
+     */
+    @Nonnull
+    private static Properties getProperties() {
+        if (props == null) {
+            props = new Properties();
+            try (InputStream stream = Build.class.getClassLoader().getResourceAsStream("build.properties")) {
+                props.load(stream);
+            } catch (IOException ignored) {
+            }
+        }
+
+        return props;
+    }
+
+    /**
+     * @return the revision of the source code, or "dev" if no properties file could be read.
+     */
+    @Nonnull
+    public static String version() {
+        return getProperties().getProperty("version", "dev");
+    }
+}

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgHelper.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgHelper.java
@@ -86,6 +86,8 @@ public class CliArgHelper {
 
         cliArgs.setNonInteractive(ns.getBoolean("force-non-interactive"));
 
+        cliArgs.setVersion(ns.getBoolean("version"));
+
         return cliArgs;
     }
 
@@ -152,6 +154,10 @@ public class CliArgHelper {
                 .help("force non-interactive mode, only useful if auto-detection fails (like on Windows)")
                 .dest("force-non-interactive")
               .action(new StoreTrueArgumentAction());
+
+        parser.addArgument("-v", "--version")
+                .help("print version of cypher-shell and exit")
+                .action(new StoreTrueArgumentAction());
 
         parser.addArgument("cypher")
                 .nargs("?")

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgs.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgs.java
@@ -15,6 +15,7 @@ public class CliArgs {
     private boolean encryption;
     private boolean debugMode;
     private boolean nonInteractive = false;
+    private boolean version = false;
 
     /**
      * Set the host to the primary value, or if null, the fallback value.
@@ -131,5 +132,13 @@ public class CliArgs {
 
     public boolean getNonInteractive() {
         return nonInteractive;
+    }
+
+    public boolean getVersion() {
+        return version;
+    }
+
+    public void setVersion(boolean version) {
+        this.version = version;
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/MainTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/MainTest.java
@@ -4,7 +4,9 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
 import org.neo4j.driver.v1.exceptions.ClientException;
+import org.neo4j.shell.cli.CliArgs;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -13,6 +15,7 @@ import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -165,6 +168,22 @@ public class MainTest {
             assertEquals(authException.code(), e.code());
             verify(shell, times(1)).connect(connectionConfig);
         }
+    }
+
+    @Test
+    public void printsVersionAndExits() throws Exception {
+        CliArgs args = new CliArgs();
+        args.setVersion(true);
+
+        PrintStream printStream = mock(PrintStream.class);
+
+        Main main = new Main(System.in, printStream);
+        main.startShell(args);
+
+        ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
+
+        verify(printStream).println(argument.capture());
+        assertTrue(argument.getValue().matches("Cypher-Shell \\d+\\.\\d+\\.\\d+.*"));
     }
 
     @Test

--- a/cypher-shell/src/test/java/org/neo4j/shell/build/BuildTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/build/BuildTest.java
@@ -1,0 +1,13 @@
+package org.neo4j.shell.build;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+
+public class BuildTest {
+    @Test
+    public void versionIsNumeric() throws Exception {
+        assertTrue(Build.version().matches("\\d+\\.\\d+\\.\\d+.*"));
+    }
+}


### PR DESCRIPTION
Now the following invocation is possible (version is calculated based on you checked out version)

```
$ ./cypher-shell --version
Cypher-Shell 1.0.0-RC1-2-g6f59496
```

New help text:

```
$ ./cypher-shell --help
usage: cypher-shell [-h] [-a ADDRESS] [-u USERNAME] [-p PASSWORD] [--encryption {true,false}] [--format {verbose,plain}]
                    [--debug] [--non-interactive] [-v] [--fail-fast | --fail-at-end] [cypher]

A command line shell where you can execute Cypher against an instance of Neo4j

positional arguments:
  cypher                 an optional string of cypher to execute and then exit

optional arguments:
  -h, --help             show this help message and exit
  --fail-fast            exit and report failure on first error when reading from file (this is the default behavior)
  --fail-at-end          exit and report failures at end of input when reading from file
  --format {verbose,plain}
                         desired output format, verbose(default) displays statistics,  plain only displays data (default:
                         verbose)
  --debug                print additional debug information (default: false)
  --non-interactive      force non-interactive mode, only  useful  if  auto-detection  fails  (like on Windows) (default:
                         false)
  -v, --version          print version of cypher-shell and exit (default: false)

connection arguments:
  -a ADDRESS, --address ADDRESS
                         address and port to connect to (default: localhost:7687)
  -u USERNAME, --username USERNAME
                         username to  connect  as.  Can  also  be  specified  using  environment  variable NEO4J_USERNAME
                         (default: )
  -p PASSWORD, --password PASSWORD
                         password to connect  with.  Can  also  be  specified  using  environment variable NEO4J_PASSWORD
                         (default: )
  --encryption {true,false}
                         whether  the  connection  to  Neo4j  should  be  encrypted;  must  be  consistent  with  Neo4j's
                         configuration (default: true)
```