### PR TITLE
Escaped param

### DIFF
--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellIntegrationTest.java
@@ -179,4 +179,23 @@ public class CypherShellIntegrationTest {
         assertThat(queryResult.get(0), is("{ bob }\n" + randomLong));
         assertEquals(randomLong, shell.getAll().get("bob"));
     }
+
+    @Test
+    public void paramsAndListVariablesWithSpecialCharacters() throws CommandException {
+        assertTrue(shell.getAll().isEmpty());
+
+        long randomLong = System.currentTimeMillis();
+        Optional result = shell.set("`bob`", String.valueOf(randomLong));
+        assertTrue(result.isPresent());
+        assertEquals(randomLong, result.get());
+
+        shell.execute("RETURN { `bob` }");
+
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(logger).printOut(captor.capture());
+
+        List<String> queryResult = captor.getAllValues();
+        assertThat(queryResult.get(0), is("{ `bob` }\n" + randomLong));
+        assertEquals(randomLong, shell.getAll().get("bob"));
+    }
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
@@ -7,6 +7,7 @@ import org.neo4j.shell.exception.CommandException;
 import org.neo4j.shell.exception.ExitException;
 import org.neo4j.shell.log.AnsiFormattedText;
 import org.neo4j.shell.log.Logger;
+import org.neo4j.shell.prettyprint.CypherVariablesFormatter;
 import org.neo4j.shell.prettyprint.PrettyPrinter;
 import org.neo4j.shell.state.BoltResult;
 import org.neo4j.shell.state.BoltStateHandler;
@@ -153,19 +154,10 @@ public class CypherShell implements StatementExecuter, Connector, TransactionHan
     @Nonnull
     public Optional set(@Nonnull String name, @Nonnull String valueString) throws CommandException {
         final BoltResult result = setParamsAndValidate(name, valueString);
-        final Object value;
-        if (name.startsWith("`")) {
-            String substring = name.substring(1, name.length() - 1);
-            String updatedName = substring.replace("``", "`");
-            value = result.getRecords().get(0).get(updatedName).asObject();
-            queryParams.put(updatedName, value);
-            return Optional.ofNullable(value);
-
-        } else {
-            value = result.getRecords().get(0).get(name).asObject();
-            queryParams.put(name, value);
-            return Optional.ofNullable(value);
-        }
+        String parameterName = CypherVariablesFormatter.unescapedCypherVariable(name);
+        final Object value = result.getRecords().get(0).get(parameterName).asObject();
+        queryParams.put(parameterName, value);
+        return Optional.ofNullable(value);
     }
 
     private BoltResult setParamsAndValidate(@Nonnull String name, @Nonnull String valueString) throws CommandException {

--- a/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
@@ -153,9 +153,19 @@ public class CypherShell implements StatementExecuter, Connector, TransactionHan
     @Nonnull
     public Optional set(@Nonnull String name, @Nonnull String valueString) throws CommandException {
         final BoltResult result = setParamsAndValidate(name, valueString);
-        final Object value = result.getRecords().get(0).get(name).asObject();
-        queryParams.put(name, value);
-        return Optional.ofNullable(value);
+        final Object value;
+        if (name.startsWith("`")) {
+            String substring = name.substring(1, name.length() - 1);
+            String updatedName = substring.replace("``", "`");
+            value = result.getRecords().get(0).get(updatedName).asObject();
+            queryParams.put(updatedName, value);
+            return Optional.ofNullable(value);
+
+        } else {
+            value = result.getRecords().get(0).get(name).asObject();
+            queryParams.put(name, value);
+            return Optional.ofNullable(value);
+        }
     }
 
     private BoltResult setParamsAndValidate(@Nonnull String name, @Nonnull String valueString) throws CommandException {

--- a/cypher-shell/src/main/java/org/neo4j/shell/commands/CommandHelper.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/commands/CommandHelper.java
@@ -1,6 +1,5 @@
 package org.neo4j.shell.commands;
 
-import org.neo4j.shell.Connector;
 import org.neo4j.shell.CypherShell;
 import org.neo4j.shell.Historian;
 import org.neo4j.shell.TransactionHandler;
@@ -23,10 +22,10 @@ public class CommandHelper {
     private final TreeMap<String, Command> commands = new TreeMap<>();
 
     public CommandHelper(Logger logger, Historian historian, CypherShell cypherShell) {
-        registerAllCommands(logger, historian, cypherShell, cypherShell, cypherShell);
+        registerAllCommands(logger, historian, cypherShell, cypherShell);
     }
 
-    private void registerAllCommands(Logger logger, Historian historian, Connector connector,
+    private void registerAllCommands(Logger logger, Historian historian,
                                      TransactionHandler transactionHandler, VariableHolder variableHolder) {
         registerCommand(new Exit(logger));
         registerCommand(new Help(logger, this));

--- a/cypher-shell/src/main/java/org/neo4j/shell/commands/Param.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/commands/Param.java
@@ -59,25 +59,20 @@ public class Param implements Command {
     @Override
     public void execute(@Nonnull final String argString) throws CommandException {
         Matcher alphanumericMatcher = argPattern.matcher(argString);
-
-        if (!alphanumericMatcher.matches()) {
-            if (argString.trim().startsWith("`")) {
-                Matcher matcher = backtickPattern.matcher(argString);
-                if (matcher.matches() && matcher.group("key").length() > 2) {
-                    variableHolder.set(matcher.group("key"), matcher.group("value"));
-                    return;
-                } else {
-                    throwError();
-                }
-            } else {
-                throwError();
-            }
+        if (alphanumericMatcher.matches()) {
+            variableHolder.set(alphanumericMatcher.group("key"), alphanumericMatcher.group("value"));
+        } else {
+            checkForBackticks(argString);
         }
-        variableHolder.set(alphanumericMatcher.group("key"), alphanumericMatcher.group("value"));
     }
 
-    private void throwError() throws CommandException {
-        throw new CommandException(AnsiFormattedText.from("Incorrect number of arguments.\nusage: ")
-                .bold().append(COMMAND_NAME).boldOff().append(" ").append(getUsage()));
+    private void checkForBackticks(@Nonnull String argString) throws CommandException {
+        Matcher matcher = backtickPattern.matcher(argString);
+        if (argString.trim().startsWith("`") && matcher.matches() && matcher.group("key").length() > 2) {
+            variableHolder.set(matcher.group("key"), matcher.group("value"));
+        } else {
+            throw new CommandException(AnsiFormattedText.from("Incorrect number of arguments.\nusage: ")
+                    .bold().append(COMMAND_NAME).boldOff().append(" ").append(getUsage()));
+        }
     }
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/CypherVariablesFormatter.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/CypherVariablesFormatter.java
@@ -17,4 +17,15 @@ public class CypherVariablesFormatter {
         }
         return string;
     }
+
+    @Nonnull
+    public static String unescapedCypherVariable(@Nonnull String string) {
+        Matcher alphaNumericMatcher = ALPHA_NUMERIC.matcher(string);
+        if (!alphaNumericMatcher.matches()) {
+            String substring = string.substring(1, string.length() - 1);
+            return substring.replace(BACKTICK + BACKTICK, BACKTICK);
+        } else {
+            return string;
+        }
+    }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
@@ -129,7 +129,7 @@ public class CypherShellTest {
     }
 
     @Test
-    public void setParamShouldAddParamAndValue() throws CommandException {
+    public void setParamShouldAddParamWithSpecialCharactersAndValue() throws CommandException {
         Value value = mock(Value.class);
         Record recordMock = mock(Record.class);
         BoltResult boltResult = mock(BoltResult.class);
@@ -147,14 +147,14 @@ public class CypherShellTest {
     }
 
     @Test
-    public void setParamShouldAddParamWithSpecialCharactersAndValue() throws CommandException {
+    public void setParamShouldAddParam() throws CommandException {
         Value value = mock(Value.class);
         Record recordMock = mock(Record.class);
         BoltResult boltResult = mock(BoltResult.class);
 
         when(mockedBoltStateHandler.runCypher(anyString(), anyMap())).thenReturn(Optional.of(boltResult));
         when(boltResult.getRecords()).thenReturn(Arrays.asList(recordMock));
-        when(recordMock.get("bo`b")).thenReturn(value);
+        when(recordMock.get("bob")).thenReturn(value);
         when(value.asObject()).thenReturn("99");
 
         assertTrue(offlineTestShell.getAll().isEmpty());

--- a/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
@@ -129,19 +129,37 @@ public class CypherShellTest {
     }
 
     @Test
-    public void verifyVariableMethods() throws CommandException {
+    public void setParamShouldAddParamAndValue() throws CommandException {
         Value value = mock(Value.class);
         Record recordMock = mock(Record.class);
         BoltResult boltResult = mock(BoltResult.class);
 
         when(mockedBoltStateHandler.runCypher(anyString(), anyMap())).thenReturn(Optional.of(boltResult));
         when(boltResult.getRecords()).thenReturn(Arrays.asList(recordMock));
-        when(recordMock.get("bob")).thenReturn(value);
+        when(recordMock.get("bo`b")).thenReturn(value);
         when(value.asObject()).thenReturn("99");
 
         assertTrue(offlineTestShell.getAll().isEmpty());
 
-        Optional result = offlineTestShell.set("bob", "99");
+        Optional result = offlineTestShell.set("`bo``b`", "99");
+        assertEquals("99", result.get());
+        assertEquals("99", offlineTestShell.getAll().get("bo`b"));
+    }
+
+    @Test
+    public void setParamShouldAddParamWithSpecialCharactersAndValue() throws CommandException {
+        Value value = mock(Value.class);
+        Record recordMock = mock(Record.class);
+        BoltResult boltResult = mock(BoltResult.class);
+
+        when(mockedBoltStateHandler.runCypher(anyString(), anyMap())).thenReturn(Optional.of(boltResult));
+        when(boltResult.getRecords()).thenReturn(Arrays.asList(recordMock));
+        when(recordMock.get("bo`b")).thenReturn(value);
+        when(value.asObject()).thenReturn("99");
+
+        assertTrue(offlineTestShell.getAll().isEmpty());
+
+        Optional result = offlineTestShell.set("`bob`", "99");
         assertEquals("99", result.get());
         assertEquals("99", offlineTestShell.getAll().get("bob"));
     }

--- a/cypher-shell/src/test/java/org/neo4j/shell/commands/ParamTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/commands/ParamTest.java
@@ -51,16 +51,76 @@ public class ParamTest {
     }
 
     @Test
+    public void setSpecialCharacterParameter() throws CommandException {
+        cmd.execute("bØb   9");
+
+        verify(mockShell).set("bØb", "9");
+    }
+
+    @Test
     public void setValueWithSpecialCharacters() throws CommandException {
+        cmd.execute("`bob#`   9");
+
+        verify(mockShell).set("`bob#`", "9");
+    }
+
+    @Test
+    public void setValueWithOddNoOfBackTicks() throws CommandException {
+        cmd.execute(" `bo `` sömething ```   9");
+
+        verify(mockShell).set("`bo `` sömething ```", "9");
+    }
+
+    @Test
+    public void shouldFailForVariablesWithoutEscaping() throws CommandException {
+        thrown.expect(CommandException.class);
+        thrown.expectMessage(containsString("Incorrect number of arguments"));
+
         cmd.execute("bob#   9");
 
-        verify(mockShell).set("bob#", "9");
+        fail("Expected error");
+    }
+
+    @Test
+    public void shouldFailForEmptyVariables() throws CommandException {
+        thrown.expect(CommandException.class);
+        thrown.expectMessage(containsString("Incorrect number of arguments"));
+
+        cmd.execute("``   9");
+
+        fail("Expected error");
+    }
+
+    @Test
+    public void shouldFailForInvalidVariables() throws CommandException {
+        thrown.expect(CommandException.class);
+        thrown.expectMessage(containsString("Incorrect number of arguments"));
+
+        cmd.execute("`   9");
+
+        fail("Expected error");
+    }
+
+    @Test
+    public void shouldFailForVariablesWithoutText() throws CommandException {
+        thrown.expect(CommandException.class);
+        thrown.expectMessage(containsString("Incorrect number of arguments"));
+
+        cmd.execute("```   9");
+
+        fail("Expected error");
     }
 
     @Test
     public void shouldNotSplitOnSpace() throws CommandException {
         cmd.execute("bob 'one two'");
         verify(mockShell).set("bob", "'one two'");
+    }
+
+    @Test
+    public void shouldAcceptUnicodeAlphaNumeric() throws CommandException {
+        cmd.execute("böb 'one two'");
+        verify(mockShell).set("böb", "'one two'");
     }
 
     @Test
@@ -71,11 +131,11 @@ public class ParamTest {
 
     @Test
     public void shouldAcceptForTwoColonsFormOfParams() throws CommandException {
-        cmd.execute("bob:: one");
-        verify(mockShell).set("bob:", "one");
+        cmd.execute("`bob:`: one");
+        verify(mockShell).set("`bob:`", "one");
 
-        cmd.execute("t:om two");
-        verify(mockShell).set("t:om", "two");
+        cmd.execute("`t:om` two");
+        verify(mockShell).set("`t:om`", "two");
     }
 
     @Test

--- a/cypher-shell/src/test/java/org/neo4j/shell/commands/ParamsTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/commands/ParamsTest.java
@@ -86,6 +86,30 @@ public class ParamsTest {
     }
 
     @Test
+    public void runCommandWithArgWithExtraSpace() throws CommandException {
+        // given
+        vars.put("var", 9);
+        vars.put("param", 9999);
+        // when
+        cmd.execute(" var");
+        // then
+        verify(logger).printOut("var: 9");
+        verifyNoMoreInteractions(logger);
+    }
+
+    @Test
+    public void runCommandWithArgWithBackticks() throws CommandException {
+        // given
+        vars.put("var", 9);
+        vars.put("param", 9999);
+        // when
+        cmd.execute("`var`");
+        // then
+        verify(logger).printOut("var: 9");
+        verifyNoMoreInteractions(logger);
+    }
+
+    @Test
     public void runCommandWithUnknownArg() throws CommandException {
         // then
         thrown.expect(CommandException.class);

--- a/cypher-shell/src/test/java/org/neo4j/shell/commands/ParamsTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/commands/ParamsTest.java
@@ -105,7 +105,19 @@ public class ParamsTest {
         // when
         cmd.execute("`var`");
         // then
-        verify(logger).printOut("var: 9");
+        verify(logger).printOut("`var`: 9");
+        verifyNoMoreInteractions(logger);
+    }
+
+    @Test
+    public void runCommandWithSpecialCharacters() throws CommandException {
+        // given
+        vars.put("var `", 9);
+        vars.put("param", 9999);
+        // when
+        cmd.execute("`var ```");
+        // then
+        verify(logger).printOut("`var ```: 9");
         verifyNoMoreInteractions(logger);
     }
 

--- a/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/CypherVariablesFormatterTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/CypherVariablesFormatterTest.java
@@ -10,7 +10,7 @@ public class CypherVariablesFormatterTest {
     private final CypherVariablesFormatter formatter = new CypherVariablesFormatter();
 
     @Test
-    public void formatNonAlphanumericStrings() throws Exception {
+    public void escapeNonAlphanumericStrings() throws Exception {
         assertThat(formatter.escape("abc12_A"), is("abc12_A"));
         assertThat(formatter.escape("Åbc12_A"), is("Åbc12_A"));
         assertThat(formatter.escape("\0"), is("`\0`"));
@@ -19,5 +19,18 @@ public class CypherVariablesFormatterTest {
         assertThat(formatter.escape("escaped content `back ticks #"), is("`escaped content ``back ticks #`"));
         assertThat(formatter.escape("escaped content two `back `ticks"),
                 is("`escaped content two ``back ``ticks`"));
+    }
+
+    @Test
+    public void reEscapeNonAlphanumericStrings() throws Exception {
+        assertThat(formatter.unescapedCypherVariable("abc12_A"), is("abc12_A"));
+        assertThat(formatter.unescapedCypherVariable("Åbc12_A"), is("Åbc12_A"));
+        assertThat(formatter.unescapedCypherVariable("`\0`"), is("\0"));
+        assertThat(formatter.unescapedCypherVariable("`\n`"), is("\n"));
+        assertThat(formatter.unescapedCypherVariable("`comma, separated`"), is("comma, separated"));
+        assertThat(formatter.unescapedCypherVariable("`escaped content ``back ticks #`"),
+                is("escaped content `back ticks #"));
+        assertThat(formatter.unescapedCypherVariable("`escaped content two ``back ``ticks`"),
+                is("escaped content two `back `ticks"));
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/CypherVariablesFormatterTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/CypherVariablesFormatterTest.java
@@ -12,6 +12,7 @@ public class CypherVariablesFormatterTest {
     @Test
     public void formatNonAlphanumericStrings() throws Exception {
         assertThat(formatter.escape("abc12_A"), is("abc12_A"));
+        assertThat(formatter.escape("Åbc12_A"), is("Åbc12_A"));
         assertThat(formatter.escape("\0"), is("`\0`"));
         assertThat(formatter.escape("\n"), is("`\n`"));
         assertThat(formatter.escape("comma, separated"), is("`comma, separated`"));


### PR DESCRIPTION
* Handles escaping of params in `:params` and `:param` commands.
* Also re-escapes  ``` ` ``` in listing of all the params as part of `:params` command.

```

neo4j> :params
neo4j> :param `foo 1` 1
neo4j> :param `foo ``2` 2
neo4j> :param `foo` 3
neo4j> :param foo 4
neo4j> :params
foo      : 4
`foo 1`  : 1
`foo ``2`: 2
neo4j> :params foo
foo: 4
neo4j> :params `foo`
`foo`: 4
neo4j> :params `foo 1`
`foo 1`: 1
neo4j> return {foo};
{foo}
4
neo4j> return {`foo`};
{`foo`}
4
neo4j> return {`foo 1`};
{`foo 1`}
1
neo4j> return {`foo ``2`};
{`foo ``2`}
2
```

