### PR TITLE
Insist that username is not empty

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/Main.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/Main.java
@@ -127,10 +127,10 @@ public class Main {
             }
             // else need to prompt for username and password
             if (connectionConfig.username().isEmpty()) {
-                connectionConfig.setUsername(promptForText("username: ", null));
+                connectionConfig.setUsername(promptForNonEmptyText("username", null));
             }
             if (connectionConfig.password().isEmpty()) {
-                connectionConfig.setPassword(promptForText("password: ", '*'));
+                connectionConfig.setPassword(promptForText("password", '*'));
             }
             // try again
             shell.connect(connectionConfig);
@@ -147,10 +147,30 @@ public class Main {
      *         in case of errors
      */
     @Nonnull
+    private String promptForNonEmptyText(@Nonnull String prompt, @Nullable Character mask) throws Exception {
+        String text = promptForText(prompt, mask);
+        if (!text.isEmpty()) {
+            return text;
+        }
+        out.println(prompt + " cannot be empty");
+        out.println();
+        return promptForNonEmptyText(prompt, mask);
+    }
+
+    /**
+     * @param prompt
+     *         to display to the user
+     * @param mask
+     *         single character to display instead of what the user is typing, use null if text is not secret
+     * @return the text which was entered
+     * @throws Exception
+     *         in case of errors
+     */
+    @Nonnull
     private String promptForText(@Nonnull String prompt, @Nullable Character mask) throws Exception {
         String line;
         ConsoleReader consoleReader = new ConsoleReader(in, out);
-        line = consoleReader.readLine(prompt, mask);
+        line = consoleReader.readLine(prompt + ": ", mask);
         consoleReader.close();
 
         if (line == null) {

--- a/cypher-shell/src/test/java/org/neo4j/shell/MainTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/MainTest.java
@@ -171,6 +171,28 @@ public class MainTest {
     }
 
     @Test
+    public void connectInteractivelyRepromptsIfUserIsNotProvided() throws Exception {
+        doThrow(authException).doNothing().when(shell).connect(connectionConfig);
+
+        String inputString = "\nbob\nsecret\n";
+        InputStream inputStream = new ByteArrayInputStream(inputString.getBytes());
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintStream ps = new PrintStream(baos);
+
+        Main main = new Main(inputStream, ps);
+        main.connectInteractively(shell, connectionConfig);
+
+        String out = new String(baos.toByteArray(), StandardCharsets.UTF_8);
+
+        assertEquals(out, "username: \r\nusername cannot be empty" + System.lineSeparator() + System.lineSeparator() +
+                "username: bob\r\npassword: ******\r\n");
+        verify(connectionConfig).setUsername("bob");
+        verify(connectionConfig).setPassword("secret");
+        verify(shell, times(2)).connect(connectionConfig);
+    }
+
+    @Test
     public void printsVersionAndExits() throws Exception {
         CliArgs args = new CliArgs();
         args.setVersion(true);


### PR DESCRIPTION
Previously you could enter an empty username:

```
$ cypher-shell
username: 
password: 
Realm [org.neo4j.server.security.enterprise.auth.InternalFlatFileRealm@7d88b6e6] does not support authentication token [org.neo4j.server.security.enterprise.auth.ShiroAuthToken@4a23347f].  Please ensure that the appropriate Realm implementation is configured correctly or that the realm accepts AuthenticationTokens of this type.

Bye!
```

(The error message shown here is from Enterprise only and we hope to improve it elsewhere.)

With this PR, the user is reprompted:

```
$ cypher-shell
username: 
username cannot be empty

username: 
```

If the user sends an interrupt (`^c`) they can escape the endless cycle of prompts:

```
$ cypher-shell
username: 
username cannot be empty

username: 
username cannot be empty

username: 
Bye!
```