### PR TITLE
updated help link to point to current instead of beta

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/commands/Help.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/commands/Help.java
@@ -17,7 +17,7 @@ public class Help implements Command {
     public static final String COMMAND_NAME = ":help";
     private final Logger logger;
     private final CommandHelper commandHelper;
-    public static String CYPHER_REFCARD_LINK = "https://neo4j.com/docs/developer-manual/3.1-beta/cypher/";
+    public static String CYPHER_REFCARD_LINK = "https://neo4j.com/docs/developer-manual/current/cypher/";
 
     public Help(@Nonnull final Logger shell, @Nonnull final CommandHelper commandHelper) {
         this.logger = shell;


### PR DESCRIPTION
In preparation for GA`:help` command lists current version of cypher help instead of beta. 

```
For help on cypher please visit:
    https://neo4j.com/docs/developer-manual/current/cypher/
```