### PR TITLE
Fallback to plain `bolt://` when url scheme is `bolt+routing://`

### DIFF
--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellIntegrationTest.java
@@ -44,7 +44,7 @@ public class CypherShellIntegrationTest {
         commitCommand = new Commit(shell);
         beginCommand = new Begin(shell);
 
-        shell.connect(new ConnectionConfig("localhost", 7687, "neo4j", "neo", true));
+        shell.connect(new ConnectionConfig("bolt://", "localhost", 7687, "neo4j", "neo", true));
     }
 
     @After
@@ -84,7 +84,7 @@ public class CypherShellIntegrationTest {
         thrown.expect(CommandException.class);
         thrown.expectMessage("Already connected");
 
-        ConnectionConfig config = new ConnectionConfig("localhost", 7687, "neo4j", "neo", true);
+        ConnectionConfig config = new ConnectionConfig("bolt://", "localhost", 7687, "neo4j", "neo", true);
         assertTrue("Shell should already be connected", shell.isConnected());
         shell.connect(config);
     }

--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellIntegrationTest.java
@@ -44,7 +44,7 @@ public class CypherShellIntegrationTest {
         commitCommand = new Commit(shell);
         beginCommand = new Begin(shell);
 
-        shell.connect(new ConnectionConfig("bolt://", "localhost", 7687, "neo4j", "neo", true));
+        shell.connect(new ConnectionConfig(logger, "bolt://", "localhost", 7687, "neo4j", "neo", true));
     }
 
     @After
@@ -84,7 +84,7 @@ public class CypherShellIntegrationTest {
         thrown.expect(CommandException.class);
         thrown.expectMessage("Already connected");
 
-        ConnectionConfig config = new ConnectionConfig("bolt://", "localhost", 7687, "neo4j", "neo", true);
+        ConnectionConfig config = new ConnectionConfig(logger, "bolt://", "localhost", 7687, "neo4j", "neo", true);
         assertTrue("Shell should already be connected", shell.isConnected());
         shell.connect(config);
     }

--- a/cypher-shell/src/main/java/org/neo4j/shell/ConnectionConfig.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/ConnectionConfig.java
@@ -5,14 +5,16 @@ import org.neo4j.driver.v1.Config;
 import javax.annotation.Nonnull;
 
 public class ConnectionConfig {
+    private final String scheme;
     private final String host;
     private final int port;
     private final Config.EncryptionLevel encryption;
     private String username;
     private String password;
 
-    public ConnectionConfig(@Nonnull String host, int port, @Nonnull String username, @Nonnull String password,
-                            boolean encryption) {
+    public ConnectionConfig(@Nonnull String scheme, @Nonnull String host, int port, @Nonnull String username,
+                            @Nonnull String password, boolean encryption) {
+        this.scheme = scheme;
         this.host = host;
         this.port = port;
         this.username = fallbackToEnvVariable(username, "NEO4J_USERNAME");
@@ -30,6 +32,11 @@ public class ConnectionConfig {
             result = preferredValue;
         }
         return result;
+    }
+
+    @Nonnull
+    public String scheme() {
+        return scheme;
     }
 
     @Nonnull
@@ -53,7 +60,7 @@ public class ConnectionConfig {
 
     @Nonnull
     public String driverUrl() {
-        return String.format("bolt://%s:%d", host(), port());
+        return String.format("%s%s:%d", scheme(), host(), port());
     }
 
     @Nonnull

--- a/cypher-shell/src/main/java/org/neo4j/shell/ConnectionConfig.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/ConnectionConfig.java
@@ -1,6 +1,8 @@
 package org.neo4j.shell;
 
 import org.neo4j.driver.v1.Config;
+import org.neo4j.shell.log.AnsiFormattedText;
+import org.neo4j.shell.log.Logger;
 
 import javax.annotation.Nonnull;
 
@@ -12,14 +14,23 @@ public class ConnectionConfig {
     private String username;
     private String password;
 
-    public ConnectionConfig(@Nonnull String scheme, @Nonnull String host, int port, @Nonnull String username,
-                            @Nonnull String password, boolean encryption) {
-        this.scheme = scheme;
+    public ConnectionConfig(@Nonnull Logger logger, @Nonnull String scheme, @Nonnull String host, int port,
+                            @Nonnull String username, @Nonnull String password, boolean encryption) {
         this.host = host;
         this.port = port;
         this.username = fallbackToEnvVariable(username, "NEO4J_USERNAME");
         this.password = fallbackToEnvVariable(password, "NEO4J_PASSWORD");
         this.encryption = encryption ? Config.EncryptionLevel.REQUIRED : Config.EncryptionLevel.NONE;
+
+        if ("bolt+routing://".equalsIgnoreCase(scheme)) {
+            logger.printError(
+                    AnsiFormattedText.s()
+                                     .colorRed()
+                                     .append("Routing is not supported by cypher-shell. Falling back to direct connection.")
+                                     .formattedString());
+            scheme = "bolt://";
+        }
+        this.scheme = scheme;
     }
 
     /**

--- a/cypher-shell/src/main/java/org/neo4j/shell/Main.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/Main.java
@@ -81,7 +81,9 @@ public class Main {
             return;
         }
 
-        ConnectionConfig connectionConfig = new ConnectionConfig(cliArgs.getHost(),
+        ConnectionConfig connectionConfig = new ConnectionConfig(
+                cliArgs.getScheme(),
+                cliArgs.getHost(),
                 cliArgs.getPort(),
                 cliArgs.getUsername(),
                 cliArgs.getPassword(),

--- a/cypher-shell/src/main/java/org/neo4j/shell/Main.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/Main.java
@@ -49,7 +49,7 @@ public class Main {
     }
 
     static String getWelcomeMessage(@Nonnull ConnectionConfig connectionConfig,
-                                           @Nonnull String serverVersion) {
+                                    @Nonnull String serverVersion) {
         String neo4j = "Neo4j";
         if (!serverVersion.isEmpty()) {
             neo4j += " " + serverVersion;
@@ -80,8 +80,11 @@ public class Main {
             out.println("Cypher-Shell " + Build.version());
             return;
         }
+        Logger logger = new AnsiLogger(cliArgs.getDebugMode());
+        logger.setFormat(cliArgs.getFormat());
 
         ConnectionConfig connectionConfig = new ConnectionConfig(
+                logger,
                 cliArgs.getScheme(),
                 cliArgs.getHost(),
                 cliArgs.getPort(),
@@ -89,10 +92,7 @@ public class Main {
                 cliArgs.getPassword(),
                 cliArgs.getEncryption());
 
-        Logger logger = new AnsiLogger(cliArgs.getDebugMode());
         try {
-            logger.setFormat(cliArgs.getFormat());
-
             CypherShell shell = new CypherShell(logger);
             connectInteractively(shell, connectionConfig);
 

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgHelper.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgHelper.java
@@ -26,7 +26,7 @@ import static org.neo4j.shell.cli.FailBehavior.FAIL_FAST;
 public class CliArgHelper {
 
     static final Pattern ADDRESS_ARG_PATTERN =
-            Pattern.compile("\\s*(?<protocol>[a-zA-Z]+://)?((?<username>\\w+):(?<password>[^\\s]+)@)?(?<host>[a-zA-Z\\d\\-\\.]+)?(:(?<port>\\d+))?\\s*");
+            Pattern.compile("\\s*(?<scheme>[a-zA-Z0-9+\\-.]+://)?((?<username>\\w+):(?<password>[^\\s]+)@)?(?<host>[a-zA-Z\\d\\-.]+)?(:(?<port>\\d+))?\\s*");
 
     /**
      * @param args to parse
@@ -53,6 +53,7 @@ public class CliArgHelper {
 
         CliArgs cliArgs = new CliArgs();
 
+        cliArgs.setScheme(addressMatcher.group("scheme"), "bolt://");
         cliArgs.setHost(addressMatcher.group("host"), "localhost");
         // Safe, regex only matches integers
         String portString = addressMatcher.group("port");
@@ -99,7 +100,7 @@ public class CliArgHelper {
             PrintWriter printWriter = new PrintWriter(System.err);
             parser.printUsage(printWriter);
             printWriter.println("cypher-shell: error: Failed to parse address: '" + address + "'");
-            printWriter.println("\n  Address should be of the form: [username:password@][host][:port]");
+            printWriter.println("\n  Address should be of the form: [scheme://][username:password@][host][:port]");
             printWriter.flush();
             return null;
         }
@@ -114,7 +115,7 @@ public class CliArgHelper {
         ArgumentGroup connGroup = parser.addArgumentGroup("connection arguments");
         connGroup.addArgument("-a", "--address")
                 .help("address and port to connect to")
-                .setDefault("localhost:7687");
+                .setDefault("bolt://localhost:7687");
         connGroup.addArgument("-u", "--username")
                 .setDefault("")
                 .help("username to connect as. Can also be specified using environment variable NEO4J_USERNAME");

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgs.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgs.java
@@ -5,6 +5,7 @@ import javax.annotation.Nullable;
 import java.util.Optional;
 
 public class CliArgs {
+    private String scheme = "bolt://";
     private String host = "localhost";
     private int port = 7687;
     private String username = "";
@@ -16,6 +17,13 @@ public class CliArgs {
     private boolean debugMode;
     private boolean nonInteractive = false;
     private boolean version = false;
+
+    /**
+     * Set the scheme to the primary value, or if null, the fallback value.
+     */
+    void setScheme(@Nullable String primary, @Nonnull String fallback) {
+        scheme = primary == null ? fallback : primary;
+    }
 
     /**
      * Set the host to the primary value, or if null, the fallback value.
@@ -85,6 +93,11 @@ public class CliArgs {
      */
     void setDebugMode(boolean enabled) {
         this.debugMode = enabled;
+    }
+
+    @Nonnull
+    public String getScheme() {
+        return scheme;
     }
 
     @Nonnull

--- a/cypher-shell/src/main/java/org/neo4j/shell/state/BoltResult.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/state/BoltResult.java
@@ -19,10 +19,12 @@ public class BoltResult {
         this.summary = summary;
     }
 
+    @Nonnull
     public List<Record> getRecords() {
         return records;
     }
 
+    @Nonnull
     public ResultSummary getSummary() {
         return summary;
     }

--- a/cypher-shell/src/test/java/org/neo4j/shell/ConnectionConfigTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/ConnectionConfigTest.java
@@ -2,11 +2,16 @@ package org.neo4j.shell;
 
 import org.junit.Test;
 import org.neo4j.driver.v1.Config;
+import org.neo4j.shell.log.Logger;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 public class ConnectionConfigTest {
-    ConnectionConfig config = new ConnectionConfig("bolt://", "localhost", 1, "bob", "pass", false);
+    private Logger logger = mock(Logger.class);
+    private ConnectionConfig config = new ConnectionConfig(logger, "bolt://", "localhost", 1, "bob",
+            "pass", false);
 
     @Test
     public void scheme() throws Exception {
@@ -39,17 +44,18 @@ public class ConnectionConfigTest {
     }
 
     @Test
-    public void driverUrlExplicitScheme() throws Exception {
-        ConnectionConfig config = new ConnectionConfig("bolt+routing://", "localhost", 1, "bob",
+    public void driverUrlRoutingScheme() throws Exception {
+        ConnectionConfig config = new ConnectionConfig(logger, "bolt+routing://", "localhost", 1, "bob",
                 "pass", false);
-        assertEquals("bolt+routing://localhost:1", config.driverUrl());
+        verify(logger).printError("@|RED Routing is not supported by cypher-shell. Falling back to direct connection.|@");
+        assertEquals("bolt://localhost:1", config.driverUrl());
     }
 
     @Test
     public void encryption() {
         assertEquals(Config.EncryptionLevel.REQUIRED,
-                new ConnectionConfig("bolt://", "", -1, "", "", true).encryption());
+                new ConnectionConfig(logger, "bolt://", "", -1, "", "", true).encryption());
         assertEquals(Config.EncryptionLevel.NONE,
-                new ConnectionConfig("bolt://", "", -1, "", "", false).encryption());
+                new ConnectionConfig(logger, "bolt://", "", -1, "", "", false).encryption());
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/ConnectionConfigTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/ConnectionConfigTest.java
@@ -6,7 +6,12 @@ import org.neo4j.driver.v1.Config;
 import static org.junit.Assert.assertEquals;
 
 public class ConnectionConfigTest {
-    ConnectionConfig config = new ConnectionConfig("localhost", 1, "bob", "pass", false);
+    ConnectionConfig config = new ConnectionConfig("bolt://", "localhost", 1, "bob", "pass", false);
+
+    @Test
+    public void scheme() throws Exception {
+        assertEquals("bolt://", config.scheme());
+    }
 
     @Test
     public void host() throws Exception {
@@ -29,13 +34,22 @@ public class ConnectionConfigTest {
     }
 
     @Test
-    public void driverUrl() throws Exception {
+    public void driverUrlDefaultScheme() throws Exception {
         assertEquals("bolt://localhost:1", config.driverUrl());
     }
 
     @Test
+    public void driverUrlExplicitScheme() throws Exception {
+        ConnectionConfig config = new ConnectionConfig("bolt+routing://", "localhost", 1, "bob",
+                "pass", false);
+        assertEquals("bolt+routing://localhost:1", config.driverUrl());
+    }
+
+    @Test
     public void encryption() {
-        assertEquals(Config.EncryptionLevel.REQUIRED, new ConnectionConfig("", -1, "", "", true).encryption());
-        assertEquals(Config.EncryptionLevel.NONE, new ConnectionConfig("", -1, "", "", false).encryption());
+        assertEquals(Config.EncryptionLevel.REQUIRED,
+                new ConnectionConfig("bolt://", "", -1, "", "", true).encryption());
+        assertEquals(Config.EncryptionLevel.NONE,
+                new ConnectionConfig("bolt://", "", -1, "", "", false).encryption());
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
@@ -58,7 +58,7 @@ public class CypherShellTest {
 
     @Test
     public void verifyDelegationOfConnectionMethods() throws CommandException {
-        ConnectionConfig cc = new ConnectionConfig("", 1, "", "", false);
+        ConnectionConfig cc = new ConnectionConfig("bolt://", "", 1, "", "", false);
         CypherShell shell = new CypherShell(logger, mockedBoltStateHandler, mockedPrettyPrinter);
 
         shell.connect(cc);

--- a/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
@@ -58,7 +58,7 @@ public class CypherShellTest {
 
     @Test
     public void verifyDelegationOfConnectionMethods() throws CommandException {
-        ConnectionConfig cc = new ConnectionConfig("bolt://", "", 1, "", "", false);
+        ConnectionConfig cc = new ConnectionConfig(logger, "bolt://", "", 1, "", "", false);
         CypherShell shell = new CypherShell(logger, mockedBoltStateHandler, mockedPrettyPrinter);
 
         shell.connect(cc);

--- a/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
@@ -46,6 +46,8 @@ public class CypherShellTest {
 
     @Before
     public void setup() {
+        when(mockedBoltStateHandler.getServerVersion()).thenReturn("");
+
         doReturn(System.out).when(logger).getOutputStream();
         offlineTestShell = new OfflineTestShell(logger, mockedBoltStateHandler, mockedPrettyPrinter);
 

--- a/cypher-shell/src/test/java/org/neo4j/shell/cli/AddressArgPatternTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/cli/AddressArgPatternTest.java
@@ -16,23 +16,23 @@ import static org.junit.Assert.assertTrue;
 @RunWith(Parameterized.class)
 public class AddressArgPatternTest {
 
-    private final String protocol;
+    private final String scheme;
     private final String host;
     private final String port;
     private final String username;
     private final String password;
     private final String connString;
 
-    public AddressArgPatternTest(String protocol, String host, String port,
+    public AddressArgPatternTest(String scheme, String host, String port,
                                  String username, String password) {
 
-        this.protocol = protocol;
+        this.scheme = scheme;
         this.host = host;
         this.port = port;
         this.username = username;
         this.password = password;
 
-        StringBuilder connString = new StringBuilder().append(protocol);
+        StringBuilder connString = new StringBuilder().append(scheme);
         // Only expect username/pass in case host is present
         if (!host.isEmpty() && !username.isEmpty() && !password.isEmpty()) {
             connString.append(username).append(":").append(password).append("@");
@@ -49,12 +49,12 @@ public class AddressArgPatternTest {
     @Parameterized.Parameters
     public static Collection<Object[]> parameters() {
         Collection<Object[]> data = new ArrayList<>();
-        for (final String protocol : getProtocols()) {
+        for (final String scheme : getSchemes()) {
             for (final String username : getUsernames()) {
                 for (final String password : getPasswords()) {
                     for (final String host : getHosts()) {
                         for (final String port : getPorts()) {
-                            data.add(new String[]{protocol, host, port, username, password});
+                            data.add(new String[]{scheme, host, port, username, password});
                         }
                     }
                 }
@@ -79,12 +79,12 @@ public class AddressArgPatternTest {
         return new String[]{"", "bob1"};
     }
 
-    private static String[] getProtocols() {
-        return new String[]{"", "bolt://"};
+    private static String[] getSchemes() {
+        return new String[]{"", "bolt://", "bolt+routing://", "w31rd.-+://"};
     }
 
     @Test
-    public void testUserPassProtocolHostPort() {
+    public void testUserPassschemeHostPort() {
         Matcher m = CliArgHelper.ADDRESS_ARG_PATTERN.matcher("   " + connString + "  ");
         assertTrue("Expected a match: " + connString, m.matches());
         if (host.isEmpty()) {
@@ -104,10 +104,10 @@ public class AddressArgPatternTest {
             assertEquals("Mismatched username", username, m.group("username"));
             assertEquals("Mismatched password", password, m.group("password"));
         }
-        if (protocol.isEmpty()) {
-            assertNull("Protocol should have been null", m.group("protocol"));
+        if (scheme.isEmpty()) {
+            assertNull("scheme should have been null", m.group("scheme"));
         } else {
-            assertEquals("Mismatched protocol", protocol, m.group("protocol"));
+            assertEquals("Mismatched scheme", scheme, m.group("scheme"));
         }
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/cli/CliArgHelperTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/cli/CliArgHelperTest.java
@@ -103,7 +103,7 @@ public class CliArgHelperTest {
 
     @Test
     public void parseFullAddress() throws Exception {
-        CliArgs cliArgs = CliArgHelper.parse("--address", "alice:foo@bar:69");
+        CliArgs cliArgs = CliArgHelper.parse("--address", "bolt+routing://alice:foo@bar:69");
         assertNotNull(cliArgs);
         assertEquals("alice", cliArgs.getUsername());
         assertEquals("foo", cliArgs.getPassword());

--- a/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/PrettyPrinterTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/PrettyPrinterTest.java
@@ -71,6 +71,7 @@ public class PrettyPrinterTest {
         when(record2.values()).thenReturn(asList(value2));
 
         when(result.getRecords()).thenReturn(asList(record1, record2));
+        when(result.getSummary()).thenReturn(mock(ResultSummary.class));
 
         // when
         String actual = plainPrinter.format(result);
@@ -102,6 +103,7 @@ public class PrettyPrinterTest {
         when(record.values()).thenReturn(asList(value));
 
         when(result.getRecords()).thenReturn(asList(record));
+        when(result.getSummary()).thenReturn(mock(ResultSummary.class));
 
         // when
         String actual = plainPrinter.format(result);
@@ -134,6 +136,7 @@ public class PrettyPrinterTest {
         when(record.values()).thenReturn(asList(value));
 
         when(result.getRecords()).thenReturn(asList(record));
+        when(result.getSummary()).thenReturn(mock(ResultSummary.class));
 
         // when
         String actual = plainPrinter.format(result);
@@ -179,6 +182,7 @@ public class PrettyPrinterTest {
         when(record.values()).thenReturn(asList(relVal, nodeVal));
 
         when(result.getRecords()).thenReturn(asList(record));
+        when(result.getSummary()).thenReturn(mock(ResultSummary.class));
 
         // when
         String actual = plainPrinter.format(result);
@@ -240,6 +244,7 @@ public class PrettyPrinterTest {
         when(record.values()).thenReturn(asList(value));
 
         when(result.getRecords()).thenReturn(asList(record));
+        when(result.getSummary()).thenReturn(mock(ResultSummary.class));
 
         // when
         String actual = plainPrinter.format(result);
@@ -287,6 +292,7 @@ public class PrettyPrinterTest {
         when(record.values()).thenReturn(asList(value));
 
         when(result.getRecords()).thenReturn(asList(record));
+        when(result.getSummary()).thenReturn(mock(ResultSummary.class));
 
         // when
         String actual = plainPrinter.format(result);
@@ -350,6 +356,7 @@ public class PrettyPrinterTest {
         when(record.values()).thenReturn(asList(value));
 
         when(result.getRecords()).thenReturn(asList(record));
+        when(result.getSummary()).thenReturn(mock(ResultSummary.class));
 
         // when
         String actual = plainPrinter.format(result);

--- a/cypher-shell/src/test/java/org/neo4j/shell/state/BoltStateHandlerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/state/BoltStateHandlerTest.java
@@ -64,7 +64,7 @@ public class BoltStateHandlerTest {
             }
         };
         BoltStateHandler handler = new BoltStateHandler(provider);
-        ConnectionConfig config = new ConnectionConfig( "bolt://", "", -1, "", "", false);
+        ConnectionConfig config = new ConnectionConfig( logger, "bolt://", "", -1, "", "", false);
         handler.connect(config);
 
         assertEquals("", handler.getServerVersion());
@@ -90,7 +90,7 @@ public class BoltStateHandlerTest {
             }
         };
         BoltStateHandler handler = new BoltStateHandler(provider);
-        ConnectionConfig config = new ConnectionConfig("bolt://", "", -1, "", "", false);
+        ConnectionConfig config = new ConnectionConfig(logger, "bolt://", "", -1, "", "", false);
         handler.connect(config);
 
         assertEquals("9.4.1-ALPHA", handler.getServerVersion());
@@ -270,7 +270,7 @@ public class BoltStateHandlerTest {
     public void turnOffEncryptionIfRequested() throws CommandException {
         RecordingDriverProvider provider = new RecordingDriverProvider();
         BoltStateHandler handler = new BoltStateHandler(provider);
-        ConnectionConfig config = new ConnectionConfig("bolt://", "", -1, "", "", false);
+        ConnectionConfig config = new ConnectionConfig(logger, "bolt://", "", -1, "", "", false);
         handler.connect(config);
         assertEquals(Config.EncryptionLevel.NONE, provider.config.encryptionLevel());
     }
@@ -279,7 +279,7 @@ public class BoltStateHandlerTest {
     public void turnOnEncryptionIfRequested() throws CommandException {
         RecordingDriverProvider provider = new RecordingDriverProvider();
         BoltStateHandler handler = new BoltStateHandler(provider);
-        ConnectionConfig config = new ConnectionConfig("bolt://", "", -1, "", "", true);
+        ConnectionConfig config = new ConnectionConfig(logger, "bolt://", "", -1, "", "", true);
         handler.connect(config);
         assertEquals(Config.EncryptionLevel.REQUIRED, provider.config.encryptionLevel());
     }
@@ -297,7 +297,7 @@ public class BoltStateHandlerTest {
         }
 
         public void connect() throws CommandException {
-            connect(new ConnectionConfig("bolt://", "", 1, "", "", false));
+            connect(new ConnectionConfig(mock(Logger.class), "bolt://", "", 1, "", "", false));
         }
     }
 

--- a/cypher-shell/src/test/java/org/neo4j/shell/state/BoltStateHandlerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/state/BoltStateHandlerTest.java
@@ -64,7 +64,7 @@ public class BoltStateHandlerTest {
             }
         };
         BoltStateHandler handler = new BoltStateHandler(provider);
-        ConnectionConfig config = new ConnectionConfig("", -1, "", "", false);
+        ConnectionConfig config = new ConnectionConfig( "bolt://", "", -1, "", "", false);
         handler.connect(config);
 
         assertEquals("", handler.getServerVersion());
@@ -90,7 +90,7 @@ public class BoltStateHandlerTest {
             }
         };
         BoltStateHandler handler = new BoltStateHandler(provider);
-        ConnectionConfig config = new ConnectionConfig("", -1, "", "", false);
+        ConnectionConfig config = new ConnectionConfig("bolt://", "", -1, "", "", false);
         handler.connect(config);
 
         assertEquals("9.4.1-ALPHA", handler.getServerVersion());
@@ -270,7 +270,7 @@ public class BoltStateHandlerTest {
     public void turnOffEncryptionIfRequested() throws CommandException {
         RecordingDriverProvider provider = new RecordingDriverProvider();
         BoltStateHandler handler = new BoltStateHandler(provider);
-        ConnectionConfig config = new ConnectionConfig("", -1, "", "", false);
+        ConnectionConfig config = new ConnectionConfig("bolt://", "", -1, "", "", false);
         handler.connect(config);
         assertEquals(Config.EncryptionLevel.NONE, provider.config.encryptionLevel());
     }
@@ -279,7 +279,7 @@ public class BoltStateHandlerTest {
     public void turnOnEncryptionIfRequested() throws CommandException {
         RecordingDriverProvider provider = new RecordingDriverProvider();
         BoltStateHandler handler = new BoltStateHandler(provider);
-        ConnectionConfig config = new ConnectionConfig("", -1, "", "", true);
+        ConnectionConfig config = new ConnectionConfig("bolt://", "", -1, "", "", true);
         handler.connect(config);
         assertEquals(Config.EncryptionLevel.REQUIRED, provider.config.encryptionLevel());
     }
@@ -297,7 +297,7 @@ public class BoltStateHandlerTest {
         }
 
         public void connect() throws CommandException {
-            connect(new ConnectionConfig("", 1, "", "", false));
+            connect(new ConnectionConfig("bolt://", "", 1, "", "", false));
         }
     }
 


### PR DESCRIPTION
This needs to be exposed so that URIs such as `bolt+routing://localhost:123` can be accessed.

### Previous behavior:

```
$ ./cypher-shell -a bolt+routing://localhost:7687
usage: cypher-shell [-h] [-a ADDRESS] [-u USERNAME] [-p PASSWORD] [--encryption {true,false}] [--format {verbose,plain}]
                    [--debug] [--non-interactive] [-v] [--fail-fast | --fail-at-end] [cypher]
cypher-shell: error: Failed to parse address: 'bolt+routing://localhost:7687'

  Address should be of the form: [username:password@][host][:port]
```

### New behavior:

```
$ cypher-shell/build/install/cypher-shell/cypher-shell -a bolt+routing://localhost
Routing is not supported by cypher-shell. Falling back to direct connection.
Connected to Neo4j 3.1.0-M12-beta2 at bolt://localhost:7687.
Type :help for a list of available commands or :exit to exit the shell.
Note that Cypher queries must end with a semicolon.
neo4j>
```

### New error message:

(Valid characters in a scheme is alphanumerics, +, -, and dot [.])

```
$ cypher-shell/build/install/cypher-shell/cypher-shell --address=bolt\!routing://localhost:123
usage: cypher-shell [-h] [-a ADDRESS] [-u USERNAME] [-p PASSWORD] [--encryption {true,false}] [--format {verbose,plain}]
                    [--debug] [--non-interactive] [-v] [--fail-fast | --fail-at-end] [cypher]
cypher-shell: error: Failed to parse address: 'bolt!routing://localhost:123'

  Address should be of the form: [scheme://][username:password@][host][:port]
```

### New help text:

```
$ cypher-shell/build/install/cypher-shell/cypher-shell --help
usage: cypher-shell [-h] [-a ADDRESS] [-u USERNAME] [-p PASSWORD] [--encryption {true,false}] [--format {verbose,plain}]
                    [--debug] [--non-interactive] [-v] [--fail-fast | --fail-at-end] [cypher]

A command line shell where you can execute Cypher against an instance of Neo4j

positional arguments:
  cypher                 an optional string of cypher to execute and then exit

optional arguments:
  -h, --help             show this help message and exit
  --fail-fast            exit and report failure on first error when reading from file (this is the default behavior)
  --fail-at-end          exit and report failures at end of input when reading from file
  --format {verbose,plain}
                         desired output format, verbose(default) displays statistics, plain only displays data (default: verbose)
  --debug                print additional debug information (default: false)
  --non-interactive      force non-interactive mode, only useful if auto-detection fails (like on Windows) (default: false)
  -v, --version          print version of cypher-shell and exit (default: false)

connection arguments:
  -a ADDRESS, --address ADDRESS
                         address and port to connect to (default: bolt://localhost:7687)
  -u USERNAME, --username USERNAME
                         username to connect as. Can also be specified using environment variable NEO4J_USERNAME (default: )
  -p PASSWORD, --password PASSWORD
                         password to connect with. Can also be specified using environment variable NEO4J_PASSWORD (default: )
  --encryption {true,false}
                         whether the connection to Neo4j  should  be  encrypted;  must  be  consistent with Neo4j's configuration
                         (default: true)
```