### PR TITLE
updated java driver to 1.1.0.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ ext {
 
     argparse4jVersion = '0.7.0'
     junitVersion = '4.12'
-    neo4jJavaVersion = '1.1.0-M06'
+    neo4jJavaVersion = '1.1.0'
     findbugsVersion = '3.0.0'
     jansiVersion = '1.13'
     jlineVersion = '2.14.2'

--- a/cypher-shell/src/test/java/org/neo4j/shell/test/bolt/FakeResultSummary.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/test/bolt/FakeResultSummary.java
@@ -61,4 +61,23 @@ class FakeResultSummary implements ResultSummary {
     public long resultConsumedAfter(TimeUnit unit) {
         return 0;
     }
+
+    @Override
+    public ServerInfo server()
+    {
+        return new ServerInfo()
+        {
+            @Override
+            public String address()
+            {
+                throw new Util.NotImplementedYetException("Not implemented yet");
+            }
+
+            @Override
+            public String version()
+            {
+                return null;
+            }
+        };
+    }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/test/bolt/FakeSession.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/test/bolt/FakeSession.java
@@ -41,11 +41,6 @@ public class FakeSession implements Session {
     }
 
     @Override
-    public String server() {
-        return null;
-    }
-
-    @Override
     public StatementResult run(String statementTemplate, Value parameters) {
         return FakeStatementResult.parseStatement(statementTemplate);
     }

--- a/cypher-shell/src/test/java/org/neo4j/shell/test/bolt/FakeStatementResult.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/test/bolt/FakeStatementResult.java
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
 /**
  * A fake StatementResult with fake records and fake values
  */
-public class FakeStatementResult implements StatementResult {
+class FakeStatementResult implements StatementResult {
 
     private final List<Record> records;
     private int currentRecord = -1;
@@ -68,6 +68,12 @@ public class FakeStatementResult implements StatementResult {
 
     @Override
     public ResultSummary consume() {
+        return new FakeResultSummary();
+    }
+
+    @Override
+    public ResultSummary summary()
+    {
         return new FakeResultSummary();
     }
 


### PR DESCRIPTION
Version is independent of the session because of routing strategy in Bolt. Although this doesn't affect `cypher-shell` version information is no longer part of the bolt `Session` but rather part of the resultSummary from where the query is executed in the server.

We grab the version of the server when we first connect, the version of the session will remain the same as long as `cypher-shell` doesn't handle routing.