### PR TITLE
Do not expand bangs when prompting for user/password

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/Main.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/Main.java
@@ -172,6 +172,10 @@ public class Main {
     private String promptForText(@Nonnull String prompt, @Nullable Character mask) throws Exception {
         String line;
         ConsoleReader consoleReader = new ConsoleReader(in, out);
+        // Disable expansion of bangs: !
+        consoleReader.setExpandEvents(false);
+        // Ensure Reader does not handle user input for ctrl+C behaviour
+        consoleReader.setHandleUserInterrupt(false);
         line = consoleReader.readLine(prompt + ": ", mask);
         consoleReader.close();
 

--- a/cypher-shell/src/test/java/org/neo4j/shell/MainTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/MainTest.java
@@ -149,6 +149,27 @@ public class MainTest {
     }
 
     @Test
+    public void connectInteractivelyPromptsHandlesBang() throws Exception {
+        doThrow(authException).doNothing().when(shell).connect(connectionConfig);
+
+        String inputString = "bo!b\nsec!ret\n";
+        InputStream inputStream = new ByteArrayInputStream(inputString.getBytes());
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintStream ps = new PrintStream(baos);
+
+        Main main = new Main(inputStream, ps);
+        main.connectInteractively(shell, connectionConfig);
+
+        String out = new String(baos.toByteArray(), StandardCharsets.UTF_8);
+
+        assertEquals(out, "username: bo!b\r\npassword: *******\r\n");
+        verify(connectionConfig).setUsername("bo!b");
+        verify(connectionConfig).setPassword("sec!ret");
+        verify(shell, times(2)).connect(connectionConfig);
+    }
+
+    @Test
     public void connectInteractivelyTriesOnlyOnceIfUserPassExists() throws Exception {
         doThrow(authException).doThrow(new RuntimeException("second try")).when(shell).connect(connectionConfig);
         doReturn("bob").when(connectionConfig).username();


### PR DESCRIPTION
Making sure we do the same thing for these prompts as we do in the rest of the shell prompts