### PR TITLE
interactive shell now uses UserMessageHandler to display welcome and exit message

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
@@ -5,7 +5,6 @@ import org.neo4j.shell.commands.CommandExecutable;
 import org.neo4j.shell.commands.CommandHelper;
 import org.neo4j.shell.exception.CommandException;
 import org.neo4j.shell.exception.ExitException;
-import org.neo4j.shell.log.AnsiFormattedText;
 import org.neo4j.shell.log.Logger;
 import org.neo4j.shell.prettyprint.CypherVariablesFormatter;
 import org.neo4j.shell.prettyprint.PrettyPrinter;
@@ -188,9 +187,9 @@ public class CypherShell implements StatementExecuter, Connector, TransactionHan
         Runtime.getRuntime().addShutdownHook(new Thread() {
             @Override
             public void run() {
-                logger.printIfVerbose(AnsiFormattedText.s().append("\nBye!").formattedString());
                 reset();
             }
         });
     }
+
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/Main.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/Main.java
@@ -6,10 +6,7 @@ import org.neo4j.shell.build.Build;
 import org.neo4j.shell.cli.CliArgHelper;
 import org.neo4j.shell.cli.CliArgs;
 import org.neo4j.shell.commands.CommandHelper;
-import org.neo4j.shell.commands.Exit;
-import org.neo4j.shell.commands.Help;
 import org.neo4j.shell.exception.CommandException;
-import org.neo4j.shell.log.AnsiFormattedText;
 import org.neo4j.shell.log.AnsiLogger;
 import org.neo4j.shell.log.Logger;
 
@@ -48,33 +45,6 @@ public class Main {
         this.out = out;
     }
 
-    static String getWelcomeMessage(@Nonnull ConnectionConfig connectionConfig,
-                                    @Nonnull String serverVersion) {
-        String neo4j = "Neo4j";
-        if (!serverVersion.isEmpty()) {
-            neo4j += " " + serverVersion;
-        }
-        AnsiFormattedText welcomeMessage = AnsiFormattedText.from("Connected to ")
-                                                            .append(neo4j)
-                                                            .append(" at ")
-                                                            .bold().append(connectionConfig.driverUrl()).boldOff();
-
-        if (!connectionConfig.username().isEmpty()) {
-            welcomeMessage = welcomeMessage
-                    .append(" as user ")
-                    .bold().append(connectionConfig.username()).boldOff();
-        }
-
-        return welcomeMessage
-                .append(".\nType ")
-                .bold().append(Help.COMMAND_NAME).boldOff()
-                .append(" for a list of available commands or ")
-                .bold().append(Exit.COMMAND_NAME).boldOff()
-                .append(" to exit the shell.")
-                .append("\nNote that Cypher queries must end with a ")
-                .bold().append("semicolon.").boldOff().formattedString();
-    }
-
     void startShell(@Nonnull CliArgs cliArgs) {
         if (cliArgs.getVersion()) {
             out.println("Cypher-Shell " + Build.version());
@@ -97,13 +67,13 @@ public class Main {
             connectInteractively(shell, connectionConfig);
 
             // Construct shellrunner after connecting, due to interrupt handling
-            ShellRunner shellRunner = ShellRunner.getShellRunner(cliArgs, shell, logger);
+            ShellRunner shellRunner = ShellRunner.getShellRunner(cliArgs, shell, logger, connectionConfig);
 
             CommandHelper commandHelper = new CommandHelper(logger, shellRunner.getHistorian(), shell);
 
             shell.setCommandHelper(commandHelper);
 
-            int code = shellRunner.runUntilEnd(getWelcomeMessage(connectionConfig, shell.getServerVersion()));
+            int code = shellRunner.runUntilEnd();
             System.exit(code);
         } catch (Throwable e) {
             logger.printError(e);

--- a/cypher-shell/src/main/java/org/neo4j/shell/UserMessagesHandler.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/UserMessagesHandler.java
@@ -1,0 +1,49 @@
+package org.neo4j.shell;
+
+import org.neo4j.shell.commands.Exit;
+import org.neo4j.shell.commands.Help;
+import org.neo4j.shell.log.AnsiFormattedText;
+
+import javax.annotation.Nonnull;
+
+public class UserMessagesHandler {
+    private ConnectionConfig connectionConfig;
+    private String serverVersion;
+
+    public UserMessagesHandler(@Nonnull ConnectionConfig connectionConfig, @Nonnull String serverVersion) {
+        this.connectionConfig = connectionConfig;
+        this.serverVersion = serverVersion;
+    }
+
+    @Nonnull
+    public String getWelcomeMessage() {
+        String neo4j = "Neo4j";
+        if (!serverVersion.isEmpty()) {
+            neo4j += " " + serverVersion;
+        }
+        AnsiFormattedText welcomeMessage = AnsiFormattedText.from("Connected to ")
+                                                            .append(neo4j)
+                                                            .append(" at ")
+                                                            .bold().append(connectionConfig.driverUrl()).boldOff();
+
+        if (!connectionConfig.username().isEmpty()) {
+            welcomeMessage = welcomeMessage
+                    .append(" as user ")
+                    .bold().append(connectionConfig.username()).boldOff();
+        }
+
+        return welcomeMessage
+                .append(".\nType ")
+                .bold().append(Help.COMMAND_NAME).boldOff()
+                .append(" for a list of available commands or ")
+                .bold().append(Exit.COMMAND_NAME).boldOff()
+                .append(" to exit the shell.")
+                .append("\nNote that Cypher queries must end with a ")
+                .bold().append("semicolon.").boldOff().formattedString();
+    }
+
+    @Nonnull
+    public String getExitMessage() {
+        return AnsiFormattedText.s().append("\nBye!").formattedString();
+    }
+}

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/InteractiveShellRunner.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/InteractiveShellRunner.java
@@ -5,6 +5,7 @@ import org.neo4j.shell.Historian;
 import org.neo4j.shell.ShellRunner;
 import org.neo4j.shell.StatementExecuter;
 import org.neo4j.shell.TransactionHandler;
+import org.neo4j.shell.UserMessagesHandler;
 import org.neo4j.shell.commands.Exit;
 import org.neo4j.shell.exception.ExitException;
 import org.neo4j.shell.exception.NoMoreInputException;
@@ -40,13 +41,16 @@ public class InteractiveShellRunner implements ShellRunner, SignalHandler {
     private final StatementParser statementParser;
     private final TransactionHandler txHandler;
     private final StatementExecuter executer;
+    private final UserMessagesHandler userMessagesHandler;
 
     public InteractiveShellRunner(@Nonnull StatementExecuter executer,
                                   @Nonnull TransactionHandler txHandler,
                                   @Nonnull Logger logger,
                                   @Nonnull StatementParser statementParser,
                                   @Nonnull InputStream inputStream,
-                                  @Nonnull File historyFile) throws IOException {
+                                  @Nonnull File historyFile,
+                                  @Nonnull UserMessagesHandler userMessagesHandler) throws IOException {
+        this.userMessagesHandler = userMessagesHandler;
         this.currentyExecuting = new AtomicBoolean(false);
         this.executer = executer;
         this.txHandler = txHandler;
@@ -70,11 +74,11 @@ public class InteractiveShellRunner implements ShellRunner, SignalHandler {
     }
 
     @Override
-    public int runUntilEnd(@Nonnull String welcomeMessage) {
+    public int runUntilEnd() {
         int exitCode = 0;
         boolean running = true;
 
-        logger.printIfVerbose(welcomeMessage);
+        logger.printIfVerbose(userMessagesHandler.getWelcomeMessage());
 
         while (running) {
             try {
@@ -95,6 +99,7 @@ public class InteractiveShellRunner implements ShellRunner, SignalHandler {
                 currentyExecuting.set(false);
             }
         }
+        logger.printIfVerbose(userMessagesHandler.getExitMessage());
         return exitCode;
     }
 

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/NonInteractiveShellRunner.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/NonInteractiveShellRunner.java
@@ -40,7 +40,7 @@ public class NonInteractiveShellRunner implements ShellRunner {
     }
 
     @Override
-    public int runUntilEnd(@Nonnull String welcomeMessage) {
+    public int runUntilEnd() {
         List<String> statements;
         try {
             new BufferedReader(new InputStreamReader(inputStream))

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/StringShellRunner.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/StringShellRunner.java
@@ -30,7 +30,7 @@ public class StringShellRunner implements ShellRunner {
     }
 
     @Override
-    public int runUntilEnd(@Nonnull String welcomeMessage) {
+    public int runUntilEnd() {
         int exitCode = 0;
         try {
             executer.execute(cypher.trim());

--- a/cypher-shell/src/main/java/org/neo4j/shell/commands/Exit.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/commands/Exit.java
@@ -57,9 +57,6 @@ public class Exit implements Command {
     public void execute(@Nonnull final String argString) throws ExitException, CommandException {
         simpleArgParse(argString, 0, COMMAND_NAME, getUsage());
 
-        logger.printOut("Exiting. Bye bye.");
-
         throw new ExitException(0);
     }
-
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
@@ -242,7 +242,9 @@ public class CypherShellTest {
     public void specifyingACypherStringShouldGiveAStringRunner() throws IOException {
         CliArgs cliArgs = CliArgHelper.parse("MATCH (n) RETURN n");
 
-        ShellRunner shellRunner = ShellRunner.getShellRunner(cliArgs, offlineTestShell, logger);
+        ConnectionConfig connectionConfig = mock(ConnectionConfig.class);
+
+        ShellRunner shellRunner = ShellRunner.getShellRunner(cliArgs, offlineTestShell, logger, connectionConfig);
 
         if (!(shellRunner instanceof StringShellRunner)) {
             fail("Expected a different runner than: " + shellRunner.getClass().getSimpleName());

--- a/cypher-shell/src/test/java/org/neo4j/shell/MainTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/MainTest.java
@@ -22,8 +22,6 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.neo4j.shell.Main.getWelcomeMessage;
 
 public class MainTest {
 
@@ -227,16 +225,5 @@ public class MainTest {
 
         verify(printStream).println(argument.capture());
         assertTrue(argument.getValue().matches("Cypher-Shell \\d+\\.\\d+\\.\\d+.*"));
-    }
-
-    @Test
-    public void welcomeMessageTest() {
-        when(connectionConfig.username()).thenReturn("bob");
-        when(connectionConfig.driverUrl()).thenReturn("bolt://some.place.com:99");
-
-        assertEquals("Connected to Neo4j 3.1.0-Beta99 at @|BOLD bolt://some.place.com:99|@ as user @|BOLD bob|@.\n" +
-                        "Type @|BOLD :help|@ for a list of available commands or @|BOLD :exit|@ to exit the shell.\n" +
-                        "Note that Cypher queries must end with a @|BOLD semicolon.|@",
-                getWelcomeMessage(connectionConfig, "3.1.0-Beta99"));
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/ShellRunnerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/ShellRunnerTest.java
@@ -8,6 +8,7 @@ import org.neo4j.shell.cli.InteractiveShellRunner;
 import org.neo4j.shell.cli.NonInteractiveShellRunner;
 import org.neo4j.shell.log.Logger;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
@@ -18,6 +19,7 @@ import static org.neo4j.shell.ShellRunner.isInputInteractive;
 public class ShellRunnerTest {
     @Rule
     public final ExpectedException thrown = ExpectedException.none();
+    private final ConnectionConfig connectionConfig = mock(ConnectionConfig.class);
 
     @Test
     public void isInputInteractiveThrowsOnWindows() throws Exception {
@@ -36,7 +38,7 @@ public class ShellRunnerTest {
     @Test
     public void inputIsInteractiveByDefaultOnWindows() throws Exception {
         assumeTrue(System.getProperty("os.name", "").toLowerCase().contains("windows"));
-        ShellRunner runner = getShellRunner(new CliArgs(), mock(CypherShell.class), mock(Logger.class));
+        ShellRunner runner = getShellRunner(new CliArgs(), mock(CypherShell.class), mock(Logger.class), connectionConfig);
         assertTrue("Should be interactive shell runner by default on windows",
                 runner instanceof InteractiveShellRunner);
     }
@@ -45,7 +47,7 @@ public class ShellRunnerTest {
     public void inputIsNonInteractiveIfForced() throws Exception {
         CliArgs args = new CliArgs();
         args.setNonInteractive(true);
-        ShellRunner runner = getShellRunner(args, mock(CypherShell.class), mock(Logger.class));
+        ShellRunner runner = getShellRunner(args, mock(CypherShell.class), mock(Logger.class), connectionConfig);
         assertTrue("Should be non-interactive shell runner when forced",
                 runner instanceof NonInteractiveShellRunner);
     }

--- a/cypher-shell/src/test/java/org/neo4j/shell/UserMessagesHandlerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/UserMessagesHandlerTest.java
@@ -1,0 +1,32 @@
+package org.neo4j.shell;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class UserMessagesHandlerTest {
+    private final ConnectionConfig connectionConfig = mock(ConnectionConfig.class);
+
+    @Test
+    public void welcomeMessageTest() {
+        when(connectionConfig.username()).thenReturn("bob");
+        when(connectionConfig.driverUrl()).thenReturn("bolt://some.place.com:99");
+
+        UserMessagesHandler userMessagesHandler = new UserMessagesHandler(connectionConfig, "3.1.0-Beta99");
+        assertEquals("Connected to Neo4j 3.1.0-Beta99 at @|BOLD bolt://some.place.com:99|@ as user @|BOLD bob|@.\n" +
+                        "Type @|BOLD :help|@ for a list of available commands or @|BOLD :exit|@ to exit the shell.\n" +
+                        "Note that Cypher queries must end with a @|BOLD semicolon.|@",
+                userMessagesHandler.getWelcomeMessage());
+    }
+
+    @Test
+    public void exitMessageTest() {
+        when(connectionConfig.username()).thenReturn("bob");
+        when(connectionConfig.driverUrl()).thenReturn("bolt://some.place.com:99");
+
+        UserMessagesHandler userMessagesHandler = new UserMessagesHandler(connectionConfig, "3.1.0-Beta99");
+        assertEquals("\nBye!", userMessagesHandler.getExitMessage());
+    }
+}

--- a/cypher-shell/src/test/java/org/neo4j/shell/cli/NonInteractiveShellRunnerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/cli/NonInteractiveShellRunnerTest.java
@@ -51,7 +51,7 @@ public class NonInteractiveShellRunnerTest {
                 cmdExecuter,
                 logger, statementParser,
                 new ByteArrayInputStream(input.getBytes()));
-        int code = runner.runUntilEnd("");
+        int code = runner.runUntilEnd();
 
         assertEquals("Exit code incorrect", 0, code);
         verify(logger, times(0)).printError(anyString());
@@ -69,7 +69,7 @@ public class NonInteractiveShellRunnerTest {
                 logger, statementParser,
                 new ByteArrayInputStream(input.getBytes()));
 
-        int code = runner.runUntilEnd("");
+        int code = runner.runUntilEnd();
 
         assertEquals("Exit code incorrect", 1, code);
         verify(logger).printError(badLineError);
@@ -87,7 +87,7 @@ public class NonInteractiveShellRunnerTest {
                 logger, statementParser,
                 new ByteArrayInputStream(input.getBytes()));
 
-        int code = runner.runUntilEnd("");
+        int code = runner.runUntilEnd();
 
         assertEquals("Exit code incorrect", 1, code);
         verify(logger, times(2)).printError(badLineError);
@@ -111,7 +111,7 @@ public class NonInteractiveShellRunnerTest {
                 new ByteArrayInputStream(input.getBytes()));
 
         // when
-        int code = runner.runUntilEnd("");
+        int code = runner.runUntilEnd();
 
         // then
         assertEquals(1, code);
@@ -134,7 +134,7 @@ public class NonInteractiveShellRunnerTest {
         // when
         doThrow(new ExitException(99)).when(cmdExecuter).execute(anyString());
 
-        int code = runner.runUntilEnd("");
+        int code = runner.runUntilEnd();
 
         // then
         assertEquals(99, code);

--- a/cypher-shell/src/test/java/org/neo4j/shell/cli/StringShellRunnerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/cli/StringShellRunnerTest.java
@@ -39,7 +39,7 @@ public class StringShellRunnerTest {
         String cypherString = "nonsense string";
         StringShellRunner runner = new StringShellRunner(CliArgHelper.parse(cypherString), statementExecuter, logger);
 
-        int code = runner.runUntilEnd("");
+        int code = runner.runUntilEnd();
 
         assertEquals("Wrong exit code", 0, code);
         verify(statementExecuter).execute("nonsense string");
@@ -53,7 +53,7 @@ public class StringShellRunnerTest {
 
         StringShellRunner runner = new StringShellRunner(CliArgHelper.parse("nan anana"), statementExecuter, logger);
 
-        int code = runner.runUntilEnd("");
+        int code = runner.runUntilEnd();
 
         assertEquals("Wrong exit code", 1, code);
         verify(logger).printError(kaboom);

--- a/cypher-shell/src/test/java/org/neo4j/shell/commands/ExitTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/commands/ExitTest.java
@@ -41,7 +41,5 @@ public class ExitTest {
         thrown.expect(ExitException.class);
 
         cmd.execute("");
-
-        verify(logger).printOut("Exiting. Bye bye.");
     }
 }


### PR DESCRIPTION
WelcomeMessage and ExitMessage are only displayed in Interactive Shell
## Interactive Shell
```
neo4j> match (n) return n;
n
(:Foo {name: "Bar"})
neo4j> :exit

Bye!
```

## Non Interactive Shell
```
cat <<EOF | cypher-shell/build/install/cypher-shell/cypher-shell -uneo4j -pneo
> match (n) return n;
> EOF
n
(:Foo {name: "Bar"})
```

## String Shell
```
cypher-shell/build/install/cypher-shell/cypher-shell -uneo4j -pneo "match (n) return n"
n
(:Foo {name: "Bar"})
```