### PR TITLE
empty password will give relevant error.

### DIFF
--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellFailureIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellFailureIntegrationTest.java
@@ -1,0 +1,37 @@
+package org.neo4j.shell.commands;
+
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.neo4j.shell.ConnectionConfig;
+import org.neo4j.shell.CypherShell;
+import org.neo4j.shell.cli.Format;
+import org.neo4j.shell.exception.CommandException;
+import org.neo4j.shell.log.Logger;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+public class CypherShellFailureIntegrationTest {
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    private Logger logger = mock(Logger.class);
+    private CypherShell shell;
+
+    @Before
+    public void setUp() throws Exception {
+        doReturn(Format.VERBOSE).when(logger).getFormat();
+
+        shell = new CypherShell(logger);
+    }
+
+    @Test
+    public void cypherWithNoPasswordShouldReturnValidError() throws CommandException {
+        thrown.expectMessage("The client is unauthorized due to authentication failure.");
+
+        shell.connect(new ConnectionConfig(logger, "bolt://", "localhost", 7687, "neo4j", "", true));
+    }
+}

--- a/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
@@ -93,12 +93,7 @@ public class BoltStateHandler implements TransactionHandler, Connector {
             throw new CommandException("Already connected");
         }
 
-        final AuthToken authToken;
-        if (!connectionConfig.username().isEmpty() && !connectionConfig.password().isEmpty()) {
-            authToken = AuthTokens.basic(connectionConfig.username(), connectionConfig.password());
-        } else {
-            authToken = null;
-        }
+        final AuthToken authToken = AuthTokens.basic(connectionConfig.username(), connectionConfig.password());
 
         try {
             driver = getDriver(connectionConfig, authToken);

--- a/cypher-shell/src/test/java/org/neo4j/shell/state/BoltStateHandlerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/state/BoltStateHandlerTest.java
@@ -86,15 +86,6 @@ public class BoltStateHandlerTest {
         assertEquals("9.4.1-ALPHA", handler.getServerVersion());
     }
 
-    private void stubVersion(StatementResult resultMock, String value) {
-        ResultSummary resultSummary = mock(ResultSummary.class);
-        ServerInfo serverInfo = mock(ServerInfo.class);
-
-        when(resultSummary.server()).thenReturn(serverInfo);
-        when(serverInfo.version()).thenReturn(value);
-        when(resultMock.summary()).thenReturn(resultSummary);
-    }
-
     @Test
     public void closeTransactionAfterRollback() throws CommandException {
         boltStateHandler.connect();
@@ -290,6 +281,15 @@ public class BoltStateHandlerTest {
     /**
      * Bolt state with faked bolt interactions
      */
+    private void stubVersion(StatementResult resultMock, String value) {
+        ResultSummary resultSummary = mock(ResultSummary.class);
+        ServerInfo serverInfo = mock(ServerInfo.class);
+
+        when(resultSummary.server()).thenReturn(serverInfo);
+        when(serverInfo.version()).thenReturn(value);
+        when(resultMock.summary()).thenReturn(resultSummary);
+    }
+
     private static class OfflineBoltStateHandler extends BoltStateHandler {
 
         public OfflineBoltStateHandler(Driver driver) {


### PR DESCRIPTION
The error message for empty password has been fixed.

```
cypher-shell/build/install/cypher-shell/cypher-shell
username: neo4j
password:
The client is unauthorized due to authentication failure.
```
