### PR TITLE
Add example of file piping to help text

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgHelper.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgHelper.java
@@ -11,12 +11,13 @@ import net.sourceforge.argparse4j.inf.ArgumentParserException;
 import net.sourceforge.argparse4j.inf.MutuallyExclusiveGroup;
 import net.sourceforge.argparse4j.inf.Namespace;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.PrintWriter;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
+import static java.lang.String.format;
 import static org.neo4j.shell.cli.FailBehavior.FAIL_AT_END;
 import static org.neo4j.shell.cli.FailBehavior.FAIL_FAST;
 
@@ -107,10 +108,15 @@ public class CliArgHelper {
         return matcher;
     }
 
-    private static ArgumentParser setupParser() {
-        ArgumentParser parser = ArgumentParsers.newArgumentParser("cypher-shell")
-                .defaultHelp(true)
-                .description("A command line shell where you can execute Cypher against an instance of Neo4j");
+    private static ArgumentParser setupParser()
+    {
+        ArgumentParser parser = ArgumentParsers.newArgumentParser( "cypher-shell" ).defaultHelp( true ).description(
+                format( "A command line shell where you can execute Cypher against an instance of Neo4j. " +
+                        "By default the shell is interactive but you can use it for scripting by passing cypher " +
+                        "directly on the command line or by piping a file with cypher statements (requires Powershell on Windows)." +
+                        "%n%n" +
+                        "example of piping a file:%n" +
+                        "  cat some-cypher.txt | cypher-shell" ) );
 
         ArgumentGroup connGroup = parser.addArgumentGroup("connection arguments");
         connGroup.addArgument("-a", "--address")


### PR DESCRIPTION
New help text:

```
usage: cypher-shell [-h] [-a ADDRESS] [-u USERNAME] [-p PASSWORD]
                    [--encryption {true,false}] [--format {verbose,plain}]
                    [--debug] [--non-interactive] [-v] [--fail-fast |
                    --fail-at-end] [cypher]

A command line shell where  you  can  execute  Cypher  against an instance of
Neo4j. By default the shell is interactive  but  you can use it for scripting
by passing cypher directly on  the  command  line  or  by  piping a file with
cypher statements (requires Powershell on Windows).

example of piping a file:
  cat some-cypher.txt | cypher-shell

positional arguments:
  cypher                 an optional string  of  cypher  to  execute and then
                         exit

optional arguments:
  -h, --help             show this help message and exit
  --fail-fast            exit and report failure on  first error when reading
                         from file (this is the default behavior)
  --fail-at-end          exit and  report  failures  at  end  of  input  when
                         reading from file
  --format {verbose,plain}
                         desired  output  format,  verbose(default)  displays
                         statistics,  plain  only   displays  data  (default:
                         verbose)
  --debug                print additional debug information (default: false)
  --non-interactive      force non-interactive  mode,  only  useful  if auto-
                         detection fails (like on Windows) (default: false)
  -v, --version          print version  of  cypher-shell  and  exit (default:
                         false)

connection arguments:
  -a ADDRESS, --address ADDRESS
                         address and  port  to  connect  to  (default:  bolt:
                         //localhost:7687)
  -u USERNAME, --username USERNAME
                         username to connect as. Can  also be specified using
                         environment variable NEO4J_USERNAME (default: )
  -p PASSWORD, --password PASSWORD
                         password to  connect  with.  Can  also  be specified
                         using environment variable  NEO4J_PASSWORD (default:
                         )
  --encryption {true,false}
                         whether  the   connection   to   Neo4j   should   be
                         encrypted;   must   be   consistent   with   Neo4j's
                         configuration (default: true)
```

Old help text (with arguments left out):

```
usage: cypher-shell [-h] [-a ADDRESS] [-u USERNAME] [-p PASSWORD]
                    [--encryption {true,false}] [--format {verbose,plain}]
                    [--debug] [--non-interactive] [-v] [--fail-fast |
                    --fail-at-end] [cypher]

A command line shell where  you  can  execute  Cypher  against an instance of
Neo4j

positional arguments:
[...]
```