### PR TITLE
Fixed handling of pipes on Windows

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/system/Utils.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/system/Utils.java
@@ -1,0 +1,14 @@
+package org.neo4j.shell.system;
+
+/**
+ * Utility functions
+ */
+public class Utils {
+    /**
+     * @return true if running on Windows, false if not or if os could not be determined.
+     */
+    public static boolean isWindows() {
+        String osName = System.getProperty("os.name");
+        return osName != null && osName.toLowerCase().contains("windows");
+    }
+}

--- a/cypher-shell/src/test/java/org/neo4j/shell/ShellRunnerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/ShellRunnerTest.java
@@ -4,44 +4,17 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.neo4j.shell.cli.CliArgs;
-import org.neo4j.shell.cli.InteractiveShellRunner;
 import org.neo4j.shell.cli.NonInteractiveShellRunner;
 import org.neo4j.shell.log.Logger;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
 import static org.mockito.Mockito.mock;
 import static org.neo4j.shell.ShellRunner.getShellRunner;
-import static org.neo4j.shell.ShellRunner.isInputInteractive;
 
 public class ShellRunnerTest {
     @Rule
     public final ExpectedException thrown = ExpectedException.none();
     private final ConnectionConfig connectionConfig = mock(ConnectionConfig.class);
-
-    @Test
-    public void isInputInteractiveThrowsOnWindows() throws Exception {
-        assertFalse("No result should be returned on Windows",
-                isInputInteractive("Windows 7").isPresent());
-    }
-
-    @Test
-    public void isInputInteractiveDoesNotThrowOnNonWindows() throws Exception {
-        assertTrue(isInputInteractive(null).isPresent());
-        assertTrue(isInputInteractive("").isPresent());
-        assertTrue(isInputInteractive("Linux").isPresent());
-        assertTrue(isInputInteractive("BeOS").isPresent());
-    }
-
-    @Test
-    public void inputIsInteractiveByDefaultOnWindows() throws Exception {
-        assumeTrue(System.getProperty("os.name", "").toLowerCase().contains("windows"));
-        ShellRunner runner = getShellRunner(new CliArgs(), mock(CypherShell.class), mock(Logger.class), connectionConfig);
-        assertTrue("Should be interactive shell runner by default on windows",
-                runner instanceof InteractiveShellRunner);
-    }
 
     @Test
     public void inputIsNonInteractiveIfForced() throws Exception {


### PR DESCRIPTION
Windows was previously hard-coded to always use the interactive shell
runner. After som additional testing this turned out to be
unnecessary. Piping in Powershell works as expected and no different
in terms of detection in Java as previously thought.

This removes most of the special cases for Windows. The only remaining
part is that we avoid calling JLine's `isatty` method on Windows
because it seemed to block forever. It would always return false on
Windows anyway.

Also noticed and fixed a related issue. When input is redirected, it's
not possible to prompt for username and password when connected
because input has of course been redirected and there will be no way
for the user to actually type in a username/password. Thus when
non-interactive, connection will always fail and never prompt.

## Windows piping demonstration

![piping](https://cloud.githubusercontent.com/assets/223655/23943114/a3736b68-096e-11e7-88fe-42671b81debb.png)


Where the file which was piped contained:

```
merge (n {name: "jonas"}) 
return n;
```

## Windows interactive still works

This demonstrates that the interactive detection actually works on Windows

![interactive](https://cloud.githubusercontent.com/assets/223655/23943128/af615656-096e-11e7-9539-ea4841fbc223.png)

