### PR TITLE
automatically select output format when terminal is interactive or not

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ gitdescribe := $(shell git describe --tags --match [0-9]*)
 lasttag := $(shell git describe --tags --match [0-9]* --abbrev=0)
 
 version ?= $(lasttag)
-versionlabel = $(shell echo ${version} | awk '{ sub("^[0-9]+\.[0-9]+\.[0-9]+-?", "", $$1); print }')
+versionlabel = $(shell echo ${version} | awk '{ sub("^[0-9]+.[0-9]+.[0-9]+-?", "", $$1); print }')
 versionnumber = $(shell echo ${version} | awk '{ sub("-.*$$", "", $$1); print }')
 
 pkgversion ?= 1

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgHelper.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgHelper.java
@@ -148,10 +148,13 @@ public class CliArgHelper {
         parser.setDefault("fail-behavior", FAIL_FAST);
 
         parser.addArgument("--format")
-                .help("desired output format, verbose(default) displays statistics, plain only displays data")
+                .help("desired output format, verbose displays results in tabular format and prints statistics, " +
+                        "plain displays data with minimal formatting")
                 .choices(new CollectionArgumentChoice<>(
-                        Format.VERBOSE.name().toLowerCase(), Format.PLAIN.name().toLowerCase()))
-                .setDefault(Format.VERBOSE.name().toLowerCase());
+                        Format.AUTO.name().toLowerCase(),
+                        Format.VERBOSE.name().toLowerCase(),
+                        Format.PLAIN.name().toLowerCase()))
+                .setDefault(Format.AUTO.name().toLowerCase());
 
         parser.addArgument("--debug")
                 .help("print additional debug information")

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgs.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgs.java
@@ -11,7 +11,7 @@ public class CliArgs {
     private String username = "";
     private String password = "";
     private FailBehavior failBehavior = FailBehavior.FAIL_FAST;
-    private Format format = Format.VERBOSE;
+    private Format format = Format.AUTO;
     private Optional<String> cypher = Optional.empty();
     private boolean encryption;
     private boolean debugMode;

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/Format.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/Format.java
@@ -1,16 +1,25 @@
 package org.neo4j.shell.cli;
 
+import javax.annotation.Nonnull;
+
+import static org.neo4j.shell.ShellRunner.isOutputInteractive;
+
 public enum Format {
+    // Will select depending on if stdout is redirected or not
+    AUTO,
     // Intended for human consumption
     VERBOSE,
     // Intended for machine consumption (nothing except data is printed
     PLAIN;
     // TODO JSON, strictly intended for machine consumption with data formatted in JSON
 
-    public static Format parse(String format) {
+    public static Format parse(@Nonnull String format) {
         if (format.equalsIgnoreCase(PLAIN.name())) {
             return PLAIN;
+        } else if (format.equalsIgnoreCase( VERBOSE.name() )) {
+            return VERBOSE;
+        } else {
+            return isOutputInteractive() ? VERBOSE : PLAIN;
         }
-        return VERBOSE;
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/cli/CliArgsTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/cli/CliArgsTest.java
@@ -61,10 +61,13 @@ public class CliArgsTest {
     @Test
     public void setFormat() throws Exception {
         // default
-        assertEquals(Format.VERBOSE, cliArgs.getFormat());
+        assertEquals(Format.AUTO, cliArgs.getFormat());
 
         cliArgs.setFormat(Format.PLAIN);
         assertEquals(Format.PLAIN, cliArgs.getFormat());
+
+        cliArgs.setFormat(Format.VERBOSE);
+        assertEquals(Format.VERBOSE, cliArgs.getFormat());
     }
 
     @Test


### PR DESCRIPTION
New help text (note `--format`):

```
usage: cypher-shell [-h] [-a ADDRESS] [-u USERNAME] [-p PASSWORD]
                    [--encryption {true,false}]
                    [--format {auto,verbose,plain}] [--debug]
                    [--non-interactive] [-v] [--fail-fast | --fail-at-end]
                    [cypher]

A command line shell where  you  can  execute  Cypher  against an instance of
Neo4j. By default the shell is interactive  but  you can use it for scripting
by passing cypher directly on  the  command  line  or  by  piping a file with
cypher statements (requires Powershell on Windows).

example of piping a file:
  cat some-cypher.txt | cypher-shell

positional arguments:
  cypher                 an optional string  of  cypher  to  execute and then
                         exit

optional arguments:
  -h, --help             show this help message and exit
  --fail-fast            exit and report failure on  first error when reading
                         from file (this is the default behavior)
  --fail-at-end          exit and  report  failures  at  end  of  input  when
                         reading from file
  --format {auto,verbose,plain}
                         desired output format,  verbose  displays results in
                         tabular  format   and   prints   statistics,   plain
                         displays  data  with  minimal  formatting  (default:
                         auto)
  --debug                print additional debug information (default: false)
  --non-interactive      force non-interactive  mode,  only  useful  if auto-
                         detection fails (like on Windows) (default: false)
  -v, --version          print version  of  cypher-shell  and  exit (default:
                         false)

connection arguments:
  -a ADDRESS, --address ADDRESS
                         address and  port  to  connect  to  (default:  bolt:
                         //localhost:7687)
  -u USERNAME, --username USERNAME
                         username to connect as. Can  also be specified using
                         environment variable NEO4J_USERNAME (default: )
  -p PASSWORD, --password PASSWORD
                         password to  connect  with.  Can  also  be specified
                         using environment variable  NEO4J_PASSWORD (default:
                         )
  --encryption {true,false}
                         whether  the   connection   to   Neo4j   should   be
                         encrypted;   must   be   consistent   with   Neo4j's
                         configuration (default: true)
```