### PR TITLE
Need to tell dpkg that we split the package.

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -9,5 +9,7 @@ Homepage: http://neo4j.org/
 Package: cypher-shell
 Architecture: all
 Depends: ${misc:Depends}, openjdk-8-jre-headless | java8-runtime-headless
+Replaces: neo4j (<< 3.1.4), neo4j-enterprise (<< 3.1.4)
+Breaks: neo4j (<< 3.1.4), neo4j-enterprise (<< 3.1.4)
 Description: command line shell for neo4j
  Cypher-shell is a command line shell for Neo4j.


### PR DESCRIPTION
Without this, upgrading `neo4j` or `neo4j-enterprise` to version 3.1.4 or later will fail, because the `cypher-shell` package tries to overwrite files that are owned by the old version of those packages.

See Debian Policy §7.6.1 for details:
  https://www.debian.org/doc/debian-policy/ch-relationships.html#s-replaces
