### PR TITLE
Fix periodic commit statements

### DIFF
--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellPlainIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellPlainIntegrationTest.java
@@ -1,0 +1,58 @@
+package org.neo4j.shell.commands;
+
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
+import org.neo4j.shell.ConnectionConfig;
+import org.neo4j.shell.CypherShell;
+import org.neo4j.shell.cli.Format;
+import org.neo4j.shell.exception.CommandException;
+import org.neo4j.shell.log.Logger;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class CypherShellPlainIntegrationTest {
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    private Logger logger = mock(Logger.class);
+    private CypherShell shell;
+
+    @Before
+    public void setUp() throws Exception {
+        doReturn(Format.PLAIN).when(logger).getFormat();
+        shell = new CypherShell(logger);
+        shell.connect(new ConnectionConfig("bolt://", "localhost", 7687, "neo4j", "neo", true));
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        shell.execute("MATCH (n) DETACH DELETE (n)");
+    }
+
+    @Test
+    public void periodicCommitWorks() throws CommandException {
+        shell.execute("USING PERIODIC COMMIT\n" +
+                "LOAD CSV FROM 'https://neo4j.com/docs/cypher-refcard/3.2/csv/artists.csv' AS line\n" +
+                "CREATE (:Artist {name: line[1], year: toInt(line[2])});");
+
+        shell.execute("MATCH (a:Artist) WHERE a.name = 'Europe' RETURN a.name");
+
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(logger, times(2)).printOut(captor.capture());
+
+        List<String> queryResult = captor.getAllValues();
+        assertThat(queryResult.get(1), containsString("Europe"));
+    }
+}

--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellVerboseIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellVerboseIntegrationTest.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -26,7 +25,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-public class CypherShellIntegrationTest {
+public class CypherShellVerboseIntegrationTest {
     @Rule
     public final ExpectedException thrown = ExpectedException.none();
 

--- a/cypher-shell/src/test/java/org/neo4j/shell/state/BoltStateHandlerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/state/BoltStateHandlerTest.java
@@ -4,6 +4,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.neo4j.driver.v1.AccessMode;
 import org.neo4j.driver.v1.AuthToken;
 import org.neo4j.driver.v1.Config;
 import org.neo4j.driver.v1.Driver;
@@ -12,6 +13,7 @@ import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.Statement;
 import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.Value;
+import org.neo4j.driver.v1.exceptions.SessionExpiredException;
 import org.neo4j.driver.v1.summary.ResultSummary;
 import org.neo4j.driver.v1.summary.ServerInfo;
 import org.neo4j.shell.ConnectionConfig;
@@ -40,6 +42,7 @@ import static org.mockito.Mockito.anyObject;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -53,7 +56,7 @@ public class BoltStateHandlerTest {
 
     @Before
     public void setup() {
-        when(mockDriver.session()).thenReturn(new FakeSession());
+        when(mockDriver.session(any(), any())).thenReturn(new FakeSession());
         doReturn(System.out).when(logger).getOutputStream();
     }
 
@@ -71,7 +74,7 @@ public class BoltStateHandlerTest {
                 super.apply(uri, authToken, config);
                 return new FakeDriver() {
                     @Override
-                    public Session session() {
+                    public Session session(AccessMode accessMode, String bookmark) {
                         return new FakeSession();
                     }
                 };
@@ -277,6 +280,36 @@ public class BoltStateHandlerTest {
     }
 
     @Test
+    public void triesAgainOnSessionExpired() throws Exception {
+        Session sessionMock = mock(Session.class);
+        StatementResult versionMock = mock(StatementResult.class);
+        StatementResult resultMock = mock(StatementResult.class);
+        Record recordMock = mock(Record.class);
+        Value valueMock = mock(Value.class);
+
+        Driver driverMock = stubVersionInAnOpenSession(versionMock, sessionMock, "neo4j-version");
+
+        when(resultMock.list()).thenReturn(asList(recordMock));
+
+        when(valueMock.toString()).thenReturn("999");
+        when(recordMock.get(0)).thenReturn(valueMock);
+        when(sessionMock.run(any(Statement.class)))
+                .thenThrow(new SessionExpiredException("leaderswitch"))
+                .thenReturn(resultMock);
+
+        OfflineBoltStateHandler boltStateHandler = new OfflineBoltStateHandler(driverMock);
+
+        boltStateHandler.connect();
+        BoltResult boltResult = boltStateHandler.runCypher("RETURN 999",
+                new HashMap<>()).get();
+
+        verify(driverMock, times(2)).session(any(), any());
+        verify(sessionMock, times(2)).run(any(Statement.class));
+
+        assertEquals("999", boltResult.getRecords().get(0).get(0).toString());
+    }
+
+    @Test
     public void shouldExecuteInSessionByDefault() throws CommandException {
         boltStateHandler.connect();
 
@@ -363,7 +396,7 @@ public class BoltStateHandlerTest {
 
         when(sessionMock.isOpen()).thenReturn(true);
         when(sessionMock.run("RETURN 1")).thenReturn(versionMock);
-        when(driverMock.session()).thenReturn(sessionMock);
+        when(driverMock.session(any(), any())).thenReturn(sessionMock);
 
         return driverMock;
     }

--- a/cypher-shell/src/test/java/org/neo4j/shell/state/BoltStateHandlerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/state/BoltStateHandlerTest.java
@@ -9,6 +9,7 @@ import org.neo4j.driver.v1.Config;
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.Session;
+import org.neo4j.driver.v1.Statement;
 import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.summary.ResultSummary;
@@ -34,6 +35,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.anyObject;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -251,17 +253,17 @@ public class BoltStateHandlerTest {
     public void shouldRunCypherQuery() throws CommandException {
         Session sessionMock = mock(Session.class);
         StatementResult versionMock = mock(StatementResult.class);
-        BoltResult resultMock = mock(BoltResult.class);
+        StatementResult resultMock = mock(StatementResult.class);
         Record recordMock = mock(Record.class);
         Value valueMock = mock(Value.class);
 
         Driver driverMock = stubVersionInAnOpenSession(versionMock, sessionMock, "neo4j-version");
 
-        when(resultMock.getRecords()).thenReturn(asList(recordMock));
+        when(resultMock.list()).thenReturn(asList(recordMock));
 
         when(valueMock.toString()).thenReturn("999");
         when(recordMock.get(0)).thenReturn(valueMock);
-        when(sessionMock.writeTransaction(anyObject())).thenReturn(asList(resultMock));
+        when(sessionMock.run(any(Statement.class))).thenReturn(resultMock);
 
         OfflineBoltStateHandler boltStateHandler = new OfflineBoltStateHandler(driverMock);
 
@@ -269,7 +271,7 @@ public class BoltStateHandlerTest {
 
         BoltResult boltResult = boltStateHandler.runCypher("RETURN 999",
                 new HashMap<>()).get();
-        verify(sessionMock).writeTransaction(anyObject());
+        verify(sessionMock).run(any(Statement.class));
 
         assertEquals("999", boltResult.getRecords().get(0).get(0).toString());
     }

--- a/cypher-shell/src/test/java/org/neo4j/shell/test/bolt/FakeDriver.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/test/bolt/FakeDriver.java
@@ -18,19 +18,19 @@ public class FakeDriver implements Driver {
 
     @Override
     public Session session(AccessMode mode) {
-        return null;
+        return new FakeSession();
     }
 
     @Override
     public Session session( String bookmark )
     {
-        return null;
+        return new FakeSession();
     }
 
     @Override
     public Session session( AccessMode mode, String bookmark )
     {
-        return null;
+        return new FakeSession();
     }
 
     @Override


### PR DESCRIPTION
Execute cypher without transaction unless BEGIN is called explicitly

Added integration test with PERIODIC COMMIT to verify this works since
it can't run inside a transaction