### PR TITLE
Fixed startup crash on Alpine Linux

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/log/AnsiLogger.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/log/AnsiLogger.java
@@ -42,7 +42,8 @@ public class AnsiLogger implements Logger {
             } else {
                 Ansi.setEnabled(false);
             }
-        } catch (UnsatisfiedLinkError t) {
+        } catch (Throwable t) {
+            // Not running on a distro with standard c library, disable Ansi.
             Ansi.setEnabled(false);
         }
     }
@@ -58,6 +59,8 @@ public class AnsiLogger implements Logger {
 
     /**
      * @return true if the shell is outputting to a TTY, false otherwise (e.g., we are writing to a file)
+     * @throws UnsatisfiedLinkError maybe if standard c library can't be found
+     * @throws NoClassDefFoundError maybe if standard c library can't be found
      */
     private static boolean isOutputInteractive() {
         return 1 == isatty(STDOUT_FILENO) && 1 == isatty(STDERR_FILENO);


### PR DESCRIPTION
This fixes the following error:

```
Exception in thread "main" java.lang.NoClassDefFoundError: Could not initialize class org.fusesource.jansi.internal.CLibrary
    at org.neo4j.shell.log.AnsiLogger.isOutputInteractive(AnsiLogger.java:63)
    at org.neo4j.shell.log.AnsiLogger.<init>(AnsiLogger.java:39)
    at org.neo4j.shell.log.AnsiLogger.<init>(AnsiLogger.java:28)
    at org.neo4j.shell.Main.startShell(Main.java:56)
    at org.neo4j.shell.Main.main(Main.java:36)
```

which occurs on distros not using libc. One such example is Alpine
Linux which is the base for Neo4j docker image. Alpine uses musl instead of libc.

Windows is another example, but that was already fixed by catching
`UnsatisfiedLinkError`. The surprise was that a different error was
thrown on Linux.