### PR TITLE
fixed non interactive shell to use plain format

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/Main.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/Main.java
@@ -1,11 +1,11 @@
 package org.neo4j.shell;
 
 import jline.console.ConsoleReader;
-
 import org.neo4j.driver.v1.exceptions.AuthenticationException;
 import org.neo4j.shell.build.Build;
 import org.neo4j.shell.cli.CliArgHelper;
 import org.neo4j.shell.cli.CliArgs;
+import org.neo4j.shell.cli.Format;
 import org.neo4j.shell.commands.CommandHelper;
 import org.neo4j.shell.exception.CommandException;
 import org.neo4j.shell.log.AnsiLogger;
@@ -53,9 +53,7 @@ public class Main {
             out.println("Cypher-Shell " + Build.version());
             return;
         }
-        Logger logger = new AnsiLogger(cliArgs.getDebugMode());
-        logger.setFormat(cliArgs.getFormat());
-
+        Logger logger = instantiateLogger(cliArgs);
         ConnectionConfig connectionConfig = new ConnectionConfig(
                 cliArgs.getScheme(),
                 cliArgs.getHost(),
@@ -82,6 +80,15 @@ public class Main {
             logger.printError(e);
             System.exit(1);
         }
+    }
+
+    private Logger instantiateLogger(@Nonnull CliArgs cliArgs) {
+        Logger logger = new AnsiLogger(cliArgs.getDebugMode());
+        logger.setFormat(cliArgs.getFormat());
+        if (cliArgs.isStringShell() && Format.AUTO.equals(cliArgs.getFormat())) {
+            logger.setFormat(Format.PLAIN);
+        }
+        return logger;
     }
 
     /**

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgs.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgs.java
@@ -154,4 +154,8 @@ public class CliArgs {
     public void setVersion(boolean version) {
         this.version = version;
     }
+
+    public boolean isStringShell() {
+        return cypher.isPresent();
+    }
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/Format.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/Format.java
@@ -2,10 +2,11 @@ package org.neo4j.shell.cli;
 
 import javax.annotation.Nonnull;
 
+import static org.neo4j.shell.ShellRunner.isInputInteractive;
 import static org.neo4j.shell.ShellRunner.isOutputInteractive;
 
 public enum Format {
-    // Will select depending on if stdout is redirected or not
+    // Will select depending based on STDOUT and STDIN redirection
     AUTO,
     // Intended for human consumption
     VERBOSE,
@@ -19,7 +20,7 @@ public enum Format {
         } else if (format.equalsIgnoreCase( VERBOSE.name() )) {
             return VERBOSE;
         } else {
-            return isOutputInteractive() ? VERBOSE : PLAIN;
+            return isInputInteractive() && isOutputInteractive() ? VERBOSE : PLAIN;
         }
     }
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/StringShellRunner.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/StringShellRunner.java
@@ -21,9 +21,8 @@ public class StringShellRunner implements ShellRunner {
                              @Nonnull Logger logger) {
         this.executer = executer;
         this.logger = logger;
-        Optional<String> cypherString = cliArgs.getCypher();
-        if (cypherString.isPresent()) {
-            this.cypher = cypherString.get();
+        if (cliArgs.isStringShell()) {
+            this.cypher = cliArgs.getCypher().get();
         } else {
             throw new NullPointerException("No cypher string specified");
         }

--- a/cypher-shell/src/test/java/org/neo4j/shell/cli/StringShellRunnerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/cli/StringShellRunnerTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.neo4j.shell.cli.CliArgHelper.parse;
 
 public class StringShellRunnerTest {
     @Rule
@@ -37,7 +38,7 @@ public class StringShellRunnerTest {
     @Test
     public void cypherShouldBePassedToRun() throws IOException, CommandException {
         String cypherString = "nonsense string";
-        StringShellRunner runner = new StringShellRunner(CliArgHelper.parse(cypherString), statementExecuter, logger);
+        StringShellRunner runner = new StringShellRunner(parse(cypherString), statementExecuter, logger);
 
         int code = runner.runUntilEnd();
 
@@ -51,7 +52,7 @@ public class StringShellRunnerTest {
         ClientException kaboom = new ClientException("Error kaboom");
         doThrow(kaboom).when(statementExecuter).execute(anyString());
 
-        StringShellRunner runner = new StringShellRunner(CliArgHelper.parse("nan anana"), statementExecuter, logger);
+        StringShellRunner runner = new StringShellRunner(parse("nan anana"), statementExecuter, logger);
 
         int code = runner.runUntilEnd();
 
@@ -62,7 +63,7 @@ public class StringShellRunnerTest {
     @Test
     public void shellRunnerHasNoHistory() throws Exception {
         // given
-        StringShellRunner runner = new StringShellRunner(CliArgHelper.parse("nan anana"), statementExecuter, logger);
+        StringShellRunner runner = new StringShellRunner(parse("nan anana"), statementExecuter, logger);
 
         // when then
         assertEquals(Historian.empty, runner.getHistorian());


### PR DESCRIPTION
Format `Plain` when you have either STDOUT or STDIN redirected
```
cat examples.cypher | cypher-shell/build/install/cypher-shell/cypher-shell -u neo4j -p neo
n
(:Movie {year: 1999, movieId: "tt0133093", title: "The Matrix"})
(:Movie:Sequel {year: 2003, movieId: "tt0234215", title: "The Matrix
Reloaded"})
(:Movie:Sequel {year: 2003, movieId: "tt0242653", title: "The Matrix Revolutions"})
```

Format `Plain` on StringShell
```
cypher-shell/build/install/cypher-shell/cypher-shell -u neo4j -p neo "RETURN 1"
1
1
```