### PR TITLE
Addded streaming results from the driver

### DIFF
--- a/cypher-shell/src/dist/cypher-shell
+++ b/cypher-shell/src/dist/cypher-shell
@@ -85,6 +85,6 @@ if [ -z "${JARPATH}" ]; then
   exit 1
 fi
 
-exec "$JAVA_CMD" ${JAVA_OPTS:-} \
+exec "$JAVA_CMD" ${JAVA_OPTS:-} -Dterminal.columns=${COLUMNS:-} \
   -jar "$JARPATH" \
   "$@"

--- a/cypher-shell/src/main/java/org/neo4j/shell/Main.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/Main.java
@@ -88,6 +88,8 @@ public class Main {
         if (cliArgs.isStringShell() && Format.AUTO.equals(cliArgs.getFormat())) {
             logger.setFormat(Format.PLAIN);
         }
+        logger.setWidth(cliArgs.getWidth());
+        logger.setWrap(cliArgs.getWrap());
         return logger;
     }
 

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgHelper.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgHelper.java
@@ -5,11 +5,7 @@ import net.sourceforge.argparse4j.impl.action.StoreConstArgumentAction;
 import net.sourceforge.argparse4j.impl.action.StoreTrueArgumentAction;
 import net.sourceforge.argparse4j.impl.choice.CollectionArgumentChoice;
 import net.sourceforge.argparse4j.impl.type.BooleanArgumentType;
-import net.sourceforge.argparse4j.inf.ArgumentGroup;
-import net.sourceforge.argparse4j.inf.ArgumentParser;
-import net.sourceforge.argparse4j.inf.ArgumentParserException;
-import net.sourceforge.argparse4j.inf.MutuallyExclusiveGroup;
-import net.sourceforge.argparse4j.inf.Namespace;
+import net.sourceforge.argparse4j.inf.*;
 
 import java.io.PrintWriter;
 import java.util.regex.Matcher;
@@ -88,6 +84,9 @@ public class CliArgHelper {
 
         cliArgs.setNonInteractive(ns.getBoolean("force-non-interactive"));
 
+        cliArgs.setWidth(ns.getInt("width"));
+        cliArgs.setWrap(ns.getBoolean("wrap"));
+
         cliArgs.setVersion(ns.getBoolean("version"));
 
         return cliArgs;
@@ -165,6 +164,15 @@ public class CliArgHelper {
                 .dest("force-non-interactive")
               .action(new StoreTrueArgumentAction());
 
+        parser.addArgument("--width")
+                .help("terminal width, only for table format")
+                .type(new WidthArgumentType())
+        .setDefault(-1);
+        parser.addArgument("--wrap")
+                .help("wrap table colum values if table is too narrow, default true")
+                .type(new BooleanArgumentType())
+        .setDefault(true);
+
         parser.addArgument("-v", "--version")
                 .help("print version of cypher-shell and exit")
                 .action(new StoreTrueArgumentAction());
@@ -177,4 +185,16 @@ public class CliArgHelper {
     }
 
 
+    private static class WidthArgumentType implements ArgumentType<Integer> {
+        @Override
+        public Integer convert(ArgumentParser parser, Argument arg, String value) throws ArgumentParserException {
+            try {
+                int result = Integer.parseInt(value);
+                if (result < 1) throw new NumberFormatException(value);
+                return result;
+            } catch (NumberFormatException nfe) {
+                throw new ArgumentParserException("Invalid width value: "+value,parser);
+            }
+        }
+    }
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgs.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgs.java
@@ -1,5 +1,7 @@
 package org.neo4j.shell.cli;
 
+import org.neo4j.shell.ShellRunner;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Optional;
@@ -17,6 +19,8 @@ public class CliArgs {
     private boolean debugMode;
     private boolean nonInteractive = false;
     private boolean version = false;
+    private int width = ShellRunner.ttyColumns();
+    private boolean wrap = true;
 
     /**
      * Set the scheme to the primary value, or if null, the fallback value.
@@ -157,5 +161,24 @@ public class CliArgs {
 
     public boolean isStringShell() {
         return cypher.isPresent();
+    }
+
+    public void setWidth(Integer width) {
+        if (width != null && width > 0) {
+            this.width = width;
+        }
+    }
+
+    @Nonnull
+    public int getWidth() {
+        return width;
+    }
+
+    public boolean getWrap() {
+        return wrap;
+    }
+
+    public void setWrap(boolean wrap) {
+        this.wrap = wrap;
     }
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/log/AnsiLogger.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/log/AnsiLogger.java
@@ -7,6 +7,7 @@ import org.neo4j.shell.cli.Format;
 import org.neo4j.shell.exception.AnsiFormattedException;
 
 import javax.annotation.Nonnull;
+import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
@@ -23,6 +24,8 @@ public class AnsiLogger implements Logger {
     private final PrintStream err;
     private final boolean debug;
     private Format format;
+    private int width;
+    private boolean wrap = true;
 
     public AnsiLogger(final boolean debug) {
         this(debug, Format.VERBOSE, System.out, System.err);
@@ -66,6 +69,19 @@ public class AnsiLogger implements Logger {
         return 1 == isatty(STDOUT_FILENO) && 1 == isatty(STDERR_FILENO);
     }
 
+    public int getWidth() {
+        return width != -1 || isOutputInteractive() ? width : -1;
+    }
+
+    @Override
+    public boolean getWrap() {
+        return wrap;
+    }
+
+    public void setWrap(boolean wrap) {
+        this.wrap = wrap;
+    }
+
     @Nonnull
     @Override
     public PrintStream getOutputStream() {
@@ -92,6 +108,11 @@ public class AnsiLogger implements Logger {
     @Override
     public boolean isDebugEnabled() {
         return debug;
+    }
+
+    @Override
+    public void setWidth(int width) {
+        this.width = width;
     }
 
     @Override
@@ -131,9 +152,9 @@ public class AnsiLogger implements Logger {
                     cause.getMessage() != null && cause.getMessage().contains("Missing username")) {
                 // Username and password was not specified
                 msg = msg.append(cause.getMessage())
-                         .append("\nPlease specify --username, and optionally --password, as argument(s)")
-                         .append("\nor as environment variable(s), NEO4J_USERNAME, and NEO4J_PASSWORD respectively.")
-                         .append("\nSee --help for more info.");
+                        .append("\nPlease specify --username, and optionally --password, as argument(s)")
+                        .append("\nor as environment variable(s), NEO4J_USERNAME, and NEO4J_PASSWORD respectively.")
+                        .append("\nSee --help for more info.");
             } else {
                 if (cause.getMessage() != null) {
                     msg = msg.append(cause.getMessage());

--- a/cypher-shell/src/main/java/org/neo4j/shell/log/Logger.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/log/Logger.java
@@ -92,4 +92,11 @@ public interface Logger {
             printOut(text);
         }
     }
+
+    void setWidth(int width);
+    int getWidth();
+
+    boolean getWrap();
+
+    void setWrap(boolean wrap);
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/OutputFormatter.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/OutputFormatter.java
@@ -11,6 +11,7 @@ import org.neo4j.driver.v1.types.Relationship;
 import org.neo4j.shell.state.BoltResult;
 
 import java.util.*;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
@@ -24,15 +25,18 @@ import static org.neo4j.shell.prettyprint.CypherVariablesFormatter.escape;
  */
 public interface OutputFormatter {
 
+    enum Capablities {info, plan, result, footer, statistics}
+
     String COMMA_SEPARATOR = ", ";
     String COLON_SEPARATOR = ": ";
     String COLON = ":";
     String SPACE = " ";
     String NEWLINE =  System.getProperty("line.separator");
 
-    @Nonnull String format(@Nonnull BoltResult result);
+    void format(@Nonnull BoltResult result, @Nonnull Consumer<String> output);
 
-    @Nonnull default String formatValue(@Nonnull final Value value) {
+    @Nonnull default String formatValue(final Value value) {
+        if (value == null) return "";
         TypeRepresentation type = (TypeRepresentation) value.type();
         switch (type.constructor()) {
             case LIST_TyCon:
@@ -161,6 +165,7 @@ public interface OutputFormatter {
         return "";
     }
 
+    Set<Capablities> capabilities();
 
     List<String> INFO = asList("Version", "Planner", "Runtime");
 

--- a/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/SimpleOutputFormatter.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/SimpleOutputFormatter.java
@@ -5,25 +5,26 @@ import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.summary.ResultSummary;
 import org.neo4j.shell.state.BoltResult;
 
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
 import javax.annotation.Nonnull;
+import java.util.EnumSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 public class SimpleOutputFormatter implements OutputFormatter {
 
-    @Override
-    @Nonnull
-    public String format(@Nonnull final BoltResult result) {
-        StringBuilder sb = new StringBuilder();
-        List<Record> records = result.getRecords();
-        if (!records.isEmpty()) {
-            sb.append(records.get(0).keys().stream().collect(Collectors.joining(COMMA_SEPARATOR)));
-            sb.append("\n");
-            sb.append(records.stream().map(this::formatRecord).collect(Collectors.joining("\n")));
+    public void format(@Nonnull BoltResult result, @Nonnull Consumer<String> output) {
+        Iterator<Record> records = result.iterate();
+        if (records.hasNext()) {
+            Record firstRow = records.next();
+            output.accept(String.join(COMMA_SEPARATOR,firstRow.keys()));
+            output.accept(formatRecord(firstRow));
+            while (records.hasNext()) {
+                output.accept(formatRecord(records.next()));
+            }
         }
-        return sb.toString();
     }
 
     @Nonnull
@@ -37,5 +38,10 @@ public class SimpleOutputFormatter implements OutputFormatter {
         if (!summary.hasPlan()) return "";
         Map<String, Value> info = OutputFormatter.info(summary);
         return info.entrySet().stream().map( e -> String.format("%s: %s",e.getKey(),e.getValue())).collect(Collectors.joining(NEWLINE));
+    }
+
+    @Override
+    public Set<Capablities> capabilities() {
+        return EnumSet.of(Capablities.info, Capablities.statistics, Capablities.result);
     }
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/TableOutputFormatter.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/TableOutputFormatter.java
@@ -1,51 +1,88 @@
 package org.neo4j.shell.prettyprint;
 
 import org.neo4j.driver.internal.InternalRecord;
-import org.neo4j.driver.internal.util.Iterables;
 import org.neo4j.driver.internal.value.MapValue;
+import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.Value;
-import org.neo4j.driver.v1.Values;
 import org.neo4j.driver.v1.summary.ResultSummary;
 import org.neo4j.shell.state.BoltResult;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
+import java.util.function.Consumer;
 
+import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public class TableOutputFormatter implements OutputFormatter {
 
-    @Override
-    @Nonnull
-    public String format(@Nonnull final BoltResult result) {
-        List<Value> data = result.getRecords().stream().map(r -> new MapValue(r.<Value>asMap(v -> v))).collect(Collectors.toList());
-        return formatValues(data);
+    private static final int SAMPLE_ROWS = 100;
+    private final int maxWidth;
+    private final boolean wrap;
+
+    public TableOutputFormatter(int maxWidth, boolean wrap) {
+        this.maxWidth = maxWidth;
+        this.wrap = wrap;
     }
 
-    @Nonnull
-    String formatValues(@Nonnull List<Value> data) {
-        if (data.isEmpty()) return "";
-        List<String> columns = Iterables.asList(data.get(0).keys());
-        if (columns.isEmpty()) return "";
+    @Override
+    public void format(@Nonnull BoltResult result, @Nonnull Consumer<String> output) {
+        Iterator<Record> rows = result.iterate();
+        if (!rows.hasNext()) return;
 
-        StringBuilder sb = new StringBuilder();
-        Map<String, Integer> columnSizes = calculateColumnSizes(columns, data);
-        String headerLine = createString(columns, columnSizes);
-        int lineWidth = headerLine.length() - 2;
+
+        Record firstRow = rows.next();
+        String[] columns = firstRow.keys().toArray(new String[0]);
+        if (columns.length == 0) return;
+
+        List<Record> topRows = sampleRows(rows, firstRow, SAMPLE_ROWS);
+
+        formatValues(columns,topRows, rows, output);
+    }
+
+    private List<Record> sampleRows(Iterator<Record> rows, Record firstRow, int count) {
+        List<Record> topRows = new ArrayList<>(count);
+        topRows.add(firstRow);
+        while (rows.hasNext() && topRows.size() < count) topRows.add(rows.next());
+        return topRows;
+    }
+
+    private MapValue rowToValue(Record firstRow) {
+        return new MapValue(firstRow.asMap(v -> v));
+    }
+
+    private void formatValues(String[] columns, @Nonnull List<Record> topRows, Iterator<Record> records, Consumer<String> output) {
+        int[] columnSizes = calculateColumnSizes(columns, topRows);
+
+        int totalWidth = 1;
+        for (int columnSize : columnSizes) totalWidth += columnSize + 3;
+
+        if (maxWidth != -1) {
+            float ratio = (float)maxWidth / (float)totalWidth;
+            totalWidth = 1;
+            for (int i = 0; i < columnSizes.length; i++) {
+                columnSizes[i] = Math.round(columnSizes[i]*ratio); // todo better distribution (of remainder)
+                totalWidth += columnSizes[i] + 3;
+            }
+        }
+
+        StringBuilder builder = new StringBuilder(totalWidth);
+        String headerLine = createString(columns, columnSizes, builder);
+        int lineWidth = totalWidth - 2;
         String dashes = "+" + OutputFormatter.repeat('-', lineWidth) + "+";
 
-        sb.append(dashes).append(NEWLINE);
-        sb.append(headerLine).append(NEWLINE);
-        sb.append(dashes).append(NEWLINE);
+        output.accept(dashes);
+        output.accept(headerLine);
+        output.accept(dashes);
 
-        for (Value record : data) {
-            sb.append(createString(columns, columnSizes, record)).append(NEWLINE);
+        for (Record record : topRows) {
+            output.accept(createString(columns, columnSizes, record, builder));
         }
-        sb.append(dashes).append(NEWLINE);
-        return sb.toString();
+        while (records.hasNext()) {
+            output.accept(createString(columns, columnSizes, records.next(), builder));
+        }
+        output.accept(dashes);
     }
 
     @Nonnull
@@ -56,42 +93,63 @@ public class TableOutputFormatter implements OutputFormatter {
     }
 
     @Nonnull
-    private String createString(@Nonnull List<String> columns, @Nonnull Map<String, Integer> columnSizes, @Nonnull Value m) {
-        StringBuilder sb = new StringBuilder("|");
-        for (String column : columns) {
+    private String createString(@Nonnull String[] columns, @Nonnull int[] columnSizes, @Nonnull Record m, StringBuilder sb) {
+        sb.setLength(0);
+        String[] row = new String[columns.length];
+        for (int i = 0; i < row.length; i++) {
+            row[i] = formatValue(m.get(i));
+        }
+        formatRow(sb, columnSizes, row);
+        return sb.toString();
+    }
+
+    private void formatRow(StringBuilder sb, int[] columnSizes, String[] row) {
+        sb.append("|");
+        boolean remainder = false;
+        for (int i = 0; i < row.length; i++) {
             sb.append(" ");
-            Integer length = columnSizes.get(column);
-            String txt = formatValue(m.get(column));
-            String value = OutputFormatter.rightPad(txt, length);
-            sb.append(value);
+            int length = columnSizes[i];
+            String txt = row[i];
+            if (txt != null) {
+                if (txt.length() > length) {
+                    row[i] = txt.substring(length);
+                    remainder = true;
+                } else row[i] = null;
+                sb.append(OutputFormatter.rightPad(txt, length));
+            } else {
+                sb.append(OutputFormatter.repeat(' ', length));
+            }
+            sb.append(" |");
+        }
+        if (wrap && remainder) {
+            sb.append(OutputFormatter.NEWLINE);
+            formatRow(sb, columnSizes, row);
+        }
+    }
+
+    @Nonnull
+    private String createString(@Nonnull String[] columns, @Nonnull int[] columnSizes, StringBuilder sb) {
+        sb.setLength(0);
+        sb.append("|");
+        for (int i = 0; i < columns.length; i++) {
+            sb.append(" ");
+            sb.append(OutputFormatter.rightPad(columns[i], columnSizes[i]));
             sb.append(" |");
         }
         return sb.toString();
     }
 
     @Nonnull
-    private String createString(@Nonnull List<String> columns, @Nonnull Map<String, Integer> columnSizes) {
-        StringBuilder sb = new StringBuilder("|");
-        for (String column : columns) {
-            sb.append(" ");
-            sb.append(OutputFormatter.rightPad(column, columnSizes.get(column)));
-            sb.append(" |");
+    private int[] calculateColumnSizes(@Nonnull String[] columns, @Nonnull List<Record> data) {
+        int[] columnSizes = new int[columns.length];
+        for (int i = 0; i < columns.length; i++) {
+            columnSizes[i] = columns[i].length();
         }
-        return sb.toString();
-    }
-
-    @Nonnull
-    private Map<String, Integer> calculateColumnSizes(@Nonnull List<String> columns, @Nonnull List<Value> data) {
-        Map<String, Integer> columnSizes = new LinkedHashMap<>();
-        for (String column : columns) {
-            columnSizes.put(column, column.length());
-        }
-        for (Value record : data) {
-            for (String column : columns) {
-                int len = formatValue(record.get(column)).length();
-                int existing = columnSizes.get(column);
-                if (existing < len) {
-                    columnSizes.put(column, len);
+        for (Record record : data) {
+            for (int i = 0; i < columns.length; i++) {
+                int len = formatValue(record.get(i)).length();
+                if (columnSizes[i] < len) {
+                    columnSizes[i] = len;
                 }
             }
         }
@@ -102,7 +160,12 @@ public class TableOutputFormatter implements OutputFormatter {
     @Nonnull
     public String formatInfo(@Nonnull ResultSummary summary) {
         Map<String, Value> info = OutputFormatter.info(summary);
-        return formatValues(Collections.singletonList(new MapValue(info)));
+        if (info.isEmpty()) return "";
+        String[] columns = info.keySet().toArray(new String[info.size()]);
+        StringBuilder sb = new StringBuilder();
+        Record record = new InternalRecord(asList(columns), info.values().toArray(new Value[info.size()]));
+        formatValues(columns, Collections.singletonList(record), Collections.emptyIterator(), sb::append);
+        return sb.toString();
     }
 
     @Override
@@ -110,5 +173,10 @@ public class TableOutputFormatter implements OutputFormatter {
     public String formatPlan(@Nullable ResultSummary summary) {
         if (summary == null || !summary.hasPlan()) return "";
         return new TablePlanFormatter().formatPlan(summary.plan());
+    }
+
+    @Override
+    public Set<Capablities> capabilities() {
+        return EnumSet.allOf(Capablities.class);
     }
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/state/BoltResult.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/state/BoltResult.java
@@ -4,28 +4,20 @@ import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.summary.ResultSummary;
 
 import javax.annotation.Nonnull;
+import java.util.Iterator;
 import java.util.List;
 
 /**
- * A class holds the result from executing some Cypher.
+ * @author mh
+ * @since 26.01.18
  */
-public class BoltResult {
-    private final List<Record> records;
-    private final ResultSummary summary;
-
-    public BoltResult(@Nonnull List<Record> records, @Nonnull ResultSummary summary) {
-
-        this.records = records;
-        this.summary = summary;
-    }
+public interface BoltResult {
+    @Nonnull
+    List<Record> getRecords();
 
     @Nonnull
-    public List<Record> getRecords() {
-        return records;
-    }
+    Iterator<Record> iterate();
 
     @Nonnull
-    public ResultSummary getSummary() {
-        return summary;
-    }
+    ResultSummary getSummary();
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
@@ -175,7 +175,7 @@ public class BoltStateHandler implements TransactionHandler, Connector {
         }
 
         // calling list()/consume() is what actually executes cypher on the server
-        return Optional.of(new BoltResult(statementResult.list(), statementResult.consume()));
+        return Optional.of(new StatementBoltResult(statementResult));
     }
 
     /**
@@ -230,7 +230,7 @@ public class BoltStateHandler implements TransactionHandler, Connector {
         List<BoltResult> results = executeWithRetry(transactionStatements, (statement, transaction) -> {
             // calling list()/consume() is what actually executes cypher on the server
             StatementResult sr = transaction.run(statement);
-            return new BoltResult(sr.list(), sr.consume());
+            return new ListBoltResult(sr.list(), sr.consume());
         });
 
         clearTransactionStatements();

--- a/cypher-shell/src/main/java/org/neo4j/shell/state/ListBoltResult.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/state/ListBoltResult.java
@@ -1,0 +1,40 @@
+package org.neo4j.shell.state;
+
+import org.neo4j.driver.v1.Record;
+import org.neo4j.driver.v1.summary.ResultSummary;
+
+import javax.annotation.Nonnull;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * A class holds the result from executing some Cypher.
+ */
+public class ListBoltResult implements BoltResult {
+    private final List<Record> records;
+    private final ResultSummary summary;
+
+    public ListBoltResult(@Nonnull List<Record> records, @Nonnull ResultSummary summary) {
+
+        this.records = records;
+        this.summary = summary;
+    }
+
+    @Override
+    @Nonnull
+    public List<Record> getRecords() {
+        return records;
+    }
+
+    @Override
+    @Nonnull
+    public Iterator<Record> iterate() {
+        return records.iterator();
+    }
+
+    @Override
+    @Nonnull
+    public ResultSummary getSummary() {
+        return summary;
+    }
+}

--- a/cypher-shell/src/main/java/org/neo4j/shell/state/StatementBoltResult.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/state/StatementBoltResult.java
@@ -1,0 +1,40 @@
+package org.neo4j.shell.state;
+
+import org.neo4j.driver.v1.Record;
+import org.neo4j.driver.v1.StatementResult;
+import org.neo4j.driver.v1.summary.ResultSummary;
+
+import javax.annotation.Nonnull;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * @author mh
+ * @since 26.01.18
+ */
+public class StatementBoltResult implements BoltResult {
+
+    private final StatementResult result;
+
+    public StatementBoltResult(StatementResult result) {
+        this.result = result;
+    }
+
+    @Nonnull
+    @Override
+    public List<Record> getRecords() {
+        return result.list();
+    }
+
+    @Nonnull
+    @Override
+    public Iterator<Record> iterate() {
+        return result;
+    }
+
+    @Nonnull
+    @Override
+    public ResultSummary getSummary() {
+        return result.summary();
+    }
+}

--- a/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
@@ -4,6 +4,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.Session;
@@ -18,10 +19,12 @@ import org.neo4j.shell.log.Logger;
 import org.neo4j.shell.prettyprint.PrettyPrinter;
 import org.neo4j.shell.state.BoltResult;
 import org.neo4j.shell.state.BoltStateHandler;
+import org.neo4j.shell.state.ListBoltResult;
 import org.neo4j.shell.test.OfflineTestShell;
 
 import java.io.IOException;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import static java.util.Arrays.asList;
 import static junit.framework.TestCase.assertTrue;
@@ -30,11 +33,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Matchers.anyMap;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.contains;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class CypherShellTest {
     @Rule
@@ -135,7 +134,7 @@ public class CypherShellTest {
     public void setParamShouldAddParamWithSpecialCharactersAndValue() throws CommandException {
         Value value = mock(Value.class);
         Record recordMock = mock(Record.class);
-        BoltResult boltResult = mock(BoltResult.class);
+        BoltResult boltResult = mock(ListBoltResult.class);
 
         when(mockedBoltStateHandler.runCypher(anyString(), anyMap())).thenReturn(Optional.of(boltResult));
         when(boltResult.getRecords()).thenReturn(asList(recordMock));
@@ -153,7 +152,7 @@ public class CypherShellTest {
     public void setParamShouldAddParam() throws CommandException {
         Value value = mock(Value.class);
         Record recordMock = mock(Record.class);
-        BoltResult boltResult = mock(BoltResult.class);
+        BoltResult boltResult = mock(ListBoltResult.class);
 
         when(mockedBoltStateHandler.runCypher(anyString(), anyMap())).thenReturn(Optional.of(boltResult));
         when(boltResult.getRecords()).thenReturn(asList(recordMock));
@@ -171,13 +170,13 @@ public class CypherShellTest {
     public void executeShouldPrintResult() throws CommandException {
         Driver mockedDriver = mock(Driver.class);
         Session session = mock(Session.class);
-        BoltResult result = mock(BoltResult.class);
+        BoltResult result = mock(ListBoltResult.class);
 
         BoltStateHandler boltStateHandler = mock(BoltStateHandler.class);
 
         when(boltStateHandler.isConnected()).thenReturn(true);
         when(boltStateHandler.runCypher(anyString(), anyMap())).thenReturn(Optional.of(result));
-        when(mockedPrettyPrinter.format(result)).thenReturn("999");
+        doAnswer((a) -> { ((Consumer<String>)a.getArguments()[1]).accept("999"); return null;}).when(mockedPrettyPrinter).format(any(BoltResult.class), anyObject());
         when(mockedDriver.session()).thenReturn(session);
 
         OfflineTestShell shell = new OfflineTestShell(logger, boltStateHandler, mockedPrettyPrinter);
@@ -187,11 +186,11 @@ public class CypherShellTest {
 
     @Test
     public void commitShouldPrintResult() throws CommandException {
-        BoltResult result = mock(BoltResult.class);
+        BoltResult result = mock(ListBoltResult.class);
 
         BoltStateHandler boltStateHandler = mock(BoltStateHandler.class);
 
-        when(mockedPrettyPrinter.format(result)).thenReturn("999");
+        doAnswer((a) -> { ((Consumer<String>)a.getArguments()[1]).accept("999"); return null;}).when(mockedPrettyPrinter).format(any(BoltResult.class), anyObject());
         when(boltStateHandler.commitTransaction()).thenReturn(Optional.of(asList(result)));
 
         OfflineTestShell shell = new OfflineTestShell(logger, boltStateHandler, mockedPrettyPrinter);

--- a/cypher-shell/src/test/java/org/neo4j/shell/cli/CliArgHelperTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/cli/CliArgHelperTest.java
@@ -39,6 +39,22 @@ public class CliArgHelperTest {
     }
 
     @Test
+    public void testWidth() {
+        assertEquals("width 120",120, CliArgHelper.parse("--width 120".split(" ")).getWidth());
+        assertNull("invalid width", CliArgHelper.parse("--width 0".split(" ")));
+        assertNull("invalid width", CliArgHelper.parse("--width -1".split(" ")));
+        assertNull("invalid width",CliArgHelper.parse("--width foo".split(" ")));
+    }
+
+    @Test
+    public void testWrap() {
+        assertTrue("wrap true", CliArgHelper.parse("--wrap true".split(" ")).getWrap());
+        assertFalse("wrap false", CliArgHelper.parse("--wrap false".split(" ")).getWrap());
+        assertTrue("default wrap", CliArgHelper.parse().getWrap());
+        assertNull("invalid wrap",CliArgHelper.parse("--wrap foo".split(" ")));
+    }
+
+    @Test
     public void testDebugIsNotDefault() {
         assertFalse("Debug should not be the default mode",
                 CliArgHelper.parse(asArray()).getDebugMode());
@@ -120,8 +136,9 @@ public class CliArgHelperTest {
 
         assertNull(cliargs);
 
-        assertTrue(bout.toString().startsWith("usage: cypher-shell [-h]"));
-        assertTrue(bout.toString().contains("cypher-shell: error: unrecognized arguments: '-notreally'"));
+        String output = bout.toString();
+        assertTrue(output, output.startsWith("usage: cypher-shell [-h]"));
+        assertTrue(output, output.contains("cypher-shell: error: unrecognized arguments: '-notreally'"));
     }
 
     @Test

--- a/cypher-shell/src/test/java/org/neo4j/shell/cli/CliArgsTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/cli/CliArgsTest.java
@@ -59,6 +59,20 @@ public class CliArgsTest {
     }
 
     @Test
+    public void setWidth() throws Exception {
+        assertEquals(-1, cliArgs.getWidth());
+
+        cliArgs.setWidth(null);
+        assertEquals(-1, cliArgs.getWidth());
+
+        cliArgs.setWidth(120);
+        assertEquals(120, cliArgs.getWidth());
+
+        cliArgs.setWidth(0);
+        assertEquals(120, cliArgs.getWidth());
+    }
+
+    @Test
     public void setFormat() throws Exception {
         // default
         assertEquals(Format.AUTO, cliArgs.getFormat());

--- a/cypher-shell/src/test/java/org/neo4j/shell/log/AnsiLoggerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/log/AnsiLoggerTest.java
@@ -57,7 +57,7 @@ public class AnsiLoggerTest {
 
     @Test
     public void printExceptionWithDebug() throws Exception {
-        logger = new AnsiLogger(true, Format.VERBOSE, out, err);
+        Logger logger = new AnsiLogger(true, Format.VERBOSE, out, err);
         logger.printError(new Throwable("bam"));
         verify(err).println(contains("java.lang.Throwable: bam"));
         verify(err).println(contains("at org.neo4j.shell.log.AnsiLoggerTest.printExceptionWithDebug"));

--- a/cypher-shell/src/test/java/org/neo4j/shell/state/BoltStateHandlerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/state/BoltStateHandlerTest.java
@@ -179,8 +179,8 @@ public class BoltStateHandlerTest {
         Session sessionMock = mock(Session.class);
         Driver driverMock = stubVersionInAnOpenSession(mock(StatementResult.class), sessionMock, "neo4j-version");
 
-        BoltResult boltResultMock1 = mock(BoltResult.class);
-        BoltResult boltResultMock2 = mock(BoltResult.class);
+        BoltResult boltResultMock1 = mock(ListBoltResult.class);
+        BoltResult boltResultMock2 = mock(ListBoltResult.class);
 
         Record record1 = mock(Record.class);
         Record record2 = mock(Record.class);


### PR DESCRIPTION
* both table mode and plain mode will now NOT materialize all results anymore
but stream to output
* table mode samples the first 100 rows for total width
* fields that are longer are wrapped, disable with --wrap false
* added --width to specify table width
* tested with PanamaPapers dataset, that caused an OOM before, now finishes quickly
* improved table format implementation for performance