### PR TITLE
adding point datatype.

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/OutputFormatter.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/OutputFormatter.java
@@ -7,11 +7,16 @@ import org.neo4j.driver.v1.summary.Plan;
 import org.neo4j.driver.v1.summary.ResultSummary;
 import org.neo4j.driver.v1.types.Node;
 import org.neo4j.driver.v1.types.Path;
+import org.neo4j.driver.v1.types.Point;
 import org.neo4j.driver.v1.types.Relationship;
 import org.neo4j.shell.state.BoltResult;
 
 import javax.annotation.Nonnull;
-import java.util.*;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
@@ -41,16 +46,39 @@ public interface OutputFormatter {
                 return relationshipAsString(value.asRelationship());
             case PATH:
                 return pathAsString(value.asPath());
+            case POINT:
+                return pointAsString(value.asPoint());
+            case DURATION:
             case ANY:
             case BOOLEAN:
+            case BYTES:
             case STRING:
             case NUMBER:
             case INTEGER:
             case FLOAT:
+            case DATE:
+            case TIME:
+            case DATE_TIME:
+            case LOCAL_TIME:
+            case LOCAL_DATE_TIME:
             case NULL:
             default:
                 return value.toString();
         }
+    }
+
+    @Nonnull
+    default String pointAsString(Point point) {
+        StringBuilder stringBuilder = new StringBuilder("point({");
+        stringBuilder.append("srid:" + point.srid() + ",");
+        stringBuilder.append(" x:" + point.x() + ",");
+        stringBuilder.append(" y:" + point.y());
+        Double z = point.z();
+        if (!Double.isNaN(z)) {
+            stringBuilder.append(", z:" + z);
+        }
+        stringBuilder.append("})");
+        return stringBuilder.toString();
     }
 
     @Nonnull

--- a/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/TableOutputFormatterTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/TableOutputFormatterTest.java
@@ -4,10 +4,13 @@ import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 import org.neo4j.driver.internal.InternalNode;
 import org.neo4j.driver.internal.InternalPath;
+import org.neo4j.driver.internal.InternalPoint2D;
+import org.neo4j.driver.internal.InternalPoint3D;
 import org.neo4j.driver.internal.InternalRecord;
 import org.neo4j.driver.internal.InternalRelationship;
 import org.neo4j.driver.internal.value.NodeValue;
 import org.neo4j.driver.internal.value.PathValue;
+import org.neo4j.driver.internal.value.PointValue;
 import org.neo4j.driver.internal.value.RelationshipValue;
 import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.Statement;
@@ -68,6 +71,27 @@ public class TableOutputFormatterTest {
             assertThat(actual, CoreMatchers.containsString("| "+k));
             assertThat(actual, CoreMatchers.containsString("| "+v.toString()));
         });
+    }
+
+    @Test
+    public void prettyPrintPoint() throws Exception {
+        // given
+        StatementResult statementResult = mock(StatementResult.class);
+        List<String> keys = asList("p1", "p2");
+
+        when(statementResult.summary()).thenReturn(mock(ResultSummary.class));
+        when(statementResult.keys()).thenReturn(keys);
+
+        Value point2d = new PointValue(new InternalPoint2D(4326, 42.78, 56.7));
+        Value point3d = new PointValue(new InternalPoint3D(4326, 1.7, 26.79, 34.23));
+        Record record = new InternalRecord(keys, new Value[]{point2d, point3d});
+
+        // when
+        String actual = verbosePrinter.format(new BoltResult(asList(record), statementResult));
+
+        // then
+        assertThat(actual, containsString("| point({srid:4326, x:42.78, y:56.7}) |"));
+        assertThat(actual, containsString("| point({srid:4326, x:1.7, y:26.79, z:34.23}) |"));
     }
 
     @Test


### PR DESCRIPTION
```
neo4j> WITH point({srid: 4326, longitude: 12.78, latitude: 56.7}) as p1 RETURN p1;
+-------------------------------------+
| p1                                  |
+-------------------------------------+
| point({srid:4326, x:12.78, y:56.7}) |
+-------------------------------------+

1 row available after 4 ms, consumed after another 1 ms
neo4j> WITH point({longitude: 12.78, latitude: 56.7}) as p1 RETURN p1;
+-------------------------------------+
| p1                                  |
+-------------------------------------+
| point({srid:4326, x:12.78, y:56.7}) |
+-------------------------------------+

1 row available after 4 ms, consumed after another 1 ms
neo4j> WITH point({crs: 'wgs-84', longitude: 12.78, latitude: 56.7}) as p1 RETURN p1;
+-------------------------------------+
| p1                                  |
+-------------------------------------+
| point({srid:4326, x:12.78, y:56.7}) |
+-------------------------------------+

1 row available after 2 ms, consumed after another 0 ms
neo4j> WITH point({crs: 'wgs-84', x: 12.78, y: 56.7, z: 64.34}) as p1 RETURN p1;
Cannot create point with 2D coordinate reference system and 3 coordinates. Please consider using equivalent 3D coordinate reference system
neo4j> WITH point({x: 12.78, y: 56.7, z: 64.34}) as p1 RETURN p1;
+----------------------------------------------+
| p1                                           |
+----------------------------------------------+
| point({srid:9157, x:12.78, y:56.7, z:64.34}) |
+----------------------------------------------+

1 row available after 12 ms, consumed after another 1 ms
neo4j>
```