### PR TITLE
update to 1.6 driver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ ext {
 
     argparse4jVersion = '0.7.0'
     junitVersion = '4.12'
-    neo4jJavaVersion = '1.6.0-rc2'
+    neo4jJavaVersion = '1.6.0'
     findbugsVersion = '3.0.0'
     jansiVersion = '1.13'
     jlineVersion = '2.14.2'

--- a/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/TableOutputFormatterTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/TableOutputFormatterTest.java
@@ -69,9 +69,9 @@ public class TableOutputFormatterTest {
         String actual = verbosePrinter.format(result);
 
         // then
-        argumentMap.forEach((k,v) -> {
-            assertThat(actual, CoreMatchers.containsString("| "+k));
-            assertThat(actual, CoreMatchers.containsString("| "+v.toString()));
+        argumentMap.forEach((k, v) -> {
+            assertThat(actual, CoreMatchers.containsString("| " + k));
+            assertThat(actual, CoreMatchers.containsString("| " + v.toString()));
         });
     }
 
@@ -113,6 +113,26 @@ public class TableOutputFormatterTest {
 
         // then
         assertThat(actual, containsString("| P1M2DT3.000000004S |"));
+    }
+
+    @Test
+    public void prettyPrintDurationWithNoTrailingZeroes() throws Exception {
+        // given
+        StatementResult statementResult = mock(StatementResult.class);
+        List<String> keys = asList("d");
+
+        when(statementResult.summary()).thenReturn(mock(ResultSummary.class));
+        when(statementResult.keys()).thenReturn(keys);
+
+        Value duration = new DurationValue(new InternalIsoDuration(1, 2, 3, 0));
+        Record record = new InternalRecord(keys, new Value[]{duration});
+
+        // when
+        String actual = verbosePrinter.format(new BoltResult(asList(record), statementResult));
+
+        // then
+        System.out.println(actual);
+        assertThat(actual, containsString("| P1M2DT3S |"));
     }
 
     @Test
@@ -241,9 +261,9 @@ public class TableOutputFormatterTest {
 
         Value nodeVal = new NodeValue(new InternalNode(1, labels, nodeProperties));
 
-        Map<String,Value> recordMap = new LinkedHashMap<>();
-        recordMap.put("rel",relVal);
-        recordMap.put("node",nodeVal);
+        Map<String, Value> recordMap = new LinkedHashMap<>();
+        recordMap.put("rel", relVal);
+        recordMap.put("node", nodeVal);
         List<String> keys = asList("rel", "node");
         when(record.keys()).thenReturn(keys);
         when(record.get(eq("rel"))).thenReturn(relVal);
@@ -266,56 +286,53 @@ public class TableOutputFormatterTest {
     }
 
     @Test
-    public void basicTable() throws Exception
-    {
+    public void basicTable() throws Exception {
         // GIVEN
-        StatementResult result = mockResult( asList( "c1", "c2" ), "a", 42 );
+        StatementResult result = mockResult(asList("c1", "c2"), "a", 42);
         // WHEN
-        String table = formatResult( result );
+        String table = formatResult(result);
         // THEN
-        assertThat( table, containsString( "| c1  | c2 |" ) );
-        assertThat( table, containsString( "| \"a\" | 42 |" ) );
-    }
-    @Test
-    public void twoRows() throws Exception
-    {
-        // GIVEN
-        StatementResult result = mockResult( asList( "c1", "c2" ), "a", 42, "b", 43 );
-        // WHEN
-        String table = formatResult( result );
-        // THEN
-        assertThat( table, containsString( "| \"a\" | 42 |" ) );
-        assertThat( table, containsString( "| \"b\" | 43 |" ) );
+        assertThat(table, containsString("| c1  | c2 |"));
+        assertThat(table, containsString("| \"a\" | 42 |"));
     }
 
     @Test
-    public void formatCollections() throws Exception
-    {
+    public void twoRows() throws Exception {
         // GIVEN
-        StatementResult result = mockResult( asList( "a", "b", "c" ), singletonMap( "a", 42 ), asList( 12, 13 ),
-                singletonMap( "a", asList( 14, 15 ) ) );
+        StatementResult result = mockResult(asList("c1", "c2"), "a", 42, "b", 43);
         // WHEN
-        String table = formatResult( result );
+        String table = formatResult(result);
         // THEN
-        assertThat( table, containsString( "| {a: 42} | [12, 13] | {a: [14, 15]} |" ) );
+        assertThat(table, containsString("| \"a\" | 42 |"));
+        assertThat(table, containsString("| \"b\" | 43 |"));
     }
 
     @Test
-    public void formatEntities() throws Exception
-    {
+    public void formatCollections() throws Exception {
         // GIVEN
-        Map<String,Value> properties = singletonMap( "name", Values.value( "Mark" ) );
-        Map<String,Value> relProperties = singletonMap( "since", Values.value( 2016 ) );
-        InternalNode node = new InternalNode( 12, asList( "Person" ), properties );
-        InternalRelationship relationship = new InternalRelationship( 24, 12, 12, "TEST", relProperties );
+        StatementResult result = mockResult(asList("a", "b", "c"), singletonMap("a", 42), asList(12, 13),
+                singletonMap("a", asList(14, 15)));
+        // WHEN
+        String table = formatResult(result);
+        // THEN
+        assertThat(table, containsString("| {a: 42} | [12, 13] | {a: [14, 15]} |"));
+    }
+
+    @Test
+    public void formatEntities() throws Exception {
+        // GIVEN
+        Map<String, Value> properties = singletonMap("name", Values.value("Mark"));
+        Map<String, Value> relProperties = singletonMap("since", Values.value(2016));
+        InternalNode node = new InternalNode(12, asList("Person"), properties);
+        InternalRelationship relationship = new InternalRelationship(24, 12, 12, "TEST", relProperties);
         StatementResult result =
-                mockResult( asList( "a", "b", "c" ), node, relationship, new InternalPath( node, relationship, node ) );
+                mockResult(asList("a", "b", "c"), node, relationship, new InternalPath(node, relationship, node));
         // WHEN
-        String table = formatResult( result );
+        String table = formatResult(result);
         // THEN
-        assertThat( table, containsString( "| (:Person {name: \"Mark\"}) | [:TEST {since: 2016}] |" ) );
-        assertThat( table, containsString(
-                "| (:Person {name: \"Mark\"})-[:TEST {since: 2016}]->(:Person {name: \"Mark\"}) |" ) );
+        assertThat(table, containsString("| (:Person {name: \"Mark\"}) | [:TEST {since: 2016}] |"));
+        assertThat(table, containsString(
+                "| (:Person {name: \"Mark\"})-[:TEST {since: 2016}]->(:Person {name: \"Mark\"}) |"));
     }
 
     private String formatResult(StatementResult result) {


### PR DESCRIPTION
```
neo4j> RETURN duration.between(datetime("2014-07-21T21:40:36.143+0200"), date("2015-06-24"));
+--------------------------------------------------------------------------------+
| duration.between(datetime("2014-07-21T21:40:36.143+0200"), date("2015-06-24")) |
+--------------------------------------------------------------------------------+
| P11M3DT-78036.-143000000S                                                      |
+--------------------------------------------------------------------------------+

1 row available after 6 ms, consumed after another 0 ms
neo4j> RETURN duration.inMonths(date("1984-10-11"), date("2015-06-24"));
+-----------------------------------------------------------+
| duration.inMonths(date("1984-10-11"), date("2015-06-24")) |
+-----------------------------------------------------------+
| P368M0DT0S                                                |
+-----------------------------------------------------------+

1 row available after 2 ms, consumed after another 0 ms
neo4j>
```