### PR TITLE
fix tests: remove locale specific parts

### DIFF
--- a/cypher-shell/src/test/java/org/neo4j/shell/cli/CliArgHelperTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/cli/CliArgHelperTest.java
@@ -120,7 +120,7 @@ public class CliArgHelperTest {
 
         assertNull(cliargs);
 
-        assertTrue(bout.toString().startsWith("usage: cypher-shell [-h]"));
+        assertTrue(bout.toString().contains("cypher-shell [-h]"));
         assertTrue(bout.toString().contains("cypher-shell: error: unrecognized arguments: '-notreally'"));
     }
 
@@ -134,7 +134,7 @@ public class CliArgHelperTest {
         assertNull("should have failed", cliargs);
 
         assertTrue("expected usage: " + bout.toString(),
-                bout.toString().startsWith("usage: cypher-shell [-h]"));
+                bout.toString().contains("cypher-shell [-h]"));
         assertTrue("expected error: " + bout.toString(),
                 bout.toString().contains("cypher-shell: error: Failed to parse address"));
         assertTrue("expected error detail: " + bout.toString(),


### PR DESCRIPTION
The word "usage" orginates from a resource bundle from argparse4j's ArgumentParserImpl class. Therefore the build failed when e.g. being on German locale.
Replaced the `startWith` with a `contains` to be tolerant regarding different resource bundle contents.