### PR TITLE
Fix java version check

### DIFF
--- a/cypher-shell/src/dist/cypher-shell
+++ b/cypher-shell/src/dist/cypher-shell
@@ -10,7 +10,8 @@ check_java() {
   [[ -n "${JAVA_MEMORY_OPTS:-}" ]] && version_command+=("${JAVA_MEMORY_OPTS[@]}")
 
   JAVA_VERSION=$("${version_command[@]}" 2>&1 | awk -F '"' '/version/ {print $2}')
-  if [[ "${JAVA_VERSION}" < "1.8" ]]; then
+  MAX_VERSION=`echo -e "$JAVA_VERSION\n1.8" | sort -t '.' -k 1,1 -k 2,2 -k 3,3 -k 4,4 -g | tail -1`
+  if [[ "${MAX_VERSION}" = "1.8" ]]; then
     echo "ERROR! Java version ${JAVA_VERSION} is not supported. "
     _show_java_help
     exit 1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-bin.zip


### PR DESCRIPTION
This is just pulling out the fix for the erroneous version check of https://github.com/neo4j/cypher-shell/pull/126. We still have some way to go to get full java 10 support.