### PR TITLE
Fix plandescription

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/TablePlanFormatter.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/TablePlanFormatter.java
@@ -39,7 +39,7 @@ class TablePlanFormatter {
 
     private static final Set<String> IGNORED_ARGUMENTS = new LinkedHashSet<>(
             asList( "Rows", "DbHits", "EstimatedRows", "planner", "planner-impl", "planner-version", "version", "runtime", "runtime-impl", "runtime-version",
-                    "time", "source-code", "PageCacheMisses", "PageCacheHits", "Order" ) );
+                    "time", "source-code", "PageCacheMisses", "PageCacheHits", "PageCacheHitRatio", "Order" ) );
     public static final Value ZERO_VALUE = Values.value(0);
 
     private int width(@Nonnull String header, @Nonnull Map<String, Integer> columns) {

--- a/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/OutputFormatterTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/OutputFormatterTest.java
@@ -1,0 +1,63 @@
+package org.neo4j.shell.prettyprint;
+
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.neo4j.driver.internal.BoltServerAddress;
+import org.neo4j.driver.internal.summary.InternalResultSummary;
+import org.neo4j.driver.internal.summary.InternalServerInfo;
+import org.neo4j.driver.internal.util.ServerVersion;
+import org.neo4j.driver.internal.value.ListValue;
+import org.neo4j.driver.internal.value.MapValue;
+import org.neo4j.driver.v1.Statement;
+import org.neo4j.driver.v1.Value;
+import org.neo4j.driver.v1.Values;
+import org.neo4j.driver.v1.summary.ProfiledPlan;
+import org.neo4j.driver.v1.summary.ResultSummary;
+import org.neo4j.driver.v1.summary.StatementType;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.neo4j.driver.internal.summary.InternalProfiledPlan.PROFILED_PLAN_FROM_VALUE;
+
+public class OutputFormatterTest
+{
+    @Test
+    public void shouldReportTotalDBHits() {
+        Value labelScan = buildOperator( "NodeByLabelScan", 1002L, 1001L, null );
+        Value filter = buildOperator( "Filter", 1402, 280, labelScan );
+        Value planMap = buildOperator( "ProduceResults", 0, 280, filter );
+
+        ProfiledPlan plan = PROFILED_PLAN_FROM_VALUE.apply( planMap );
+        ResultSummary summary = new InternalResultSummary(
+                new Statement( "PROFILE MATCH (n:LABEL) WHERE 20 < n.age < 35 return n" ),
+                new InternalServerInfo( new BoltServerAddress( "localhost:7687" ), ServerVersion.vInDev ),
+                StatementType.READ_ONLY,
+                null,
+                plan,
+                plan,
+                Collections.emptyList(),
+                39,
+                55 );
+
+        // When
+        Map<String,Value> info = OutputFormatter.info( summary );
+
+        //Then
+        assertThat( info.get( "DbHits" ).asLong(), equalTo( 2404L ) );
+    }
+
+    private Value buildOperator( String operator, long dbHits, long rows, Value child ) {
+        Map<String, Value> operatorMap = new HashMap<>();
+        operatorMap.put( "operatorType", Values.value( operator ) );
+        operatorMap.put( "dbHits", Values.value( dbHits ) );
+        operatorMap.put( "rows", Values.value( rows ) );
+        if ( child != null ) {
+            operatorMap.put( "children", new ListValue( child ) );
+        }
+        return new MapValue( operatorMap );
+    }
+}


### PR DESCRIPTION
Don't print `PageCacheHitRatio` in the `Other` column

Fixed reporting of DbHits, previously it only reported the topmost operators DbHits.