### PR TITLE
render empty maps as `{}`

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/OutputFormatter.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/OutputFormatter.java
@@ -107,7 +107,7 @@ public interface OutputFormatter {
     @Nonnull default String relationshipAsString(@Nonnull Relationship relationship) {
         List<String> relationshipAsString = new ArrayList<>();
         relationshipAsString.add(COLON + escape(relationship.type()));
-        relationshipAsString.add(mapAsString(relationship.asMap(this::formatValue)));
+        relationshipAsString.add(mapAsStringWithEmpty(relationship.asMap(this::formatValue)));
 
         return "[" + joinWithSpace(relationshipAsString) + "]";
     }
@@ -115,7 +115,7 @@ public interface OutputFormatter {
     @Nonnull default String nodeAsString(@Nonnull final Node node) {
         List<String> nodeAsString = new ArrayList<>();
         nodeAsString.add(collectNodeLabels(node));
-        nodeAsString.add(mapAsString(node.asMap(this::formatValue)));
+        nodeAsString.add(mapAsStringWithEmpty(node.asMap(this::formatValue)));
 
         return "(" + joinWithSpace(nodeAsString) + ")";
     }
@@ -130,10 +130,11 @@ public interface OutputFormatter {
         return list.stream().collect(Collectors.joining(COMMA_SEPARATOR,"[","]"));
     }
 
+    @Nonnull static String mapAsStringWithEmpty(@Nonnull Map<String, Object> map) {
+        return map.isEmpty() ? "" : mapAsString(map);
+    }
+
     @Nonnull static String mapAsString(@Nonnull Map<String, Object> map) {
-        if (map.isEmpty()) {
-            return "";
-        }
         return map.entrySet().stream()
                 .map(e -> escape(e.getKey()) + COLON_SEPARATOR + e.getValue())
                 .collect(Collectors.joining(COMMA_SEPARATOR,"{","}"));

--- a/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/PrettyPrinterTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/PrettyPrinterTest.java
@@ -16,13 +16,11 @@ import org.neo4j.shell.state.BoltResult;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableMap;
-import static org.hamcrest.CoreMatchers.any;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -158,6 +156,36 @@ public class PrettyPrinterTest {
 
         // then
         assertThat(actual, is("col1, col2\n[val1_1, val1_2], [val2_1]\n[val2_1]"));
+    }
+
+    @Test
+    public void prettyPrintMaps() throws Exception {
+        checkMapForPrettyPrint(map(), "map\n{}");
+        checkMapForPrettyPrint(map("abc", "def"), "map\n{abc: def}");
+    }
+
+    private void checkMapForPrettyPrint(Map<String, String> map, String expectedResult) {
+        // given
+        BoltResult result = mock(BoltResult.class);
+
+        Record record = mock(Record.class);
+        Value value = mock(Value.class);
+
+        when(value.type()).thenReturn(InternalTypeSystem.TYPE_SYSTEM.MAP());
+
+        when(value.asMap((Function<Value, String>) anyObject())).thenReturn(map);
+
+        when(record.keys()).thenReturn(asList("map"));
+        when(record.values()).thenReturn(asList(value));
+
+        when(result.getRecords()).thenReturn(asList(record));
+        when(result.getSummary()).thenReturn(mock(ResultSummary.class));
+
+        // when
+        String actual = plainPrinter.format(result);
+
+        // then
+        assertThat(actual, is(expectedResult));
     }
 
     @Test

--- a/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/PrettyPrinterTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/PrettyPrinterTest.java
@@ -160,8 +160,8 @@ public class PrettyPrinterTest {
 
     @Test
     public void prettyPrintMaps() throws Exception {
-        checkMapForPrettyPrint(map(), "map\n{}");
-        checkMapForPrettyPrint(map("abc", "def"), "map\n{abc: def}");
+        checkMapForPrettyPrint(map(),  String.format("map%n{}"));
+        checkMapForPrettyPrint(map("abc", "def"), String.format("map%n{abc: def}"));
     }
 
     private void checkMapForPrettyPrint(Map<String, String> map, String expectedResult) {

--- a/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/PrettyPrinterTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/PrettyPrinterTest.java
@@ -160,8 +160,8 @@ public class PrettyPrinterTest {
 
     @Test
     public void prettyPrintMaps() throws Exception {
-        checkMapForPrettyPrint(map(),  String.format("map%n{}"));
-        checkMapForPrettyPrint(map("abc", "def"), String.format("map%n{abc: def}"));
+        checkMapForPrettyPrint(map(), "map\n{}");
+        checkMapForPrettyPrint(map("abc", "def"), "map\n{abc: def}");
     }
 
     private void checkMapForPrettyPrint(Map<String, String> map, String expectedResult) {


### PR DESCRIPTION
when returning an empty map `return {} as map` the output was an empty string. Instead `{}` is expected for value type map. This is fixed by this PR.

In contrast, the "empty string" behaviour is expected for property maps on nodes or relationships. This behaviour is unchanged.