### PR TITLE
Ignore case for commands

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/commands/CommandHelper.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/commands/CommandHelper.java
@@ -1,5 +1,11 @@
 package org.neo4j.shell.commands;
 
+import java.util.List;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import org.neo4j.shell.CypherShell;
 import org.neo4j.shell.Historian;
 import org.neo4j.shell.TransactionHandler;
@@ -9,17 +15,11 @@ import org.neo4j.shell.exception.DuplicateCommandException;
 import org.neo4j.shell.log.AnsiFormattedText;
 import org.neo4j.shell.log.Logger;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.util.List;
-import java.util.TreeMap;
-import java.util.stream.Collectors;
-
 /**
  * Utility methods for dealing with commands
  */
 public class CommandHelper {
-    private final TreeMap<String, Command> commands = new TreeMap<>();
+    private final TreeMap<String, Command> commands = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
     public CommandHelper(Logger logger, Historian historian, CypherShell cypherShell) {
         registerAllCommands(logger, historian, cypherShell, cypherShell);

--- a/cypher-shell/src/test/java/org/neo4j/shell/cli/CommandHelperTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/cli/CommandHelperTest.java
@@ -1,9 +1,18 @@
 package org.neo4j.shell.cli;
 
 import org.junit.Test;
-import org.neo4j.shell.exception.CommandException;
 
-import static org.junit.Assert.*;
+import org.neo4j.shell.CypherShell;
+import org.neo4j.shell.Historian;
+import org.neo4j.shell.commands.Begin;
+import org.neo4j.shell.commands.Command;
+import org.neo4j.shell.commands.CommandHelper;
+import org.neo4j.shell.exception.CommandException;
+import org.neo4j.shell.log.AnsiLogger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.neo4j.shell.commands.CommandHelper.simpleArgParse;
 
 public class CommandHelperTest {
@@ -19,12 +28,26 @@ public class CommandHelperTest {
     }
 
     @Test
-    public void oneArg() throws CommandException {
+    public void oneArg() {
         try {
             assertEquals(0, simpleArgParse("bob", 0, "", ""));
             fail();
         } catch (CommandException e) {
             assertTrue(e.getMessage().contains("Incorrect number of arguments"));
         }
+    }
+
+    @Test
+    public void shouldIgnoreCaseForCommands()
+    {
+        // Given
+        AnsiLogger logger = new AnsiLogger( false );
+        CommandHelper commandHelper = new CommandHelper( logger, Historian.empty, new CypherShell( logger ) );
+
+        // When
+        Command begin = commandHelper.getCommand( ":BEGIN" );
+
+        // Then
+        assertTrue( begin instanceof Begin );
     }
 }


### PR DESCRIPTION
It is confusing that we ignore case for Cypher statements but not for
commands such as `:begin` etc.

Fixes #101