### PR TITLE
Don't send parameter lambdas to server

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ ext {
 
     argparse4jVersion = '0.7.0'
     junitVersion = '4.12'
-    evaluatorVersion = '4.0.0-SNAPSHOT'
+    evaluatorVersion = '3.5.4'
     neo4jJavaDriverVersion = '1.7.0'
     findbugsVersion = '3.0.0'
     jansiVersion = '1.13'

--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,7 @@ ext {
 
     argparse4jVersion = '0.7.0'
     junitVersion = '4.12'
+    evaluatorVersion = '4.0.0-SNAPSHOT'
     neo4jJavaDriverVersion = '1.7.0'
     findbugsVersion = '3.0.0'
     jansiVersion = '1.13'

--- a/cypher-shell/build.gradle
+++ b/cypher-shell/build.gradle
@@ -37,6 +37,7 @@ distributions {
 
 dependencies {
     compile "net.sourceforge.argparse4j:argparse4j:$argparse4jVersion"
+    compile "org.neo4j:neo4j-cypher-expression-evaluator:$evaluatorVersion"
     compile "org.neo4j.driver:neo4j-java-driver:$neo4jJavaDriverVersion"
     compileOnly "com.google.code.findbugs:annotations:$findbugsVersion"
     compile "org.fusesource.jansi:jansi:$jansiVersion"

--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellVerboseIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellVerboseIntegrationTest.java
@@ -12,8 +12,6 @@ import org.neo4j.shell.cli.Format;
 import org.neo4j.shell.exception.CommandException;
 import org.neo4j.shell.prettyprint.PrettyConfig;
 
-import java.util.Optional;
-
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -160,10 +158,8 @@ public class CypherShellVerboseIntegrationTest {
         long randomLong = System.currentTimeMillis();
         String stringInput = "\"randomString\"";
         shell.setParameter("string", stringInput);
-
-        Optional<Object> bob = shell.setParameter("bob", String.valueOf(randomLong));
-        assertTrue(bob.isPresent());
-        assertEquals(randomLong, bob.get());
+        Object paramValue = shell.setParameter("bob", String.valueOf(randomLong));
+        assertEquals(randomLong, paramValue);
 
         shell.execute("RETURN { bob }, $string");
 
@@ -179,9 +175,8 @@ public class CypherShellVerboseIntegrationTest {
         assertTrue(shell.allParameterValues().isEmpty());
 
         long randomLong = System.currentTimeMillis();
-        Optional<Object> bob = shell.setParameter("`bob`", String.valueOf(randomLong));
-        assertTrue(bob.isPresent());
-        assertEquals(randomLong, bob.get());
+        Object paramValue = shell.setParameter("`bob`", String.valueOf(randomLong));
+        assertEquals(randomLong, paramValue);
 
         shell.execute("RETURN { `bob` }");
 

--- a/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
@@ -1,6 +1,5 @@
 package org.neo4j.shell;
 
-import org.neo4j.driver.v1.Record;
 import org.neo4j.cypher.internal.evaluator.EvaluationException;
 import org.neo4j.cypher.internal.evaluator.Evaluator;
 import org.neo4j.cypher.internal.evaluator.ExpressionEvaluator;
@@ -56,7 +55,7 @@ public class CypherShell implements StatementExecuter, Connector, TransactionHan
      * @param text to trim
      * @return text without trailing semicolons
      */
-    private static String stripTrailingSemicolons(@Nonnull String text) {
+    protected static String stripTrailingSemicolons(@Nonnull String text) {
         int end = text.length();
         while (end > 0 && text.substring(0, end).endsWith(";")) {
             end -= 1;
@@ -98,7 +97,7 @@ public class CypherShell implements StatementExecuter, Connector, TransactionHan
     }
 
     @Nonnull
-    private Optional<CommandExecutable> getCommandExecutable(@Nonnull final String line) {
+    protected Optional<CommandExecutable> getCommandExecutable(@Nonnull final String line) {
         Matcher m = cmdNamePattern.matcher(line);
         if (commandHelper == null || !m.matches()) {
             return Optional.empty();
@@ -116,7 +115,7 @@ public class CypherShell implements StatementExecuter, Connector, TransactionHan
         return Optional.of(() -> cmd.execute(stripTrailingSemicolons(args)));
     }
 
-    private void executeCmd(@Nonnull final CommandExecutable cmdExe) throws ExitException, CommandException {
+    protected void executeCmd(@Nonnull final CommandExecutable cmdExe) throws ExitException, CommandException {
         cmdExe.execute();
     }
 
@@ -160,13 +159,12 @@ public class CypherShell implements StatementExecuter, Connector, TransactionHan
 
     @Override
     @Nonnull
-    public Optional<Object> setParameter(@Nonnull String name, @Nonnull String valueString) throws CommandException {
-
+    public Object setParameter(@Nonnull String name, @Nonnull String valueString) throws CommandException {
         try {
             String parameterName = CypherVariablesFormatter.unescapedCypherVariable(name);
             Object value = evaluator.evaluate(valueString, Object.class);
             queryParams.put(parameterName, new ParamValue(valueString, value));
-            return Optional.ofNullable(value);
+            return value;
         } catch (EvaluationException e) {
            throw new CommandException(e.getMessage(), e);
         }
@@ -197,7 +195,7 @@ public class CypherShell implements StatementExecuter, Connector, TransactionHan
         boltStateHandler.reset();
     }
 
-    private void addRuntimeHookToResetShell() {
+    protected void addRuntimeHookToResetShell() {
         Runtime.getRuntime().addShutdownHook(new Thread(this::reset));
     }
 

--- a/cypher-shell/src/main/java/org/neo4j/shell/ParameterMap.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/ParameterMap.java
@@ -5,7 +5,6 @@ import org.neo4j.shell.state.ParamValue;
 
 import javax.annotation.Nonnull;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * An object which keeps named parameters and allows them them to be set/unset.
@@ -14,8 +13,9 @@ public interface ParameterMap {
     /**
      * @param name of variable to set value for
      * @param valueString to interpret the value from
+     * @return the evaluated value
      */
-    Optional setParameter(@Nonnull String name, @Nonnull String valueString) throws CommandException;
+    Object setParameter(@Nonnull String name, @Nonnull String valueString) throws CommandException;
 
     /**
      * @return map of all currently set variables and their values

--- a/cypher-shell/src/main/java/org/neo4j/shell/exception/AnsiFormattedException.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/exception/AnsiFormattedException.java
@@ -16,6 +16,11 @@ public class AnsiFormattedException extends Exception {
         this.message = AnsiFormattedText.from(message);
     }
 
+    public AnsiFormattedException(@Nullable String message, Throwable cause) {
+        super(message, cause);
+        this.message = AnsiFormattedText.from(message);
+    }
+
     public AnsiFormattedException(@Nonnull AnsiFormattedText message) {
         super(message.plainString());
         this.message = message;

--- a/cypher-shell/src/main/java/org/neo4j/shell/exception/CommandException.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/exception/CommandException.java
@@ -13,6 +13,10 @@ public class CommandException extends AnsiFormattedException {
         super(msg);
     }
 
+    public CommandException(@Nullable String msg, Throwable cause) {
+        super(msg, cause);
+    }
+
     public CommandException(@Nonnull AnsiFormattedText append) {
         super(append);
     }

--- a/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
@@ -108,16 +108,13 @@ public class CypherShellTest {
     }
 
     @Test
-    public void setWhenOfflineShouldThrow() throws CommandException {
-        thrown.expect(CommandException.class);
-        thrown.expectMessage("not connected");
-
+    public void setWhenOfflineShouldWork() throws CommandException {
         CypherShell shell = new OfflineTestShell(logger, mockedBoltStateHandler, mockedPrettyPrinter);
         when(mockedBoltStateHandler.isConnected()).thenReturn(false);
-
         when(mockedBoltStateHandler.runCypher(anyString(), anyMap())).thenThrow(new CommandException("not connected"));
 
-        shell.setParameter("bob", "99");
+        Object result = shell.setParameter("bob", "99");
+        assertEquals(99L, result);
     }
 
     @Test
@@ -143,9 +140,9 @@ public class CypherShellTest {
 
         assertTrue(offlineTestShell.allParameterValues().isEmpty());
 
-        Optional result = offlineTestShell.setParameter("`bo``b`", "99");
-        assertEquals("99", result.get());
-        assertEquals("99", offlineTestShell.allParameterValues().get("bo`b"));
+        Object result = offlineTestShell.setParameter("`bo``b`", "99");
+        assertEquals(99L, result);
+        assertEquals(99L, offlineTestShell.allParameterValues().get("bo`b"));
     }
 
     @Test
@@ -161,9 +158,9 @@ public class CypherShellTest {
 
         assertTrue(offlineTestShell.allParameterValues().isEmpty());
 
-        Optional result = offlineTestShell.setParameter("`bob`", "99");
-        assertEquals("99", result.get());
-        assertEquals("99", offlineTestShell.allParameterValues().get("bob"));
+        Object result = offlineTestShell.setParameter("`bob`", "99");
+        assertEquals(99L, result);
+        assertEquals(99L, offlineTestShell.allParameterValues().get("bob"));
     }
 
     @Test
@@ -267,17 +264,13 @@ public class CypherShellTest {
     }
 
     @Test
-    public void setWithSomeBoltError() throws CommandException {
-        // then
-        thrown.expect(CommandException.class);
-        thrown.expectMessage("Failed to set value of parameter");
-
+    public void setParameterDoesNotTriggerByBoltError() throws CommandException {
         // given
         when(mockedBoltStateHandler.runCypher(anyString(), anyMap())).thenReturn(Optional.empty());
-
         CypherShell shell = new CypherShell(logger, mockedBoltStateHandler, mockedPrettyPrinter);
 
         // when
-        shell.setParameter("bob", "99");
+        Object result = shell.setParameter("bob", "99");
+        assertEquals(99L, result);
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
@@ -21,7 +21,6 @@ import org.neo4j.shell.prettyprint.PrettyPrinter;
 import org.neo4j.shell.state.BoltResult;
 import org.neo4j.shell.state.BoltStateHandler;
 import org.neo4j.shell.state.ListBoltResult;
-import org.neo4j.shell.test.OfflineTestShell;
 
 import java.io.IOException;
 import java.util.Optional;

--- a/cypher-shell/src/test/java/org/neo4j/shell/OfflineTestShell.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/OfflineTestShell.java
@@ -1,12 +1,9 @@
-package org.neo4j.shell.test;
+package org.neo4j.shell;
 
 
-import org.neo4j.shell.CypherShell;
 import org.neo4j.shell.log.Logger;
 import org.neo4j.shell.prettyprint.PrettyPrinter;
 import org.neo4j.shell.state.BoltStateHandler;
-
-import static org.mockito.Mockito.mock;
 
 /**
  * This class initializes a {@link CypherShell} with a fake


### PR DESCRIPTION
For evaluating parameters we were basically sending `RETURN expression`
in order to evaluate the expression. This PR replaces that with using a
new shiny stand-alone expression evaluator.