### PR TITLE
Stream results of autocommit queries

### DIFF
--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/MainIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/MainIntegrationTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 import org.neo4j.shell.cli.CliArgs;
 import org.neo4j.shell.log.AnsiLogger;
 import org.neo4j.shell.log.Logger;
+import org.neo4j.shell.prettyprint.PrettyConfig;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -32,8 +33,7 @@ public class MainIntegrationTest {
         cliArgs.setPassword( "", "" );
 
         Logger logger = new AnsiLogger(cliArgs.getDebugMode());
-        logger.setFormat(cliArgs.getFormat());
-
+        PrettyConfig prettyConfig = new PrettyConfig(cliArgs);
         ConnectionConfig connectionConfig = new ConnectionConfig(
                 cliArgs.getScheme(),
                 cliArgs.getHost(),
@@ -42,7 +42,7 @@ public class MainIntegrationTest {
                 cliArgs.getPassword(),
                 cliArgs.getEncryption());
 
-        CypherShell shell = new CypherShell(logger);
+        CypherShell shell = new CypherShell(logger, prettyConfig);
 
         // when
         assertEquals("", connectionConfig.username());

--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/StringLinePrinter.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/StringLinePrinter.java
@@ -8,7 +8,7 @@ public class StringLinePrinter implements LinePrinter {
     private StringBuilder sb = new StringBuilder();
 
     @Override
-    public void println(String line) {
+    public void printOut(String line) {
         sb.append(line).append(OutputFormatter.NEWLINE);
     }
 

--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/StringLinePrinter.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/StringLinePrinter.java
@@ -1,0 +1,22 @@
+package org.neo4j.shell;
+
+import org.neo4j.shell.prettyprint.LinePrinter;
+import org.neo4j.shell.prettyprint.OutputFormatter;
+
+public class StringLinePrinter implements LinePrinter {
+
+    private StringBuilder sb = new StringBuilder();
+
+    @Override
+    public void println(String line) {
+        sb.append(line).append(OutputFormatter.NEWLINE);
+    }
+
+    public void clear() {
+        sb.setLength(0);
+    }
+
+    public String output() {
+        return sb.toString();
+    }
+}

--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellFailureIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellFailureIntegrationTest.java
@@ -5,29 +5,25 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-
 import org.neo4j.driver.v1.exceptions.AuthenticationException;
 import org.neo4j.shell.ConnectionConfig;
 import org.neo4j.shell.CypherShell;
+import org.neo4j.shell.StringLinePrinter;
 import org.neo4j.shell.cli.Format;
 import org.neo4j.shell.exception.CommandException;
-import org.neo4j.shell.log.Logger;
-
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
+import org.neo4j.shell.prettyprint.PrettyConfig;
 
 public class CypherShellFailureIntegrationTest {
     @Rule
     public final ExpectedException thrown = ExpectedException.none();
 
-    private Logger logger = mock(Logger.class);
+    private StringLinePrinter linePrinter = new StringLinePrinter();
     private CypherShell shell;
 
     @Before
     public void setUp() throws Exception {
-        doReturn(Format.VERBOSE).when(logger).getFormat();
-
-        shell = new CypherShell(logger);
+        linePrinter.clear();
+        shell = new CypherShell(linePrinter, new PrettyConfig(Format.VERBOSE, true, 1000));
     }
 
     @Test

--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellVerboseIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellVerboseIntegrationTest.java
@@ -195,7 +195,7 @@ public class CypherShellVerboseIntegrationTest {
     public void cypherWithOrder() throws CommandException {
         // given
         String serverVersion = shell.getServerVersion();
-        assumeTrue(minorVersion(serverVersion) >= 5 || majorVersion(serverVersion) == 4);
+        assumeTrue(minorVersion(serverVersion) == 6 || majorVersion(serverVersion) == 4);
 
         shell.execute( "CREATE INDEX ON :Person(age)" );
 

--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellVerboseIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellVerboseIntegrationTest.java
@@ -5,29 +5,28 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.mockito.ArgumentCaptor;
 import org.neo4j.shell.ConnectionConfig;
 import org.neo4j.shell.CypherShell;
+import org.neo4j.shell.StringLinePrinter;
 import org.neo4j.shell.cli.Format;
 import org.neo4j.shell.exception.CommandException;
-import org.neo4j.shell.log.Logger;
+import org.neo4j.shell.prettyprint.PrettyConfig;
 
-import java.util.List;
 import java.util.Optional;
 
-import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
-import static org.mockito.Mockito.*;
 import static org.neo4j.shell.Versions.majorVersion;
+import static org.neo4j.shell.Versions.minorVersion;
 
 public class CypherShellVerboseIntegrationTest {
     @Rule
     public final ExpectedException thrown = ExpectedException.none();
 
-    private Logger logger = mock(Logger.class);
+    private StringLinePrinter linePrinter = new StringLinePrinter();
     private Command rollbackCommand;
     private Command commitCommand;
     private Command beginCommand;
@@ -35,9 +34,8 @@ public class CypherShellVerboseIntegrationTest {
 
     @Before
     public void setUp() throws Exception {
-        doReturn(Format.VERBOSE).when(logger).getFormat();
-
-        shell = new CypherShell(logger);
+        linePrinter.clear();
+        shell = new CypherShell(linePrinter, new PrettyConfig(Format.VERBOSE, true, 1000));
         rollbackCommand = new Rollback(shell);
         commitCommand = new Commit(shell);
         beginCommand = new Begin(shell);
@@ -56,11 +54,7 @@ public class CypherShellVerboseIntegrationTest {
         shell.execute("CREATE (:TestPerson {name: \"Jane Smith\"})");
 
         //then
-        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-        verify(logger, times(1)).printOut(captor.capture());
-
-        List<String> result = captor.getAllValues();
-        assertThat(result.get(0), containsString("Added 1 nodes, Set 1 properties, Added 1 labels"));
+        assertThat(linePrinter.output(), containsString("Added 1 nodes, Set 1 properties, Added 1 labels"));
     }
 
     @Test
@@ -69,13 +63,10 @@ public class CypherShellVerboseIntegrationTest {
         shell.execute("CREATE (jane :TestPerson {name: \"Jane Smith\"}) RETURN jane");
 
         //then
-        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-        verify(logger, times(1)).printOut(captor.capture());
-
-        List<String> result = captor.getAllValues();
-        assertThat(result.get(0), containsString("| jane "));
-        assertThat(result.get(0), containsString("| (:TestPerson {name: \"Jane Smith\"}) |" ));
-        assertThat(result.get(0), containsString("Added 1 nodes, Set 1 properties, Added 1 labels"));
+        String output = linePrinter.output();
+        assertThat(output, containsString("| jane "));
+        assertThat(output, containsString("| (:TestPerson {name: \"Jane Smith\"}) |" ));
+        assertThat(output, containsString("Added 1 nodes, Set 1 properties, Added 1 labels"));
     }
 
     @Test
@@ -95,18 +86,16 @@ public class CypherShellVerboseIntegrationTest {
 
         //when
         beginCommand.execute("");
-        shell.execute("CREATE (:Random)");
+        shell.execute("CREATE (:NotCreated)");
         rollbackCommand.execute("");
 
         //then
-        shell.execute("MATCH (n:TestPerson) RETURN n ORDER BY n.name");
+        shell.execute("MATCH (n) RETURN n");
 
-        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-        verify(logger, times(2)).printOut(captor.capture());
-
-        List<String> result = captor.getAllValues();
-        assertThat(result.get(1), containsString("| n "));
-        assertThat(result.get(1), containsString("| (:TestPerson {name: \"Jane Smith\"}) |"));
+        String output = linePrinter.output();
+        assertThat(output, containsString("| n "));
+        assertThat(output, containsString("| (:TestPerson {name: \"Jane Smith\"}) |"));
+        assertThat(output, not(containsString(":NotCreated")));
     }
 
     @Test
@@ -119,47 +108,48 @@ public class CypherShellVerboseIntegrationTest {
         shell.execute("CREATE (:TestPerson {name: \"Jane Smith\"})");
         shell.execute("MATCH (n:TestPerson) RETURN n ORDER BY n.name");
 
-        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-        verify(logger, times(3)).printOut(captor.capture());
-
-        List<String> result = captor.getAllValues();
-        assertThat(result.get(2), containsString("| (:TestPerson {name: \"Jane Smith\"}) |" +
-                "\n| (:TestPerson {name: \"Jane Smith\"}) |"));
+        String result = linePrinter.output();
+        assertThat(result, containsString(
+                "| (:TestPerson {name: \"Jane Smith\"}) |\n" +
+                "| (:TestPerson {name: \"Jane Smith\"}) |"));
     }
 
     @Test
     public void resetInTxScenario() throws CommandException {
         //when
         beginCommand.execute("");
-        shell.execute("CREATE (:Random)");
+        shell.execute("CREATE (:NotCreated)");
         shell.reset();
 
         //then
         shell.execute("CREATE (:TestPerson {name: \"Jane Smith\"})");
-        shell.execute("MATCH (n:TestPerson) RETURN n ORDER BY n.name");
+        shell.execute("MATCH (n) RETURN n");
 
-        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-        verify(logger, times(2)).printOut(captor.capture());
-
-        List<String> result = captor.getAllValues();
-        assertThat(result.get(1), containsString("| (:TestPerson {name: \"Jane Smith\"}) |"));
+        String result = linePrinter.output();
+        assertThat(result, containsString("| (:TestPerson {name: \"Jane Smith\"}) |"));
+        assertThat(result, not(containsString(":NotCreated")));
     }
 
     @Test
     public void commitScenario() throws CommandException {
         beginCommand.execute("");
         shell.execute("CREATE (:TestPerson {name: \"Joe Smith\"})");
+        assertThat(linePrinter.output(), equalTo(""));
+        // Here ^^ we assert that nothing is printed before commit on explicit transactions. This was
+        // existing behaviour on typing this comment, but it could we worth thinking that through if
+        // we change explicit transaction queries to stream results.
+
         shell.execute("CREATE (:TestPerson {name: \"Jane Smith\"})");
+        assertThat(linePrinter.output(), equalTo(""));
+
         shell.execute("MATCH (n:TestPerson) RETURN n ORDER BY n.name");
+        assertThat(linePrinter.output(), equalTo(""));
+
         commitCommand.execute("");
 
         //then
-
-        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-        verify(logger, times(3)).printOut(captor.capture());
-
-        List<String> result = captor.getAllValues();
-        assertThat(result.get(2),
+        String result = linePrinter.output();
+        assertThat(result,
                 containsString("\n| (:TestPerson {name: \"Jane Smith\"}) |\n| (:TestPerson {name: \"Joe Smith\"})  |\n"));
     }
 
@@ -170,18 +160,16 @@ public class CypherShellVerboseIntegrationTest {
         long randomLong = System.currentTimeMillis();
         String stringInput = "\"randomString\"";
         shell.setParameter("string", stringInput);
-        Optional result = shell.setParameter("bob", String.valueOf(randomLong));
-        assertTrue(result.isPresent());
-        assertEquals(randomLong, result.get());
+
+        Optional<Object> bob = shell.setParameter("bob", String.valueOf(randomLong));
+        assertTrue(bob.isPresent());
+        assertEquals(randomLong, bob.get());
 
         shell.execute("RETURN { bob }, $string");
 
-        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-        verify(logger).printOut(captor.capture());
-
-        List<String> queryResult = captor.getAllValues();
-        assertThat(queryResult.get(0), containsString("| { bob }"));
-        assertThat(queryResult.get(0), containsString("| " + randomLong + " | " + stringInput + " |"));
+        String result = linePrinter.output();
+        assertThat(result, containsString("| { bob }"));
+        assertThat(result, containsString("| " + randomLong + " | " + stringInput + " |"));
         assertEquals(randomLong, shell.allParameterValues().get("bob"));
         assertEquals("randomString", shell.allParameterValues().get("string"));
     }
@@ -191,40 +179,33 @@ public class CypherShellVerboseIntegrationTest {
         assertTrue(shell.allParameterValues().isEmpty());
 
         long randomLong = System.currentTimeMillis();
-        Optional result = shell.setParameter("`bob`", String.valueOf(randomLong));
-        assertTrue(result.isPresent());
-        assertEquals(randomLong, result.get());
+        Optional<Object> bob = shell.setParameter("`bob`", String.valueOf(randomLong));
+        assertTrue(bob.isPresent());
+        assertEquals(randomLong, bob.get());
 
         shell.execute("RETURN { `bob` }");
 
-        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-        verify(logger).printOut(captor.capture());
-
-        List<String> queryResult = captor.getAllValues();
-        assertThat(queryResult.get(0), containsString("| { `bob` }"));
-        assertThat(queryResult.get(0), containsString("\n| " + randomLong+ " |\n"));
+        String result = linePrinter.output();
+        assertThat(result, containsString("| { `bob` }"));
+        assertThat(result, containsString("\n| " + randomLong+ " |\n"));
         assertEquals(randomLong, shell.allParameterValues().get("bob"));
     }
 
     @Test
     public void cypherWithOrder() throws CommandException {
         // given
+        String serverVersion = shell.getServerVersion();
+        assumeTrue(minorVersion(serverVersion) >= 5 || majorVersion(serverVersion) == 4);
+
         shell.execute( "CREATE INDEX ON :Person(age)" );
 
         //when
         shell.execute("CYPHER RUNTIME=INTERPRETED EXPLAIN MATCH (n:Person) WHERE n.age >= 18 RETURN n.name, n.age");
 
         //then
-        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-        verify(logger, times(2)).printOut(captor.capture());
-
-        List<String> result = captor.getAllValues();
-        String actual = result.get(0);
-        if ( actual.contains( "CYPHER 3.5" )) // Sadly best way to have test that relies on 3.5 functionality...
-        {
-            assertThat( actual, containsString( "Ordered by" ) );
-            assertThat( actual, containsString( "n.age ASC" ) );
-        }
+        String actual = linePrinter.output();
+        assertThat( actual, containsString( "Ordered by" ) );
+        assertThat( actual, containsString( "n.age ASC" ) );
     }
 
     @Test
@@ -236,11 +217,7 @@ public class CypherShellVerboseIntegrationTest {
         shell.execute("CYPHER planner=rule EXPLAIN MATCH (e:E) WHERE e.bucket='Live' and e.id = 23253473 RETURN count(e)");
 
         //then
-        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-        verify(logger, times(1)).printOut(captor.capture());
-
-        List<String> result = captor.getAllValues();
-        String actual = result.get(0);
+        String actual = linePrinter.output();
         assertThat(actual, containsString("\"EXPLAIN\""));
         assertThat(actual, containsString("\"READ_ONLY\""));
         assertThat(actual, containsString("\"RULE\""));

--- a/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
@@ -34,7 +34,7 @@ public class CypherShell implements StatementExecuter, Connector, TransactionHan
     protected CommandHelper commandHelper;
 
     public CypherShell(@Nonnull Logger logger) {
-        this(logger, new BoltStateHandler(), new PrettyPrinter(logger.getFormat()));
+        this(logger, new BoltStateHandler(), new PrettyPrinter(logger.getFormat(), logger.getWrap(), logger.getNumSampleRows()));
     }
 
     protected CypherShell(@Nonnull Logger logger,
@@ -83,7 +83,7 @@ public class CypherShell implements StatementExecuter, Connector, TransactionHan
      */
     protected void executeCypher(@Nonnull final String cypher) throws CommandException {
         final Optional<BoltResult> result = boltStateHandler.runCypher(cypher, allParameterValues());
-        result.ifPresent(boltResult -> logger.printOut(prettyPrinter.format(boltResult)));
+        result.ifPresent(boltResult -> prettyPrinter.format(boltResult, logger::printOut));
     }
 
     @Override
@@ -138,7 +138,7 @@ public class CypherShell implements StatementExecuter, Connector, TransactionHan
     @Override
     public Optional<List<BoltResult>> commitTransaction() throws CommandException {
         Optional<List<BoltResult>> results = boltStateHandler.commitTransaction();
-        results.ifPresent(boltResult -> boltResult.forEach(result -> logger.printOut(prettyPrinter.format(result))));
+        results.ifPresent(boltResult -> boltResult.forEach(result -> prettyPrinter.format(result, logger::printOut)));
         return results;
     }
 

--- a/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
@@ -1,12 +1,14 @@
 package org.neo4j.shell;
 
+import org.neo4j.driver.v1.Record;
 import org.neo4j.shell.commands.Command;
 import org.neo4j.shell.commands.CommandExecutable;
 import org.neo4j.shell.commands.CommandHelper;
 import org.neo4j.shell.exception.CommandException;
 import org.neo4j.shell.exception.ExitException;
-import org.neo4j.shell.log.Logger;
 import org.neo4j.shell.prettyprint.CypherVariablesFormatter;
+import org.neo4j.shell.prettyprint.LinePrinter;
+import org.neo4j.shell.prettyprint.PrettyConfig;
 import org.neo4j.shell.prettyprint.PrettyPrinter;
 import org.neo4j.shell.state.BoltResult;
 import org.neo4j.shell.state.BoltStateHandler;
@@ -28,19 +30,19 @@ public class CypherShell implements StatementExecuter, Connector, TransactionHan
     // Final space to catch newline
     protected static final Pattern cmdNamePattern = Pattern.compile("^\\s*(?<name>[^\\s]+)\\b(?<args>.*)\\s*$");
     protected final Map<String, ParamValue> queryParams = new HashMap<>();
-    private final Logger logger;
+    private final LinePrinter linePrinter;
     private final BoltStateHandler boltStateHandler;
     private final PrettyPrinter prettyPrinter;
     protected CommandHelper commandHelper;
 
-    public CypherShell(@Nonnull Logger logger) {
-        this(logger, new BoltStateHandler(), new PrettyPrinter(logger.getFormat(), logger.getWrap(), logger.getNumSampleRows()));
+    public CypherShell(@Nonnull LinePrinter linePrinter, @Nonnull PrettyConfig prettyConfig) {
+        this(linePrinter, new BoltStateHandler(), new PrettyPrinter(prettyConfig));
     }
 
-    protected CypherShell(@Nonnull Logger logger,
+    protected CypherShell(@Nonnull LinePrinter linePrinter,
                           @Nonnull BoltStateHandler boltStateHandler,
                           @Nonnull PrettyPrinter prettyPrinter) {
-        this.logger = logger;
+        this.linePrinter = linePrinter;
         this.boltStateHandler = boltStateHandler;
         this.prettyPrinter = prettyPrinter;
         addRuntimeHookToResetShell();
@@ -83,7 +85,7 @@ public class CypherShell implements StatementExecuter, Connector, TransactionHan
      */
     protected void executeCypher(@Nonnull final String cypher) throws CommandException {
         final Optional<BoltResult> result = boltStateHandler.runCypher(cypher, allParameterValues());
-        result.ifPresent(boltResult -> prettyPrinter.format(boltResult, logger::printOut));
+        result.ifPresent(boltResult -> prettyPrinter.format(boltResult, linePrinter));
     }
 
     @Override
@@ -138,7 +140,7 @@ public class CypherShell implements StatementExecuter, Connector, TransactionHan
     @Override
     public Optional<List<BoltResult>> commitTransaction() throws CommandException {
         Optional<List<BoltResult>> results = boltStateHandler.commitTransaction();
-        results.ifPresent(boltResult -> boltResult.forEach(result -> prettyPrinter.format(result, logger::printOut)));
+        results.ifPresent(boltResult -> boltResult.forEach(result -> prettyPrinter.format(result, linePrinter)));
         return results;
     }
 
@@ -154,21 +156,25 @@ public class CypherShell implements StatementExecuter, Connector, TransactionHan
 
     @Override
     @Nonnull
-    public Optional setParameter(@Nonnull String name, @Nonnull String valueString) throws CommandException {
-        final BoltResult result = setParamsAndValidate(name, valueString);
+    public Optional<Object> setParameter(@Nonnull String name, @Nonnull String valueString) throws CommandException {
+        final Record records = evaluateParamOnServer(name, valueString);
         String parameterName = CypherVariablesFormatter.unescapedCypherVariable(name);
-        final Object value = result.getRecords().get(0).get(parameterName).asObject();
+        final Object value = records.get(parameterName).asObject();
         queryParams.put(parameterName, new ParamValue(valueString, value));
         return Optional.ofNullable(value);
     }
 
-    private BoltResult setParamsAndValidate(@Nonnull String name, @Nonnull String valueString) throws CommandException {
+    private Record evaluateParamOnServer(@Nonnull String name, @Nonnull String valueString) throws CommandException {
         String cypher = "RETURN " + valueString + " as " + name;
-        final Optional<BoltResult> result = boltStateHandler.runCypher(cypher, allParameterValues());
-        if (!result.isPresent() || result.get().getRecords().isEmpty()) {
+        final Optional<BoltResult> resultOpt = boltStateHandler.runCypher(cypher, allParameterValues());
+        if (!resultOpt.isPresent()) {
             throw new CommandException("Failed to set value of parameter");
         }
-        return result.get();
+        List<Record> records = resultOpt.get().getRecords();
+        if (records.size() != 1) {
+            throw new CommandException("Failed to set value of parameter");
+        }
+        return records.get(0);
     }
 
     @Override

--- a/cypher-shell/src/main/java/org/neo4j/shell/Main.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/Main.java
@@ -93,6 +93,8 @@ public class Main {
         if (cliArgs.isStringShell() && Format.AUTO.equals(cliArgs.getFormat())) {
             logger.setFormat(Format.PLAIN);
         }
+        logger.setWrap(cliArgs.getWrap());
+        logger.setNumSampleRows(cliArgs.getNumSampleRows());
         return logger;
     }
 

--- a/cypher-shell/src/main/java/org/neo4j/shell/Main.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/Main.java
@@ -10,6 +10,7 @@ import org.neo4j.shell.commands.CommandHelper;
 import org.neo4j.shell.exception.CommandException;
 import org.neo4j.shell.log.AnsiLogger;
 import org.neo4j.shell.log.Logger;
+import org.neo4j.shell.prettyprint.PrettyConfig;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -58,7 +59,8 @@ public class Main {
         if (cliArgs.getVersion() || cliArgs.getDriverVersion()) {
             return;
         }
-        Logger logger = instantiateLogger(cliArgs);
+        Logger logger = new AnsiLogger(cliArgs.getDebugMode());
+        PrettyConfig prettyConfig = new PrettyConfig(cliArgs);
         ConnectionConfig connectionConfig = new ConnectionConfig(
                 cliArgs.getScheme(),
                 cliArgs.getHost(),
@@ -68,7 +70,7 @@ public class Main {
                 cliArgs.getEncryption());
 
         try {
-            CypherShell shell = new CypherShell(logger);
+            CypherShell shell = new CypherShell(logger, prettyConfig);
             // Can only prompt for password if input has not been redirected
             connectMaybeInteractively(shell, connectionConfig, isInputInteractive());
 
@@ -85,17 +87,6 @@ public class Main {
             logger.printError(e);
             System.exit(1);
         }
-    }
-
-    private Logger instantiateLogger(@Nonnull CliArgs cliArgs) {
-        Logger logger = new AnsiLogger(cliArgs.getDebugMode());
-        logger.setFormat(cliArgs.getFormat());
-        if (cliArgs.isStringShell() && Format.AUTO.equals(cliArgs.getFormat())) {
-            logger.setFormat(Format.PLAIN);
-        }
-        logger.setWrap(cliArgs.getWrap());
-        logger.setNumSampleRows(cliArgs.getNumSampleRows());
-        return logger;
     }
 
     /**

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgHelper.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgHelper.java
@@ -5,11 +5,7 @@ import net.sourceforge.argparse4j.impl.action.StoreConstArgumentAction;
 import net.sourceforge.argparse4j.impl.action.StoreTrueArgumentAction;
 import net.sourceforge.argparse4j.impl.choice.CollectionArgumentChoice;
 import net.sourceforge.argparse4j.impl.type.BooleanArgumentType;
-import net.sourceforge.argparse4j.inf.ArgumentGroup;
-import net.sourceforge.argparse4j.inf.ArgumentParser;
-import net.sourceforge.argparse4j.inf.ArgumentParserException;
-import net.sourceforge.argparse4j.inf.MutuallyExclusiveGroup;
-import net.sourceforge.argparse4j.inf.Namespace;
+import net.sourceforge.argparse4j.inf.*;
 
 import java.io.PrintWriter;
 import java.util.regex.Matcher;
@@ -87,6 +83,10 @@ public class CliArgHelper {
         cliArgs.setDebugMode(ns.getBoolean("debug"));
 
         cliArgs.setNonInteractive(ns.getBoolean("force-non-interactive"));
+
+        cliArgs.setWrap(ns.getBoolean("wrap"));
+
+        cliArgs.setNumSampleRows(ns.getInt("sample-rows"));
 
         cliArgs.setVersion(ns.getBoolean("version"));
 
@@ -167,6 +167,17 @@ public class CliArgHelper {
                 .dest("force-non-interactive")
               .action(new StoreTrueArgumentAction());
 
+        parser.addArgument("--sample-rows")
+                .help("number of rows sampled to compute table widths (only for format=VERBOSE)")
+                .type(new PositiveIntegerType())
+                .dest("sample-rows")
+                .setDefault(CliArgs.DEFAULT_NUM_SAMPLE_ROWS);
+
+        parser.addArgument("--wrap")
+                .help("wrap table colum values if column is too narrow (only for format=VERBOSE)")
+                .type(new BooleanArgumentType())
+                .setDefault(true);
+
         parser.addArgument("-v", "--version")
                 .help("print version of cypher-shell and exit")
                 .action(new StoreTrueArgumentAction());
@@ -183,5 +194,16 @@ public class CliArgHelper {
         return parser;
     }
 
-
+    private static class PositiveIntegerType implements ArgumentType<Integer> {
+        @Override
+        public Integer convert(ArgumentParser parser, Argument arg, String value) throws ArgumentParserException {
+            try {
+                int result = Integer.parseInt(value);
+                if (result < 1) throw new NumberFormatException(value);
+                return result;
+            } catch (NumberFormatException nfe) {
+                throw new ArgumentParserException("Invalid value: "+value, parser);
+            }
+        }
+    }
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgs.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgs.java
@@ -5,9 +5,14 @@ import javax.annotation.Nullable;
 import java.util.Optional;
 
 public class CliArgs {
-    private String scheme = "bolt://";
-    private String host = "localhost";
-    private int port = 7687;
+    private static final String DEFAULT_SCHEME = "bolt://";
+    private static final String DEFAULT_HOST = "localhost";
+    private static final int DEFAULT_PORT = 7687;
+    static final int DEFAULT_NUM_SAMPLE_ROWS = 1000;
+
+    private String scheme = DEFAULT_SCHEME;
+    private String host = DEFAULT_HOST;
+    private int port = DEFAULT_PORT;
     private String username = "";
     private String password = "";
     private FailBehavior failBehavior = FailBehavior.FAIL_FAST;
@@ -18,6 +23,8 @@ public class CliArgs {
     private boolean nonInteractive = false;
     private boolean version = false;
     private boolean driverVersion = false;
+    private int numSampleRows = DEFAULT_NUM_SAMPLE_ROWS;
+    private boolean wrap = true;
 
     /**
      * Set the scheme to the primary value, or if null, the fallback value.
@@ -106,7 +113,6 @@ public class CliArgs {
         return host;
     }
 
-    @Nonnull
     public int getPort() {
         return port;
     }
@@ -166,5 +172,23 @@ public class CliArgs {
 
     public boolean isStringShell() {
         return cypher.isPresent();
+    }
+
+    public boolean getWrap() {
+        return wrap;
+    }
+
+    public void setWrap(boolean wrap) {
+        this.wrap = wrap;
+    }
+
+    public int getNumSampleRows() {
+        return numSampleRows;
+    }
+
+    public void setNumSampleRows(Integer numSampleRows) {
+        if (numSampleRows != null && numSampleRows > 0) {
+            this.numSampleRows = numSampleRows;
+        }
     }
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/log/AnsiLogger.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/log/AnsiLogger.java
@@ -23,6 +23,8 @@ public class AnsiLogger implements Logger {
     private final PrintStream err;
     private final boolean debug;
     private Format format;
+    private int numSampleRows;
+    private boolean wrap = true;
 
     public AnsiLogger(final boolean debug) {
         this(debug, Format.VERBOSE, System.out, System.err);
@@ -64,6 +66,26 @@ public class AnsiLogger implements Logger {
      */
     private static boolean isOutputInteractive() {
         return 1 == isatty(STDOUT_FILENO) && 1 == isatty(STDERR_FILENO);
+    }
+
+    @Override
+    public int getNumSampleRows() {
+        return numSampleRows;
+    }
+
+    @Override
+    public void setNumSampleRows(int numSampleRows) {
+        this.numSampleRows = numSampleRows;
+    }
+
+    @Override
+    public boolean getWrap() {
+        return wrap;
+    }
+
+    @Override
+    public void setWrap(boolean wrap) {
+        this.wrap = wrap;
     }
 
     @Nonnull

--- a/cypher-shell/src/main/java/org/neo4j/shell/log/AnsiLogger.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/log/AnsiLogger.java
@@ -109,11 +109,6 @@ public class AnsiLogger implements Logger {
         out.println(Ansi.ansi().render(msg).toString());
     }
 
-    @Override
-    public void println(String line) {
-        printOut(line);
-    }
-
     /**
      * Interpret the cause of a Bolt exception and translate it into a sensible error message.
      */

--- a/cypher-shell/src/main/java/org/neo4j/shell/log/AnsiLogger.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/log/AnsiLogger.java
@@ -23,8 +23,6 @@ public class AnsiLogger implements Logger {
     private final PrintStream err;
     private final boolean debug;
     private Format format;
-    private int numSampleRows;
-    private boolean wrap = true;
 
     public AnsiLogger(final boolean debug) {
         this(debug, Format.VERBOSE, System.out, System.err);
@@ -68,26 +66,6 @@ public class AnsiLogger implements Logger {
         return 1 == isatty(STDOUT_FILENO) && 1 == isatty(STDERR_FILENO);
     }
 
-    @Override
-    public int getNumSampleRows() {
-        return numSampleRows;
-    }
-
-    @Override
-    public void setNumSampleRows(int numSampleRows) {
-        this.numSampleRows = numSampleRows;
-    }
-
-    @Override
-    public boolean getWrap() {
-        return wrap;
-    }
-
-    @Override
-    public void setWrap(boolean wrap) {
-        this.wrap = wrap;
-    }
-
     @Nonnull
     @Override
     public PrintStream getOutputStream() {
@@ -129,6 +107,11 @@ public class AnsiLogger implements Logger {
     @Override
     public void printOut(@Nonnull final String msg) {
         out.println(Ansi.ansi().render(msg).toString());
+    }
+
+    @Override
+    public void println(String line) {
+        printOut(line);
     }
 
     /**

--- a/cypher-shell/src/main/java/org/neo4j/shell/log/Logger.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/log/Logger.java
@@ -35,13 +35,6 @@ public interface Logger extends LinePrinter {
     void printError(@Nonnull String text);
 
     /**
-     * Print the designated text to configured output stream.
-     *
-     * @param text to print to the output stream
-     */
-    void printOut(@Nonnull String text);
-
-    /**
      * @return the current format of the logger
      */
     @Nonnull

--- a/cypher-shell/src/main/java/org/neo4j/shell/log/Logger.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/log/Logger.java
@@ -1,11 +1,12 @@
 package org.neo4j.shell.log;
 
 import org.neo4j.shell.cli.Format;
+import org.neo4j.shell.prettyprint.LinePrinter;
 
 import javax.annotation.Nonnull;
 import java.io.PrintStream;
 
-public interface Logger {
+public interface Logger extends LinePrinter {
     /**
      * @return the output stream
      */
@@ -92,12 +93,4 @@ public interface Logger {
             printOut(text);
         }
     }
-
-    boolean getWrap();
-
-    void setWrap(boolean wrap);
-
-    int getNumSampleRows();
-
-    void setNumSampleRows(int numSampleRows);
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/log/Logger.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/log/Logger.java
@@ -92,4 +92,12 @@ public interface Logger {
             printOut(text);
         }
     }
+
+    boolean getWrap();
+
+    void setWrap(boolean wrap);
+
+    int getNumSampleRows();
+
+    void setNumSampleRows(int numSampleRows);
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/LinePrinter.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/LinePrinter.java
@@ -1,0 +1,9 @@
+package org.neo4j.shell.prettyprint;
+
+/**
+ * Prints lines.
+ */
+@FunctionalInterface
+public interface LinePrinter {
+    void println( String line );
+}

--- a/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/LinePrinter.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/LinePrinter.java
@@ -5,5 +5,11 @@ package org.neo4j.shell.prettyprint;
  */
 @FunctionalInterface
 public interface LinePrinter {
-    void println( String line );
+
+    /**
+     * Print the designated line to configured output stream.
+     *
+     * @param line to print to the output stream
+     */
+    void printOut(String line );
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/OutputFormatter.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/OutputFormatter.java
@@ -163,7 +163,7 @@ public interface OutputFormatter {
     }
 
     @Nonnull static String rightPad(@Nonnull String str, int width) {
-        return rightPad(str,width,' ');
+        return rightPad(str, width, ' ');
     }
     @Nonnull static String rightPad(@Nonnull String str, int width, char c) {
         int actualSize = str.length();

--- a/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/OutputFormatter.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/OutputFormatter.java
@@ -13,11 +13,7 @@ import org.neo4j.driver.v1.types.Relationship;
 import org.neo4j.shell.state.BoltResult;
 
 import javax.annotation.Nonnull;
-import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
@@ -26,15 +22,18 @@ import static org.neo4j.shell.prettyprint.CypherVariablesFormatter.escape;
 
 public interface OutputFormatter {
 
+    enum Capablities {info, plan, result, footer, statistics}
+
     String COMMA_SEPARATOR = ", ";
     String COLON_SEPARATOR = ": ";
     String COLON = ":";
     String SPACE = " ";
     String NEWLINE =  System.getProperty("line.separator");
 
-    @Nonnull String format(@Nonnull BoltResult result);
+    void format(@Nonnull BoltResult result, @Nonnull LinePrinter linePrinter);
 
-    @Nonnull default String formatValue(@Nonnull final Value value) {
+    @Nonnull default String formatValue(final Value value) {
+        if (value == null) return "";
         TypeRepresentation type = (TypeRepresentation) value.type();
         switch (type.constructor()) {
             case LIST:
@@ -101,7 +100,7 @@ public interface OutputFormatter {
             }
         }
 
-        return list.stream().collect(Collectors.joining());
+        return String.join("", list);
     }
 
     @Nonnull default String relationshipAsString(@Nonnull Relationship relationship) {
@@ -187,6 +186,7 @@ public interface OutputFormatter {
         return "";
     }
 
+    Set<Capablities> capabilities();
 
     List<String> INFO = asList("Version", "Planner", "Runtime");
 

--- a/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/PrettyConfig.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/PrettyConfig.java
@@ -1,0 +1,33 @@
+package org.neo4j.shell.prettyprint;
+
+import org.neo4j.shell.cli.CliArgs;
+import org.neo4j.shell.cli.Format;
+
+/**
+ * Configuration of pretty printer.
+ */
+public class PrettyConfig {
+
+    public static final PrettyConfig DEFAULT = new PrettyConfig(new CliArgs());
+
+    public final Format format;
+    public final boolean wrap;
+    public final int numSampleRows;
+
+    public PrettyConfig(CliArgs cliArgs) {
+        this(selectFormat(cliArgs), cliArgs.getWrap(), cliArgs.getNumSampleRows());
+    }
+
+    private static Format selectFormat(CliArgs cliArgs) {
+        if (cliArgs.isStringShell() && Format.AUTO.equals(cliArgs.getFormat())) {
+            return Format.PLAIN;
+        }
+        return cliArgs.getFormat();
+    }
+
+    public PrettyConfig(Format format, boolean wrap, int numSampleRows) {
+        this.format = format;
+        this.wrap = wrap;
+        this.numSampleRows = numSampleRows;
+    }
+}

--- a/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/PrettyPrinter.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/PrettyPrinter.java
@@ -5,7 +5,7 @@ import org.neo4j.shell.state.BoltResult;
 
 import javax.annotation.Nonnull;
 
-import static java.util.Arrays.asList;
+import java.util.Set;
 
 /**
  * Print the result from neo4j in a intelligible fashion.
@@ -14,17 +14,26 @@ public class PrettyPrinter {
     private final StatisticsCollector statisticsCollector;
     private final OutputFormatter outputFormatter;
 
-    public PrettyPrinter(@Nonnull Format format) {
+    public PrettyPrinter(@Nonnull Format format, boolean wrap, int numSampleRows) {
         this.statisticsCollector = new StatisticsCollector(format);
-        this.outputFormatter = format == Format.VERBOSE ? new TableOutputFormatter() : new SimpleOutputFormatter();
+        this.outputFormatter = format == Format.VERBOSE ? new TableOutputFormatter(wrap, numSampleRows) : new SimpleOutputFormatter();
     }
 
-    public String format(@Nonnull final BoltResult result) {
-        String infoOutput = outputFormatter.formatInfo(result.getSummary());
-        String planOutput = outputFormatter.formatPlan(result.getSummary());
-        String statistics = statisticsCollector.collect(result.getSummary());
-        String resultOutput = outputFormatter.format(result);
-        String footer = outputFormatter.formatFooter(result);
-        return OutputFormatter.joinNonBlanks(OutputFormatter.NEWLINE, asList(infoOutput, planOutput, resultOutput, footer, statistics));
+    public void format(@Nonnull final BoltResult result, LinePrinter linePrinter) {
+        Set<OutputFormatter.Capablities> capabilities = outputFormatter.capabilities();
+
+        if (capabilities.contains(OutputFormatter.Capablities.result)) outputFormatter.format(result, linePrinter);
+
+        if (capabilities.contains(OutputFormatter.Capablities.info)) linePrinter.println(outputFormatter.formatInfo(result.getSummary()));
+        if (capabilities.contains(OutputFormatter.Capablities.plan)) linePrinter.println(outputFormatter.formatPlan(result.getSummary()));
+        if (capabilities.contains(OutputFormatter.Capablities.footer)) linePrinter.println(outputFormatter.formatFooter(result));
+        if (capabilities.contains(OutputFormatter.Capablities.statistics)) linePrinter.println(statisticsCollector.collect(result.getSummary()));
+    }
+
+    // Helper for testing
+    String format(@Nonnull final BoltResult result) {
+        StringBuilder sb = new StringBuilder();
+        format(result, line -> {if (line!=null && !line.trim().isEmpty()) sb.append(line).append(OutputFormatter.NEWLINE);});
+        return sb.toString();
     }
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/PrettyPrinter.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/PrettyPrinter.java
@@ -24,10 +24,10 @@ public class PrettyPrinter {
 
         if (capabilities.contains(OutputFormatter.Capablities.result)) outputFormatter.format(result, linePrinter);
 
-        if (capabilities.contains(OutputFormatter.Capablities.info)) linePrinter.println(outputFormatter.formatInfo(result.getSummary()));
-        if (capabilities.contains(OutputFormatter.Capablities.plan)) linePrinter.println(outputFormatter.formatPlan(result.getSummary()));
-        if (capabilities.contains(OutputFormatter.Capablities.footer)) linePrinter.println(outputFormatter.formatFooter(result));
-        if (capabilities.contains(OutputFormatter.Capablities.statistics)) linePrinter.println(statisticsCollector.collect(result.getSummary()));
+        if (capabilities.contains(OutputFormatter.Capablities.info)) linePrinter.printOut(outputFormatter.formatInfo(result.getSummary()));
+        if (capabilities.contains(OutputFormatter.Capablities.plan)) linePrinter.printOut(outputFormatter.formatPlan(result.getSummary()));
+        if (capabilities.contains(OutputFormatter.Capablities.footer)) linePrinter.printOut(outputFormatter.formatFooter(result));
+        if (capabilities.contains(OutputFormatter.Capablities.statistics)) linePrinter.printOut(statisticsCollector.collect(result.getSummary()));
     }
 
     // Helper for testing

--- a/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/PrettyPrinter.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/PrettyPrinter.java
@@ -14,9 +14,9 @@ public class PrettyPrinter {
     private final StatisticsCollector statisticsCollector;
     private final OutputFormatter outputFormatter;
 
-    public PrettyPrinter(@Nonnull Format format, boolean wrap, int numSampleRows) {
-        this.statisticsCollector = new StatisticsCollector(format);
-        this.outputFormatter = format == Format.VERBOSE ? new TableOutputFormatter(wrap, numSampleRows) : new SimpleOutputFormatter();
+    public PrettyPrinter(@Nonnull PrettyConfig prettyConfig) {
+        this.statisticsCollector = new StatisticsCollector(prettyConfig.format);
+        this.outputFormatter = selectFormatter(prettyConfig);
     }
 
     public void format(@Nonnull final BoltResult result, LinePrinter linePrinter) {
@@ -35,5 +35,13 @@ public class PrettyPrinter {
         StringBuilder sb = new StringBuilder();
         format(result, line -> {if (line!=null && !line.trim().isEmpty()) sb.append(line).append(OutputFormatter.NEWLINE);});
         return sb.toString();
+    }
+
+    private OutputFormatter selectFormatter(PrettyConfig prettyConfig) {
+        if (prettyConfig.format == Format.VERBOSE) {
+            return new TableOutputFormatter(prettyConfig.wrap, prettyConfig.numSampleRows);
+        } else {
+            return new SimpleOutputFormatter();
+        }
     }
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/SimpleOutputFormatter.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/SimpleOutputFormatter.java
@@ -19,10 +19,10 @@ public class SimpleOutputFormatter implements OutputFormatter {
         Iterator<Record> records = result.iterate();
         if (records.hasNext()) {
             Record firstRow = records.next();
-            output.println(String.join(COMMA_SEPARATOR, firstRow.keys()));
-            output.println(formatRecord(firstRow));
+            output.printOut(String.join(COMMA_SEPARATOR, firstRow.keys()));
+            output.printOut(formatRecord(firstRow));
             while (records.hasNext()) {
-                output.println(formatRecord(records.next()));
+                output.printOut(formatRecord(records.next()));
             }
         }
     }

--- a/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/TableOutputFormatter.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/TableOutputFormatter.java
@@ -59,17 +59,17 @@ public class TableOutputFormatter implements OutputFormatter {
         int lineWidth = totalWidth - 2;
         String dashes = "+" + OutputFormatter.repeat('-', lineWidth) + "+";
 
-        output.println(dashes);
-        output.println(headerLine);
-        output.println(dashes);
+        output.printOut(dashes);
+        output.printOut(headerLine);
+        output.printOut(dashes);
 
         for (Record record : topRecords) {
-            output.println(formatRecord(builder, columnSizes, record));
+            output.printOut(formatRecord(builder, columnSizes, record));
         }
         while (records.hasNext()) {
-            output.println(formatRecord(builder, columnSizes, records.next()));
+            output.printOut(formatRecord(builder, columnSizes, records.next()));
         }
-        output.println(dashes);
+        output.printOut(dashes);
     }
 
     private int[] calculateColumnSizes(@Nonnull String[] columns, @Nonnull List<Record> data) {

--- a/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/TableOutputFormatter.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/TableOutputFormatter.java
@@ -110,10 +110,18 @@ public class TableOutputFormatter implements OutputFormatter {
             String txt = row[i];
             if (txt != null) {
                 if (txt.length() > length) {
-                    row[i] = txt.substring(length);
-                    remainder = true;
-                } else row[i] = null;
-                sb.append(OutputFormatter.rightPad(txt, length));
+                    if (wrap) {
+                        sb.append(txt, 0, length);
+                        row[i] = txt.substring(length);
+                        remainder = true;
+                    } else {
+                        sb.append(txt, 0, length - 1);
+                        sb.append("…");
+                    }
+                } else {
+                    row[i] = null;
+                    sb.append(OutputFormatter.rightPad(txt, length));
+                }
             } else {
                 sb.append(OutputFormatter.repeat(' ', length));
             }

--- a/cypher-shell/src/main/java/org/neo4j/shell/state/BoltResult.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/state/BoltResult.java
@@ -1,37 +1,26 @@
 package org.neo4j.shell.state;
 
 import org.neo4j.driver.v1.Record;
-import org.neo4j.driver.v1.StatementResult;
 import org.neo4j.driver.v1.summary.ResultSummary;
 
 import javax.annotation.Nonnull;
+import java.util.Iterator;
 import java.util.List;
 
 /**
- * A class holds the result from executing some Cypher.
+ * The result of executing some Cypher over bolt.
  */
-public class BoltResult {
-    private final List<Record> records;
-    private StatementResult statementResult;
-
-    public BoltResult(@Nonnull List<Record> records, StatementResult statementResult) {
-        //Not calling statementResult.list() because it executes cypher in the server
-        this.records = records;
-        this.statementResult = statementResult;
-    }
+public interface BoltResult {
 
     @Nonnull
-    public List<Record> getRecords() {
-        return records;
-    }
+    List<String> getKeys();
 
     @Nonnull
-    public List<String> getKeys() {
-        return statementResult.keys();
-    }
+    List<Record> getRecords();
 
     @Nonnull
-    public ResultSummary getSummary() {
-        return statementResult.summary();
-    }
+    Iterator<Record> iterate();
+
+    @Nonnull
+    ResultSummary getSummary();
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -175,9 +174,7 @@ public class BoltStateHandler implements TransactionHandler, Connector {
             return Optional.empty();
         }
 
-        // calling list() is what actually executes cypher on the server
-        List<Record> list = statementResult.list();
-        return Optional.of(new BoltResult(list, statementResult));
+        return Optional.of(new StatementBoltResult(statementResult));
     }
 
     /**
@@ -232,8 +229,7 @@ public class BoltStateHandler implements TransactionHandler, Connector {
         List<BoltResult> results = executeWithRetry(transactionStatements, (statement, transaction) -> {
             // calling list() is what actually executes cypher on the server
             StatementResult sr = transaction.run(statement);
-            List<Record> list = sr.list();
-            return new BoltResult(list, sr);
+            return new ListBoltResult(sr.list(), sr.consume(), sr.keys());
         });
 
         clearTransactionStatements();

--- a/cypher-shell/src/main/java/org/neo4j/shell/state/ListBoltResult.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/state/ListBoltResult.java
@@ -1,0 +1,53 @@
+package org.neo4j.shell.state;
+
+import org.neo4j.driver.v1.Record;
+import org.neo4j.driver.v1.summary.ResultSummary;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * A fully materialized Cypher result.
+ */
+public class ListBoltResult implements BoltResult {
+
+    private final List<String> keys;
+    private final List<Record> records;
+    private final ResultSummary summary;
+
+    public ListBoltResult(@Nonnull List<Record> records, @Nonnull ResultSummary summary) {
+        this(records, summary, records.isEmpty() ? Collections.emptyList() : records.get(0).keys());
+    }
+
+    public ListBoltResult(@Nonnull List<Record> records, @Nonnull ResultSummary summary, @Nonnull List<String> keys) {
+        this.keys = keys;
+        this.records = records;
+        this.summary = summary;
+    }
+
+    @Nonnull
+    @Override
+    public List<String> getKeys() {
+        return keys;
+    }
+
+    @Override
+    @Nonnull
+    public List<Record> getRecords() {
+        return records;
+    }
+
+    @Override
+    @Nonnull
+    public Iterator<Record> iterate() {
+        return records.iterator();
+    }
+
+    @Override
+    @Nonnull
+    public ResultSummary getSummary() {
+        return summary;
+    }
+}

--- a/cypher-shell/src/main/java/org/neo4j/shell/state/StatementBoltResult.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/state/StatementBoltResult.java
@@ -1,0 +1,45 @@
+package org.neo4j.shell.state;
+
+import org.neo4j.driver.v1.Record;
+import org.neo4j.driver.v1.StatementResult;
+import org.neo4j.driver.v1.summary.ResultSummary;
+
+import javax.annotation.Nonnull;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Wrapper around {@link StatementResult}. Might or might not be materialized.
+ */
+public class StatementBoltResult implements BoltResult {
+
+    private final StatementResult result;
+
+    public StatementBoltResult(StatementResult result) {
+        this.result = result;
+    }
+
+    @Nonnull
+    @Override
+    public List<String> getKeys() {
+        return result.keys();
+    }
+
+    @Nonnull
+    @Override
+    public List<Record> getRecords() {
+        return result.list();
+    }
+
+    @Nonnull
+    @Override
+    public Iterator<Record> iterate() {
+        return result;
+    }
+
+    @Nonnull
+    @Override
+    public ResultSummary getSummary() {
+        return result.summary();
+    }
+}

--- a/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
@@ -176,7 +176,7 @@ public class CypherShellTest {
 
         when(boltStateHandler.isConnected()).thenReturn(true);
         when(boltStateHandler.runCypher(anyString(), anyMap())).thenReturn(Optional.of(result));
-        doAnswer((a) -> { ((LinePrinter)a.getArguments()[1]).println("999"); return null;}).when(mockedPrettyPrinter).format(any(BoltResult.class), anyObject());
+        doAnswer((a) -> { ((LinePrinter)a.getArguments()[1]).printOut("999"); return null;}).when(mockedPrettyPrinter).format(any(BoltResult.class), anyObject());
         when(mockedDriver.session()).thenReturn(session);
 
         OfflineTestShell shell = new OfflineTestShell(logger, boltStateHandler, mockedPrettyPrinter);
@@ -190,7 +190,7 @@ public class CypherShellTest {
 
         BoltStateHandler boltStateHandler = mock(BoltStateHandler.class);
 
-        doAnswer((a) -> { ((LinePrinter)a.getArguments()[1]).println("999"); return null;}).when(mockedPrettyPrinter).format(any(BoltResult.class), anyObject());
+        doAnswer((a) -> { ((LinePrinter)a.getArguments()[1]).printOut("999"); return null;}).when(mockedPrettyPrinter).format(any(BoltResult.class), anyObject());
         when(boltStateHandler.commitTransaction()).thenReturn(Optional.of(asList(result)));
 
         OfflineTestShell shell = new OfflineTestShell(logger, boltStateHandler, mockedPrettyPrinter);

--- a/cypher-shell/src/test/java/org/neo4j/shell/cli/CliArgHelperTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/cli/CliArgHelperTest.java
@@ -39,6 +39,22 @@ public class CliArgHelperTest {
     }
 
     @Test
+    public void testNumSampleRows() {
+        assertEquals("sample-rows 200", 200, CliArgHelper.parse("--sample-rows 200".split(" ")).getNumSampleRows());
+        assertNull("invalid sample-rows", CliArgHelper.parse("--sample-rows 0".split(" ")));
+        assertNull("invalid sample-rows", CliArgHelper.parse("--sample-rows -1".split(" ")));
+        assertNull("invalid sample-rows", CliArgHelper.parse("--sample-rows foo".split(" ")));
+    }
+
+    @Test
+    public void testWrap() {
+        assertTrue("wrap true", CliArgHelper.parse("--wrap true".split(" ")).getWrap());
+        assertFalse("wrap false", CliArgHelper.parse("--wrap false".split(" ")).getWrap());
+        assertTrue("default wrap", CliArgHelper.parse().getWrap());
+        assertNull("invalid wrap",CliArgHelper.parse("--wrap foo".split(" ")));
+    }
+
+    @Test
     public void testDebugIsNotDefault() {
         assertFalse("Debug should not be the default mode",
                 CliArgHelper.parse(asArray()).getDebugMode());

--- a/cypher-shell/src/test/java/org/neo4j/shell/cli/CliArgsTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/cli/CliArgsTest.java
@@ -59,6 +59,21 @@ public class CliArgsTest {
     }
 
     @Test
+    public void getNumSampleRows() throws Exception {
+        assertEquals(1000, CliArgs.DEFAULT_NUM_SAMPLE_ROWS);
+        assertEquals(CliArgs.DEFAULT_NUM_SAMPLE_ROWS, cliArgs.getNumSampleRows());
+
+        cliArgs.setNumSampleRows(null);
+        assertEquals(CliArgs.DEFAULT_NUM_SAMPLE_ROWS, cliArgs.getNumSampleRows());
+
+        cliArgs.setNumSampleRows(0);
+        assertEquals(CliArgs.DEFAULT_NUM_SAMPLE_ROWS, cliArgs.getNumSampleRows());
+
+        cliArgs.setNumSampleRows(120);
+        assertEquals(120, cliArgs.getNumSampleRows());
+    }
+
+    @Test
     public void setFormat() throws Exception {
         // default
         assertEquals(Format.AUTO, cliArgs.getFormat());

--- a/cypher-shell/src/test/java/org/neo4j/shell/cli/CommandHelperTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/cli/CommandHelperTest.java
@@ -9,6 +9,7 @@ import org.neo4j.shell.commands.Command;
 import org.neo4j.shell.commands.CommandHelper;
 import org.neo4j.shell.exception.CommandException;
 import org.neo4j.shell.log.AnsiLogger;
+import org.neo4j.shell.prettyprint.PrettyConfig;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -42,7 +43,7 @@ public class CommandHelperTest {
     {
         // Given
         AnsiLogger logger = new AnsiLogger( false );
-        CommandHelper commandHelper = new CommandHelper( logger, Historian.empty, new CypherShell( logger ) );
+        CommandHelper commandHelper = new CommandHelper( logger, Historian.empty, new CypherShell(logger, PrettyConfig.DEFAULT) );
 
         // When
         Command begin = commandHelper.getCommand( ":BEGIN" );

--- a/cypher-shell/src/test/java/org/neo4j/shell/log/AnsiLoggerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/log/AnsiLoggerTest.java
@@ -57,7 +57,7 @@ public class AnsiLoggerTest {
 
     @Test
     public void printExceptionWithDebug() throws Exception {
-        logger = new AnsiLogger(true, Format.VERBOSE, out, err);
+        Logger logger = new AnsiLogger(true, Format.VERBOSE, out, err);
         logger.printError(new Throwable("bam"));
         verify(err).println(contains("java.lang.Throwable: bam"));
         verify(err).println(contains("at org.neo4j.shell.log.AnsiLoggerTest.printExceptionWithDebug"));

--- a/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/PrettyPrinterTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/PrettyPrinterTest.java
@@ -36,8 +36,8 @@ import static org.neo4j.driver.internal.util.Iterables.map;
 @SuppressWarnings("ArraysAsListWithZeroOrOneArgument")
 public class PrettyPrinterTest {
 
-    private final PrettyPrinter plainPrinter = new PrettyPrinter(Format.PLAIN, false, 100);
-    private final PrettyPrinter verbosePrinter = new PrettyPrinter(Format.VERBOSE, true, 100);
+    private final PrettyPrinter plainPrinter = new PrettyPrinter(new PrettyConfig(Format.PLAIN, false, 100));
+    private final PrettyPrinter verbosePrinter = new PrettyPrinter(new PrettyConfig(Format.VERBOSE, true, 100));
 
     @Test
     public void returnStatisticsForEmptyRecords() {

--- a/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/PrettyPrinterTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/PrettyPrinterTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.neo4j.driver.internal.util.Iterables.map;
+import static org.neo4j.shell.prettyprint.OutputFormatter.NEWLINE;
 
 @SuppressWarnings("ArraysAsListWithZeroOrOneArgument")
 public class PrettyPrinterTest {
@@ -144,13 +145,17 @@ public class PrettyPrinterTest {
         String actual = plainPrinter.format(result);
 
         // then
-        assertThat(actual, is("col1, col2\n[\"val1_1\", \"val1_2\"], [\"val2_1\"]\n[\"val2_1\"]\n"));
+        assertThat(actual, is(String.join(NEWLINE,
+                "col1, col2",
+                "[\"val1_1\", \"val1_2\"], [\"val2_1\"]",
+                "[\"val2_1\"]",
+                "")));
     }
 
     @Test
     public void prettyPrintMaps() {
-        checkMapForPrettyPrint(map(), "map\n{}\n");
-        checkMapForPrettyPrint(map("abc", "def"), "map\n{abc: def}\n");
+        checkMapForPrettyPrint(map(), "map"+NEWLINE+"{}"+NEWLINE);
+        checkMapForPrettyPrint(map("abc", "def"), "map"+NEWLINE+"{abc: def}"+NEWLINE);
     }
 
     private void checkMapForPrettyPrint(Map<String, String> map, String expectedResult) {
@@ -200,8 +205,8 @@ public class PrettyPrinterTest {
         String actual = plainPrinter.format(result);
 
         // then
-        assertThat(actual, is("col1, col2\n" +
-                "(:label1:label2 {prop2: prop2_value, prop1: prop1_value})\n"));
+        assertThat(actual, is("col1, col2" + NEWLINE +
+                "(:label1:label2 {prop2: prop2_value, prop1: prop1_value})" + NEWLINE));
     }
 
     @Test
@@ -230,7 +235,8 @@ public class PrettyPrinterTest {
         String actual = plainPrinter.format(result);
 
         // then
-        assertThat(actual, is("rel\n[:RELATIONSHIP_TYPE {prop2: prop2_value, prop1: prop1_value}]\n"));
+        assertThat(actual, is("rel" + NEWLINE+
+                "[:RELATIONSHIP_TYPE {prop2: prop2_value, prop1: prop1_value}]" + NEWLINE));
     }
 
     @Test
@@ -272,8 +278,10 @@ public class PrettyPrinterTest {
         String actual = plainPrinter.format(result);
 
         // then
-        assertThat(actual, is("rel, node\n[:`RELATIONSHIP,TYPE` {prop2: prop2_value, prop1: \"prop1, value\"}], " +
-                "(:`label ``1`:label2 {prop1: \"prop1:value\", `1prop2`: \"\", ä: not-escaped})\n"));
+        assertThat(actual, is(
+                "rel, node" + NEWLINE +
+                "[:`RELATIONSHIP,TYPE` {prop2: prop2_value, prop1: \"prop1, value\"}], " +
+                "(:`label ``1`:label2 {prop1: \"prop1:value\", `1prop2`: \"\", ä: not-escaped})" + NEWLINE));
     }
 
     @Test
@@ -331,9 +339,9 @@ public class PrettyPrinterTest {
         String actual = plainPrinter.format(result);
 
         // then
-        assertThat(actual, is("path\n" +
+        assertThat(actual, is("path" + NEWLINE +
                 "(:start {prop1: prop1_value})-[:RELATIONSHIP_TYPE]->" +
-                "(:middle)<-[:RELATIONSHIP_TYPE]-(:end {prop2: prop2_value})\n"));
+                "(:middle)<-[:RELATIONSHIP_TYPE]-(:end {prop2: prop2_value})" + NEWLINE));
     }
 
     @Test
@@ -375,7 +383,7 @@ public class PrettyPrinterTest {
         String actual = plainPrinter.format(result);
 
         // then
-        assertThat(actual, is("path\n(:start)-[:RELATIONSHIP_TYPE]->(:end)\n"));
+        assertThat(actual, is("path" + NEWLINE + "(:start)-[:RELATIONSHIP_TYPE]->(:end)" + NEWLINE));
     }
 
     @Test
@@ -435,8 +443,8 @@ public class PrettyPrinterTest {
         String actual = plainPrinter.format(result);
 
         // then
-        assertThat(actual, is("path\n" +
+        assertThat(actual, is("path" + NEWLINE +
                 "(:start)-[:RELATIONSHIP_TYPE]->" +
-                "(:second)<-[:RELATIONSHIP_TYPE]-(:third)-[:RELATIONSHIP_TYPE]->(:end)\n"));
+                "(:second)<-[:RELATIONSHIP_TYPE]-(:third)-[:RELATIONSHIP_TYPE]->(:end)" + NEWLINE));
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/TableOutputFormatterTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/TableOutputFormatterTest.java
@@ -39,6 +39,7 @@ import static org.hamcrest.core.StringContains.containsString;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.neo4j.shell.prettyprint.OutputFormatter.NEWLINE;
 
 @SuppressWarnings("ArraysAsListWithZeroOrOneArgument")
 public class TableOutputFormatterTest {
@@ -290,19 +291,20 @@ public class TableOutputFormatterTest {
         new TableOutputFormatter(true, 2).format(new ListBoltResult(result.list(), result.summary()), printer);
         String table = printer.result();
         // THEN
-        assertThat(table, is(
-                "+------+\n" +
-                "| c1   |\n" +
-                "+------+\n" +
-                "| \"a\"  |\n" +
-                "| \"bb\" |\n" +
-                "| \"ccc |\n" +
-                "| \"    |\n" +
-                "| \"ddd |\n" +
-                "| d\"   |\n" +
-                "| \"eee |\n" +
-                "| ee\"  |\n" +
-                "+------+\n"));
+        assertThat(table, is(String.join(NEWLINE,
+                "+------+",
+                "| c1   |",
+                "+------+",
+                "| \"a\"  |",
+                "| \"bb\" |",
+                "| \"ccc |",
+                "| \"    |",
+                "| \"ddd |",
+                "| d\"   |",
+                "| \"eee |",
+                "| ee\"  |",
+                "+------+",
+                "")));
     }
 
     @Test
@@ -315,16 +317,17 @@ public class TableOutputFormatterTest {
         new TableOutputFormatter(false, 2).format(new ListBoltResult(result.list(), result.summary()), printer);
         String table = printer.result();
         // THEN
-        assertThat(table, is(
-                "+------+\n" +
-                "| c1   |\n" +
-                "+------+\n" +
-                "| \"a\"  |\n" +
-                "| \"bb\" |\n" +
-                "| \"cc… |\n" +
-                "| \"dd… |\n" +
-                "| \"ee… |\n" +
-                "+------+\n"));
+        assertThat(table, is(String.join(NEWLINE,
+                "+------+",
+                "| c1   |",
+                "+------+",
+                "| \"a\"  |",
+                "| \"bb\" |",
+                "| \"cc… |",
+                "| \"dd… |",
+                "| \"ee… |",
+                "+------+",
+                "")));
     }
 
     @Test

--- a/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/TableOutputFormatterTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/TableOutputFormatterTest.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings("ArraysAsListWithZeroOrOneArgument")
 public class TableOutputFormatterTest {
 
-    private final PrettyPrinter verbosePrinter = new PrettyPrinter(Format.VERBOSE, true, 100);
+    private final PrettyPrinter verbosePrinter = new PrettyPrinter(new PrettyConfig(Format.VERBOSE, true, 100));
 
     @Test
     public void prettyPrintPlanInformation() {

--- a/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/TableOutputFormatterTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/TableOutputFormatterTest.java
@@ -286,9 +286,9 @@ public class TableOutputFormatterTest {
         // GIVEN
         StatementResult result = mockResult( asList( "c1"), "a", "bb","ccc","dddd","eeeee" );
         // WHEN
-        StringBuilder sb = new StringBuilder();
-        new TableOutputFormatter(true, 2).format(new ListBoltResult(result.list(), result.summary()), (s) -> sb.append(s).append("\n"));
-        String table = sb.toString();
+        ToStringLinePrinter printer = new ToStringLinePrinter();
+        new TableOutputFormatter(true, 2).format(new ListBoltResult(result.list(), result.summary()), printer);
+        String table = printer.result();
         // THEN
         assertThat(table, is(
                 "+------+\n" +
@@ -311,9 +311,9 @@ public class TableOutputFormatterTest {
         // GIVEN
         StatementResult result = mockResult( asList( "c1"), "a", "bb","ccc","dddd","eeeee" );
         // WHEN
-        StringBuilder sb = new StringBuilder();
-        new TableOutputFormatter(false, 2).format(new ListBoltResult(result.list(), result.summary()), (s) -> sb.append(s).append("\n"));
-        String table = sb.toString();
+        ToStringLinePrinter printer = new ToStringLinePrinter();
+        new TableOutputFormatter(false, 2).format(new ListBoltResult(result.list(), result.summary()), printer);
+        String table = printer.result();
         // THEN
         assertThat(table, is(
                 "+------+\n" +

--- a/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/TableOutputFormatterTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/TableOutputFormatterTest.java
@@ -306,7 +306,7 @@ public class TableOutputFormatterTest {
     }
 
     @Test
-    public void cutContent()
+    public void truncateContent()
     {
         // GIVEN
         StatementResult result = mockResult( asList( "c1"), "a", "bb","ccc","dddd","eeeee" );
@@ -321,9 +321,9 @@ public class TableOutputFormatterTest {
                 "+------+\n" +
                 "| \"a\"  |\n" +
                 "| \"bb\" |\n" +
-                "| \"ccc |\n" +
-                "| \"ddd |\n" +
-                "| \"eee |\n" +
+                "| \"cc… |\n" +
+                "| \"dd… |\n" +
+                "| \"ee… |\n" +
                 "+------+\n"));
     }
 

--- a/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/ToStringLinePrinter.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/ToStringLinePrinter.java
@@ -1,0 +1,23 @@
+package org.neo4j.shell.prettyprint;
+
+import javax.annotation.Nonnull;
+
+public class ToStringLinePrinter implements LinePrinter {
+
+    final StringBuilder sb;
+
+    public ToStringLinePrinter() {
+        this.sb = new StringBuilder();
+    }
+
+    @Override
+    public void println(String line) {
+        sb.append(line);
+        sb.append(OutputFormatter.NEWLINE);
+    }
+
+    @Nonnull
+    public String result() {
+        return sb.toString();
+    }
+}

--- a/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/ToStringLinePrinter.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/ToStringLinePrinter.java
@@ -11,7 +11,7 @@ public class ToStringLinePrinter implements LinePrinter {
     }
 
     @Override
-    public void println(String line) {
+    public void printOut(String line) {
         sb.append(line);
         sb.append(OutputFormatter.NEWLINE);
     }

--- a/cypher-shell/src/test/java/org/neo4j/shell/state/BoltStateHandlerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/state/BoltStateHandlerTest.java
@@ -179,9 +179,6 @@ public class BoltStateHandlerTest {
         Session sessionMock = mock(Session.class);
         Driver driverMock = stubVersionInAnOpenSession(mock(StatementResult.class), sessionMock, "neo4j-version");
 
-        BoltResult boltResultMock1 = mock(BoltResult.class);
-        BoltResult boltResultMock2 = mock(BoltResult.class);
-
         Record record1 = mock(Record.class);
         Record record2 = mock(Record.class);
         Record record3 = mock(Record.class);
@@ -190,8 +187,8 @@ public class BoltStateHandlerTest {
         Value str1Val = mock(Value.class);
         Value str2Val = mock(Value.class);
 
-        when(boltResultMock1.getRecords()).thenReturn(asList(record1, record2));
-        when(boltResultMock2.getRecords()).thenReturn(asList(record3));
+        BoltResult boltResult1 = new ListBoltResult(asList(record1, record2), mock(ResultSummary.class));
+        BoltResult boltResult2 = new ListBoltResult(asList(record3), mock(ResultSummary.class));
 
         when(str1Val.toString()).thenReturn("str1");
         when(str2Val.toString()).thenReturn("str2");
@@ -203,7 +200,7 @@ public class BoltStateHandlerTest {
 
         when(record3.get(0)).thenReturn(str1Val);
         when(record3.get(1)).thenReturn(str2Val);
-        when(sessionMock.writeTransaction(anyObject())).thenReturn(asList(boltResultMock1, boltResultMock2));
+        when(sessionMock.writeTransaction(anyObject())).thenReturn(asList(boltResult1, boltResult2));
 
         OfflineBoltStateHandler boltStateHandler = new OfflineBoltStateHandler(driverMock);
         boltStateHandler.connect();


### PR DESCRIPTION
When executing queries in autocommit mode, results are no longer materialized before printing. This was causing issues for big queries that would materialize as OOM crashes or just generally slow execution.

For --format=PLAIN this means each records is printed directly as it arrives in the shell.

For --format=VERBOSE, we cannot simply stream, because we need to know the widths of the columns before we can print even the column header. To achieve this we materialize the 1000 first rows, and compute the column widths from this sample. Any remaining rows will be streamed. If any remaining row contains a value that overflows it's column width, that value will either be wrapped to the next row (--wrap=true), or truncated (--wrap=false).

This replaces the streaming aspects of #108. I felt unsure about the maxWidth aspects, so left that out for now.

[changelog]: queries executing in auto-commit mode do no longer materialize results. For --format=VERBOSE this means that column widths are computed from the first 1000 rows (--sample-rows), and any later values that overflow their colums are either wrapped or truncated (--wrap)