### PR TITLE
Multi-database refinement round 1

### DIFF
--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellMultiDatabaseIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellMultiDatabaseIntegrationTest.java
@@ -14,6 +14,7 @@ import org.neo4j.shell.cli.Format;
 import org.neo4j.shell.exception.CommandException;
 import org.neo4j.shell.prettyprint.PrettyConfig;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assume.assumeTrue;
@@ -56,14 +57,32 @@ public class CypherShellMultiDatabaseIntegrationTest
         useCommand.execute(SYSTEM_DB_NAME);
 
         assertThat(linePrinter.output(), is(""));
+
+        shell.execute("SHOW DATABASES");
+        assertThat(linePrinter.output(), containsString("neo4j"));
+        assertThat(linePrinter.output(), containsString("system"));
+    }
+
+    @Test
+    public void switchingToSystemDatabaseAndBackToNeo4jWorks() throws CommandException {
+        useCommand.execute(SYSTEM_DB_NAME);
+        useCommand.execute(DEFAULT_DEFAULT_DB_NAME);
+
+        assertThat(linePrinter.output(), is(""));
+
+        shell.execute("RETURN 'toadstool'");
+        assertThat(linePrinter.output(), containsString("toadstool"));
     }
 
     @Test
     public void switchingToSystemDatabaseAndBackToDefaultWorks() throws CommandException {
         useCommand.execute(SYSTEM_DB_NAME);
-        useCommand.execute(DEFAULT_DEFAULT_DB_NAME);
+        useCommand.execute(ABSENT_DB_NAME);
 
         assertThat(linePrinter.output(), is(""));
+
+        shell.execute("RETURN 'pottypie'");
+        assertThat(linePrinter.output(), containsString("pottypie"));
     }
 
     @Test

--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellMultiDatabaseIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellMultiDatabaseIntegrationTest.java
@@ -57,10 +57,7 @@ public class CypherShellMultiDatabaseIntegrationTest
         useCommand.execute(SYSTEM_DB_NAME);
 
         assertThat(linePrinter.output(), is(""));
-
-        shell.execute("SHOW DATABASES");
-        assertThat(linePrinter.output(), containsString("neo4j"));
-        assertThat(linePrinter.output(), containsString("system"));
+        assertOnSystemDB();
     }
 
     @Test
@@ -69,9 +66,7 @@ public class CypherShellMultiDatabaseIntegrationTest
         useCommand.execute(DEFAULT_DEFAULT_DB_NAME);
 
         assertThat(linePrinter.output(), is(""));
-
-        shell.execute("RETURN 'toadstool'");
-        assertThat(linePrinter.output(), containsString("toadstool"));
+        assertOnRegularDB();
     }
 
     @Test
@@ -80,9 +75,7 @@ public class CypherShellMultiDatabaseIntegrationTest
         useCommand.execute(ABSENT_DB_NAME);
 
         assertThat(linePrinter.output(), is(""));
-
-        shell.execute("RETURN 'pottypie'");
-        assertThat(linePrinter.output(), containsString("pottypie"));
+        assertOnRegularDB();
     }
 
     @Test
@@ -101,6 +94,7 @@ public class CypherShellMultiDatabaseIntegrationTest
         useCommand.execute(SYSTEM_DB_NAME);
 
         assertThat(linePrinter.output(), is(""));
+        assertOnSystemDB();
     }
 
     @Test
@@ -109,5 +103,18 @@ public class CypherShellMultiDatabaseIntegrationTest
         thrown.expectMessage("The database requested does not exist.");
 
         useCommand.execute("this_database_name_does_not_exist_in_test_container");
+    }
+
+    // HELPERS
+
+    private void assertOnRegularDB() throws CommandException {
+        shell.execute("RETURN 'toadstool'");
+        assertThat(linePrinter.output(), containsString("toadstool"));
+    }
+
+    private void assertOnSystemDB() throws CommandException {
+        shell.execute("SHOW DATABASES");
+        assertThat(linePrinter.output(), containsString("neo4j"));
+        assertThat(linePrinter.output(), containsString("system"));
     }
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/DatabaseManager.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/DatabaseManager.java
@@ -7,6 +7,7 @@ import org.neo4j.shell.exception.CommandException;
  */
 public interface DatabaseManager
 {
+    String ABSENT_DB_NAME = "";
     String DEFAULT_DEFAULT_DB_NAME = "neo4j";
     String SYSTEM_DB_NAME = "system";
 

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/InteractiveShellRunner.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/InteractiveShellRunner.java
@@ -35,7 +35,7 @@ import static org.neo4j.shell.DatabaseManager.DEFAULT_DEFAULT_DB_NAME;
 public class InteractiveShellRunner implements ShellRunner, SignalHandler {
     static final String INTERRUPT_SIGNAL = "INT";
     private final static String FRESH_PROMPT = "> ";
-    private final static AnsiFormattedText CONTINUATION_PROMPT = AnsiFormattedText.s().bold().append("  ");
+    private final static AnsiFormattedText CONTINUATION_PROMPT = AnsiFormattedText.s().bold().append("       ");
     private final static String TRANSACTION_PROMPT = "# ";
     // Need to know if we are currently executing when catch Ctrl-C, needs to be atomic due to
     // being called from different thread
@@ -172,7 +172,7 @@ public class InteractiveShellRunner implements ShellRunner, SignalHandler {
                 .append(connectionConfig.username())
                 .append("@")
                 .append(databaseName)
-                .appendNewLine()
+//                .appendNewLine()
                 .append( txHandler.isTransactionOpen() ? TRANSACTION_PROMPT : FRESH_PROMPT );
         return prompt;
     }

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/InteractiveShellRunner.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/InteractiveShellRunner.java
@@ -37,6 +37,8 @@ public class InteractiveShellRunner implements ShellRunner, SignalHandler {
     static final String INTERRUPT_SIGNAL = "INT";
     private final static String FRESH_PROMPT = "> ";
     private final static String TRANSACTION_PROMPT = "# ";
+    private final static String USERNAME_DB_DELIMITER = "@";
+    private final static int ONELINE_PROMPT_MAX_LENGTH = 50;
     // Need to know if we are currently executing when catch Ctrl-C, needs to be atomic due to
     // being called from different thread
     private final AtomicBoolean currentlyExecuting;
@@ -170,13 +172,17 @@ public class InteractiveShellRunner implements ShellRunner, SignalHandler {
         //  but that does not work in general)
         databaseName = ABSENT_DB_NAME.equals(databaseName) ? DEFAULT_DEFAULT_DB_NAME : databaseName;
 
-        int promptIndent = connectionConfig.username().length() + 1 + databaseName.length() + 2;
+        int promptIndent = connectionConfig.username().length() +
+                           USERNAME_DB_DELIMITER.length() +
+                           databaseName.length() +
+                           FRESH_PROMPT.length();
+
         AnsiFormattedText prePrompt = AnsiFormattedText.s().bold()
                 .append(connectionConfig.username())
                 .append("@")
                 .append(databaseName);
 
-        if (promptIndent <= 50) {
+        if (promptIndent <= ONELINE_PROMPT_MAX_LENGTH) {
             continuationPrompt = AnsiFormattedText.s().bold().append(OutputFormatter.repeat(' ', promptIndent));
             return prePrompt
                     .append( txHandler.isTransactionOpen() ? TRANSACTION_PROMPT : FRESH_PROMPT );

--- a/cypher-shell/src/main/java/org/neo4j/shell/commands/Use.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/commands/Use.java
@@ -54,7 +54,8 @@ public class Use implements Command {
 
     @Override
     public void execute(@Nonnull final String argString) throws ExitException, CommandException {
-        String[] args = simpleArgParse(argString, 1, COMMAND_NAME, getUsage());
-        databaseManager.setActiveDatabase(args[0]);
+        String[] args = simpleArgParse(argString, 0, 1, COMMAND_NAME, getUsage());
+        String databaseName = args.length == 0 ? DatabaseManager.ABSENT_DB_NAME : args[0];
+        databaseManager.setActiveDatabase(databaseName);
     }
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
@@ -149,7 +149,8 @@ public class BoltStateHandler implements TransactionHandler, Connector, Database
         Consumer<SessionParametersTemplate> sessionArgs = t -> t.withDefaultAccessMode(AccessMode.WRITE).withDatabase(activeDatabaseName);
         session = driver.session(sessionArgs.andThen(sessionOptionalArgs));
 
-        StatementResult run = session.run("RETURN 1");
+        String query = activeDatabaseName.equals(SYSTEM_DB_NAME) ? "SHOW DATABASES" : "RETURN 1";
+        StatementResult run = session.run(query);
         this.version = run.summary().server().version();
         // It would be nice if we could also get the actual database name here, in the case where we used ABSENT_DB_NAME
         run.consume();

--- a/cypher-shell/src/test/java/org/neo4j/shell/cli/InteractiveShellRunnerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/cli/InteractiveShellRunnerTest.java
@@ -270,21 +270,21 @@ public class InteractiveShellRunnerTest {
         AnsiFormattedText prompt = runner.getPrompt();
 
         // then
-        assertEquals( format("myusername@mydb%n> "), prompt.plainString());
+        assertEquals( format("myusername@mydb> "), prompt.plainString());
 
         // when
         statementParser.parseMoreText("  \t \n   "); // whitespace
         prompt = runner.getPrompt();
 
         // then
-        assertEquals( format("myusername@mydb%n> "), prompt.plainString());
+        assertEquals( format("myusername@mydb> "), prompt.plainString());
 
         // when
         statementParser.parseMoreText("bla bla"); // non whitespace
         prompt = runner.getPrompt();
 
         // then
-        assertEquals("  ", prompt.plainString());
+        assertEquals("       ", prompt.plainString());
     }
 
     @Test
@@ -299,21 +299,21 @@ public class InteractiveShellRunnerTest {
         AnsiFormattedText prompt = runner.getPrompt();
 
         // then
-        assertEquals(format("myusername@mydb%n# "), prompt.plainString());
+        assertEquals(format("myusername@mydb# "), prompt.plainString());
 
         // when
         statementParser.parseMoreText("  \t \n   "); // whitespace
         prompt = runner.getPrompt();
 
         // then
-        assertEquals(format("myusername@mydb%n# "), prompt.plainString());
+        assertEquals(format("myusername@mydb# "), prompt.plainString());
 
         // when
         statementParser.parseMoreText("bla bla"); // non whitespace
         prompt = runner.getPrompt();
 
         // then
-        assertEquals("  ", prompt.plainString());
+        assertEquals("       ", prompt.plainString());
     }
 
     @Test

--- a/cypher-shell/src/test/java/org/neo4j/shell/commands/UseTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/commands/UseTest.java
@@ -28,12 +28,10 @@ public class UseTest
     }
 
     @Test
-    public void shouldFailIfNoArgs() throws CommandException {
-        thrown.expect(CommandException.class);
-        thrown.expectMessage(containsString("Incorrect number of arguments"));
-
+    public void setAbsentDatabaseOnNoArgument() throws CommandException {
         cmd.execute("");
-        fail("Expected error");
+
+        verify(mockShell).setActiveDatabase(DatabaseManager.ABSENT_DB_NAME);
     }
 
     @Test


### PR DESCRIPTION
Improve multi-database functionality so that

 * Connecting to system-db no longer result in a `Not a recognised system command: RETURN 1`
 * The prompt no longer contains a newline if shorter than 50 characters
 * Calling `:use` without a database name will reconnect to the server default database