### PR TITLE
made java dependency consistent with Neo4j

### DIFF
--- a/packaging/rpm/cypher-shell.spec
+++ b/packaging/rpm/cypher-shell.spec
@@ -8,7 +8,7 @@ URL: https://github.com/neo4j/cypher-shell
 Source0: https://github.com/neo4j/cypher-shell/archive/%{version}.tar.gz
 
 #Conflicts:
-Requires: which, jre-headless >= 1.8
+Requires: which, jre == 1.8.0
 BuildArch: noarch
 Prefix: /usr
 


### PR DESCRIPTION
neo4j 3.x requires cypher-shell 1.1 and jre == 1.8.0
making cypher-shell require jre ==1.8.0 instead of java-headless. This makes it compatible with oracle java.