### PR TITLE
Fix Java version check for Mac OS X

### DIFF
--- a/cypher-shell/src/dist/cypher-shell
+++ b/cypher-shell/src/dist/cypher-shell
@@ -10,11 +10,12 @@ check_java() {
   [[ -n "${JAVA_MEMORY_OPTS:-}" ]] && version_command+=("${JAVA_MEMORY_OPTS[@]}")
 
   JAVA_VERSION=$("${version_command[@]}" 2>&1 | awk -F '"' '/version/ {print $2}')
-  MAX_VERSION=`echo -e "$JAVA_VERSION\n1.8" | sort -t '.' -k 1,1 -k 2,2 -k 3,3 -k 4,4 -g | tail -1`
-  if [[ "${MAX_VERSION}" = "1.8" ]]; then
-    echo "ERROR! Java version ${JAVA_VERSION} is not supported. "
-    _show_java_help
-    exit 1
+  if [[ $JAVA_VERSION = "1."* ]]; then
+    if [[ "${JAVA_VERSION}" < "1.8" ]]; then
+      echo "ERROR! Java version ${JAVA_VERSION} is not supported. "
+      _show_java_help
+      exit 1
+    fi
   fi
 }
 
@@ -25,6 +26,10 @@ _find_java_cmd() {
 
   if [[ "${JAVA_HOME:-}" ]] ; then
     JAVA_CMD="${JAVA_HOME}/bin/java"
+    if [[ ! -f "${JAVA_CMD}" ]]; then
+      echo "ERROR: JAVA_HOME is incorrectly defined as ${JAVA_HOME} (the executable ${JAVA_CMD} does not exist)"
+      exit 1
+    fi
   else
     if [ "${DIST_OS}" != "macosx" ] ; then
       # Don't use default java on Darwin because it displays a misleading dialog box
@@ -54,7 +59,7 @@ _find_java_home() {
 
   case "${DIST_OS}" in
     "macosx")
-      JAVA_HOME="$(/usr/libexec/java_home -v 1.8)"
+      JAVA_HOME="$(/usr/libexec/java_home -v 1.8+)"
       ;;
     "gentoo")
       JAVA_HOME="$(java-config --jre-home)"
@@ -63,7 +68,7 @@ _find_java_home() {
 }
 
 _show_java_help() {
-  echo "* Please use Oracle(R) Java(TM) 8 or OpenJDK(TM) 8."
+  echo "* Please use Oracle(R) Java(TM) >=8 or OpenJDK(TM) >=8."
 }
 
 build_classpath() {


### PR DESCRIPTION
There was a case where cypher-shell would fail to start on OS X with _only_ Java 11 installed.