### PR TITLE
Fix case sensitivity of system database name

### DIFF
--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellMultiDatabaseIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellMultiDatabaseIntegrationTest.java
@@ -108,7 +108,7 @@ public class CypherShellMultiDatabaseIntegrationTest
     @Test
     public void switchingToNonExistingDatabaseShouldGiveErrorResponseFromServer() throws CommandException {
         thrown.expect(ClientException.class);
-        thrown.expectMessage("The database requested does not exist.");
+        thrown.expectMessage("Database does not exist");
 
         useCommand.execute("this_database_name_does_not_exist_in_test_container");
     }

--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellMultiDatabaseIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellMultiDatabaseIntegrationTest.java
@@ -61,6 +61,14 @@ public class CypherShellMultiDatabaseIntegrationTest
     }
 
     @Test
+    public void switchingToSystemDatabaseIsNotCaseSensitive() throws CommandException {
+        useCommand.execute("SyStEm");
+
+        assertThat(linePrinter.output(), is(""));
+        assertOnSystemDB();
+    }
+
+    @Test
     public void switchingToSystemDatabaseAndBackToNeo4jWorks() throws CommandException {
         useCommand.execute(SYSTEM_DB_NAME);
         useCommand.execute(DEFAULT_DEFAULT_DB_NAME);

--- a/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
@@ -162,7 +162,7 @@ public class BoltStateHandler implements TransactionHandler, Connector, Database
         };
         session = driver.session(sessionArgs.andThen(sessionOptionalArgs));
 
-        String query = activeDatabaseNameAsSetByUser.equals(SYSTEM_DB_NAME) ? "SHOW DATABASES" : "RETURN 1";
+        String query = activeDatabaseNameAsSetByUser.compareToIgnoreCase(SYSTEM_DB_NAME) == 0 ? "SHOW DATABASES" : "RETURN 1";
 
         resetActualDbName(); // Set this to null first in case run throws an exception
         StatementResult run = session.run(query);


### PR DESCRIPTION
Use case insensitive comparison when checking if we are on the
system database to decide which ping query to use.