### PR TITLE
Stop unwrapping Bolt exceptions.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ ext {
     argparse4jVersion = '0.7.0'
     junitVersion = '4.12'
     evaluatorVersion = '3.5.4'
-    neo4jJavaDriverVersion = '2.0.0-alpha02'
+    neo4jJavaDriverVersion = '2.0.0-alpha03'
     findbugsVersion = '3.0.0'
     jansiVersion = '1.13'
     jlineVersion = '2.14.6'

--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/MainIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/MainIntegrationTest.java
@@ -1,39 +1,127 @@
 package org.neo4j.shell;
 
+import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
-import org.neo4j.shell.cli.CliArgs;
-import org.neo4j.shell.log.AnsiLogger;
-import org.neo4j.shell.log.Logger;
-import org.neo4j.shell.prettyprint.PrettyConfig;
+import org.junit.rules.ExpectedException;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.PrintStream;
 
+import org.neo4j.driver.exceptions.ServiceUnavailableException;
+import org.neo4j.shell.cli.CliArgs;
+import org.neo4j.shell.log.AnsiLogger;
+import org.neo4j.shell.log.Logger;
+import org.neo4j.shell.prettyprint.PrettyConfig;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class MainIntegrationTest {
+public class MainIntegrationTest
+{
+
+    private static class ShellAndConnection
+    {
+        CypherShell shell;
+        ConnectionConfig connectionConfig;
+
+        ShellAndConnection( CypherShell shell, ConnectionConfig connectionConfig )
+        {
+            this.shell = shell;
+            this.connectionConfig = connectionConfig;
+        }
+    }
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
 
     @Test
-    public void connectInteractivelyPromptOnWrongAuthentication() throws Exception {
+    public void connectInteractivelyPromptOnWrongAuthentication() throws Exception
+    {
         // given
-        // what the user inputs when prompted
-        String inputString = String.format( "neo4j%nneo%n" );
-        InputStream inputStream = new ByteArrayInputStream(inputString.getBytes());
-
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        PrintStream ps = new PrintStream(baos);
-
-        Main main = new Main(inputStream, ps);
+        Main main = getMain( baos );
 
         CliArgs cliArgs = new CliArgs();
-        cliArgs.setUsername("", "");
+        cliArgs.setUsername( "", "" );
         cliArgs.setPassword( "", "" );
 
-        Logger logger = new AnsiLogger(cliArgs.getDebugMode());
-        PrettyConfig prettyConfig = new PrettyConfig(cliArgs);
+        ShellAndConnection sac = getShell( cliArgs );
+        CypherShell shell = sac.shell;
+        ConnectionConfig connectionConfig = sac.connectionConfig;
+
+        // when
+        assertEquals( "", connectionConfig.username() );
+        assertEquals( "", connectionConfig.password() );
+
+        main.connectMaybeInteractively( shell, connectionConfig, true );
+
+        // then
+        // should be connected
+        assertTrue( shell.isConnected() );
+        // should have prompted and set the username and password
+        assertEquals( "neo4j", connectionConfig.username() );
+        assertEquals( "neo", connectionConfig.password() );
+
+        String out = baos.toString();
+        assertEquals( String.format( "username: neo4j%npassword: ***%n" ), out );
+    }
+
+    @Test
+    public void wrongPortWithBolt() throws Exception
+    {
+        // given
+        Main main = getMain( new ByteArrayOutputStream() );
+
+        CliArgs cliArgs = new CliArgs();
+        cliArgs.setScheme( "bolt://", "" );
+        cliArgs.setPort( 1234 );
+
+        ShellAndConnection sac = getShell( cliArgs );
+        CypherShell shell = sac.shell;
+        ConnectionConfig connectionConfig = sac.connectionConfig;
+
+        exception.expect( ServiceUnavailableException.class );
+        exception.expectMessage( "Unable to connect to localhost:1234, ensure the database is running and that there is a working network connection to it" );
+        main.connectMaybeInteractively( shell, connectionConfig, true );
+    }
+
+    @Ignore
+    public void wrongPortWithNeo4j() throws Exception
+    {
+        // given
+        Main main = getMain( new ByteArrayOutputStream() );
+
+        CliArgs cliArgs = new CliArgs();
+        cliArgs.setScheme( "neo4j://", "" );
+        cliArgs.setPort( 1234 );
+
+        ShellAndConnection sac = getShell( cliArgs );
+        CypherShell shell = sac.shell;
+        ConnectionConfig connectionConfig = sac.connectionConfig;
+
+        exception.expect( ServiceUnavailableException.class );
+        exception.expectMessage( "Unable to connect to localhost:1234, ensure the database is running and that there is a working network connection to it" );
+        main.connectMaybeInteractively( shell, connectionConfig, true );
+    }
+
+    private Main getMain( ByteArrayOutputStream baos )
+    {
+        // what the user inputs when prompted
+        String inputString = String.format( "neo4j%nneo%n" );
+        InputStream inputStream = new ByteArrayInputStream( inputString.getBytes() );
+
+        PrintStream ps = new PrintStream( baos );
+
+        return new Main( inputStream, ps );
+    }
+
+    private ShellAndConnection getShell( CliArgs cliArgs )
+    {
+        Logger logger = new AnsiLogger( cliArgs.getDebugMode() );
+        PrettyConfig prettyConfig = new PrettyConfig( cliArgs );
         ConnectionConfig connectionConfig = new ConnectionConfig(
                 cliArgs.getScheme(),
                 cliArgs.getHost(),
@@ -41,24 +129,8 @@ public class MainIntegrationTest {
                 cliArgs.getUsername(),
                 cliArgs.getPassword(),
                 cliArgs.getEncryption(),
-                cliArgs.getDatabase());
+                cliArgs.getDatabase() );
 
-        CypherShell shell = new CypherShell(logger, prettyConfig, true);
-
-        // when
-        assertEquals("", connectionConfig.username());
-        assertEquals("", connectionConfig.password());
-
-        main.connectMaybeInteractively(shell, connectionConfig, true);
-
-        // then
-        // should be connected
-        assertTrue(shell.isConnected());
-        // should have prompted and set the username and password
-        assertEquals("neo4j", connectionConfig.username());
-        assertEquals("neo", connectionConfig.password());
-
-        String out = baos.toString();
-        assertEquals( String.format( "username: neo4j%npassword: ***%n" ), out );
+        return new ShellAndConnection( new CypherShell( logger, prettyConfig, true ), connectionConfig );
     }
 }

--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/MainIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/MainIntegrationTest.java
@@ -88,7 +88,7 @@ public class MainIntegrationTest
         main.connectMaybeInteractively( shell, connectionConfig, true );
     }
 
-    @Ignore
+    @Test
     public void wrongPortWithNeo4j() throws Exception
     {
         // given
@@ -103,7 +103,7 @@ public class MainIntegrationTest
         ConnectionConfig connectionConfig = sac.connectionConfig;
 
         exception.expect( ServiceUnavailableException.class );
-        exception.expectMessage( "Unable to connect to localhost:1234, ensure the database is running and that there is a working network connection to it" );
+        exception.expectMessage( "Unable to connect to database, ensure the database is running and that there is a working network connection to it" );
         main.connectMaybeInteractively( shell, connectionConfig, true );
     }
 

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgs.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgs.java
@@ -32,7 +32,7 @@ public class CliArgs {
     /**
      * Set the scheme to the primary value, or if null, the fallback value.
      */
-    void setScheme(@Nullable String primary, @Nonnull String fallback) {
+    public void setScheme(@Nullable String primary, @Nonnull String fallback) {
         scheme = primary == null ? fallback : primary;
     }
 
@@ -46,7 +46,7 @@ public class CliArgs {
     /**
      * Set the port to the value.
      */
-    void setPort(int port) {
+    public void setPort(int port) {
         this.port = port;
     }
 

--- a/cypher-shell/src/main/java/org/neo4j/shell/log/AnsiLogger.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/log/AnsiLogger.java
@@ -110,7 +110,7 @@ public class AnsiLogger implements Logger {
     }
 
     /**
-     * Interpret the cause of a Bolt exception and translate it into a sensible error message.
+     * Formatting for Bolt exceptions.
      */
     @Nonnull
     String getFormattedMessage(@Nonnull final Throwable e) {

--- a/cypher-shell/src/main/java/org/neo4j/shell/log/AnsiLogger.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/log/AnsiLogger.java
@@ -122,23 +122,20 @@ public class AnsiLogger implements Logger {
             e.printStackTrace(ps);
             msg.append(new String(baos.toByteArray(), StandardCharsets.UTF_8));
         } else {
-            //noinspection ThrowableResultOfMethodCallIgnored
-            final Throwable cause = getRootCause(e);
-
-            if (cause instanceof AnsiFormattedException) {
-                msg = msg.append(((AnsiFormattedException) cause).getFormattedMessage());
-            } else if (cause instanceof ClientException &&
-                    cause.getMessage() != null && cause.getMessage().contains("Missing username")) {
+            if (e instanceof AnsiFormattedException) {
+                msg = msg.append(((AnsiFormattedException) e).getFormattedMessage());
+            } else if (e instanceof ClientException &&
+                    e.getMessage() != null && e.getMessage().contains("Missing username")) {
                 // Username and password was not specified
-                msg = msg.append(cause.getMessage())
+                msg = msg.append(e.getMessage())
                          .append("\nPlease specify --username, and optionally --password, as argument(s)")
                          .append("\nor as environment variable(s), NEO4J_USERNAME, and NEO4J_PASSWORD respectively.")
                          .append("\nSee --help for more info.");
             } else {
-                if (cause.getMessage() != null) {
-                    msg = msg.append(cause.getMessage());
+                if (e.getMessage() != null) {
+                    msg = msg.append(e.getMessage());
                 } else {
-                    msg = msg.append(cause.getClass().getSimpleName());
+                    msg = msg.append(e.getClass().getSimpleName());
                 }
             }
         }

--- a/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
@@ -172,6 +172,9 @@ public class BoltStateHandler implements TransactionHandler, Connector, Database
     }
 
     private void reconnect(boolean keepBookmark) {
+        // This will already throw an exception if there is no connectivity
+        driver.verifyConnectivity();
+
         SessionConfig.Builder builder = SessionConfig.builder();
         builder.withDefaultAccessMode( AccessMode.WRITE );
         if ( !ABSENT_DB_NAME.equals( activeDatabaseNameAsSetByUser ) )

--- a/cypher-shell/src/test/java/org/neo4j/shell/log/AnsiLoggerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/log/AnsiLoggerTest.java
@@ -135,13 +135,13 @@ public class AnsiLoggerTest {
 
     @Test
     public void testNested() {
-        assertEquals("@|RED nested|@", logger.getFormattedMessage(new ClientException("outer",
+        assertEquals("@|RED outer|@", logger.getFormattedMessage(new ClientException("outer",
                 new CommandException("nested"))));
     }
 
     @Test
     public void testNestedDeep() {
-        assertEquals("@|RED nested deep|@", logger.getFormattedMessage(
+        assertEquals("@|RED outer|@", logger.getFormattedMessage(
                 new ClientException("outer",
                         new ClientException("nested",
                                 new ClientException("nested deep")))));
@@ -150,7 +150,7 @@ public class AnsiLoggerTest {
     @Test
     public void testNullMessage() {
         assertEquals("@|RED ClientException|@", logger.getFormattedMessage(new ClientException(null)));
-        assertEquals("@|RED NullPointerException|@",
+        assertEquals("@|RED outer|@",
                 logger.getFormattedMessage(new ClientException("outer", new NullPointerException(null))));
     }
 

--- a/cypher-shell/src/test/java/org/neo4j/shell/test/bolt/FakeDriver.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/test/bolt/FakeDriver.java
@@ -3,14 +3,13 @@ package org.neo4j.shell.test.bolt;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Metrics;
 import org.neo4j.driver.Session;
-import org.neo4j.driver.SessionParametersTemplate;
 import org.neo4j.driver.async.AsyncSession;
 import org.neo4j.driver.exceptions.Neo4jException;
+import org.neo4j.driver.internal.SessionConfig;
 import org.neo4j.driver.reactive.RxSession;
 import org.neo4j.driver.types.TypeSystem;
 
 import java.util.concurrent.CompletionStage;
-import java.util.function.Consumer;
 
 public class FakeDriver implements Driver {
     @Override
@@ -24,7 +23,7 @@ public class FakeDriver implements Driver {
     }
 
     @Override
-    public Session session(Consumer<SessionParametersTemplate> templateConsumer) {
+    public Session session( SessionConfig sessionConfig) {
         return new FakeSession();
     }
 
@@ -50,7 +49,7 @@ public class FakeDriver implements Driver {
     }
 
     @Override
-    public RxSession rxSession(Consumer<SessionParametersTemplate> templateConsumer)
+    public RxSession rxSession( SessionConfig sessionConfig )
     {
         return null;
     }
@@ -62,13 +61,24 @@ public class FakeDriver implements Driver {
     }
 
     @Override
-    public AsyncSession asyncSession(Consumer<SessionParametersTemplate> templateConsumer)
+    public AsyncSession asyncSession( SessionConfig sessionConfig )
     {
         return null;
     }
 
     @Override
     public TypeSystem defaultTypeSystem()
+    {
+        return null;
+    }
+
+    @Override
+    public void verifyConnectivity()
+    {
+    }
+
+    @Override
+    public CompletionStage<Void> verifyConnectivityAsync()
     {
         return null;
     }


### PR DESCRIPTION
Bolt throws sensible exceptions, we should not unwrap them.

Also add integration tests for error messages if a DBMS is not
reachable. One test ignored, since there is a problem in the Java Driver