### PR TITLE
Turn encryption off by default

### DIFF
--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellFailureIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellFailureIntegrationTest.java
@@ -34,6 +34,6 @@ public class CypherShellFailureIntegrationTest {
         thrown.expect(AuthenticationException.class);
         thrown.expectMessage("The client is unauthorized due to authentication failure.");
 
-        shell.connect(new ConnectionConfig("bolt://", "localhost", 7687, "neo4j", "", true, ABSENT_DB_NAME));
+        shell.connect(new ConnectionConfig("bolt://", "localhost", 7687, "neo4j", "", false, ABSENT_DB_NAME));
     }
 }

--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellMultiDatabaseIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellMultiDatabaseIntegrationTest.java
@@ -44,7 +44,7 @@ public class CypherShellMultiDatabaseIntegrationTest
         beginCommand = new Begin( shell );
         rollbackCommand = new Rollback( shell );
 
-        shell.connect( new ConnectionConfig( "bolt://", "localhost", 7687, "neo4j", "neo", true, ABSENT_DB_NAME ) );
+        shell.connect( new ConnectionConfig( "bolt://", "localhost", 7687, "neo4j", "neo", false, ABSENT_DB_NAME ) );
 
         // Multiple databases are only available from 4.0
         assumeTrue( majorVersion( shell.getServerVersion() ) >= 4 );
@@ -136,7 +136,7 @@ public class CypherShellMultiDatabaseIntegrationTest
     {
         shell = new CypherShell( linePrinter, new PrettyConfig( Format.PLAIN, true, 1000 ), true );
         useCommand = new Use( shell );
-        shell.connect( new ConnectionConfig( "bolt://", "localhost", 7687, "neo4j", "neo", true, ABSENT_DB_NAME ) );
+        shell.connect( new ConnectionConfig( "bolt://", "localhost", 7687, "neo4j", "neo", false, ABSENT_DB_NAME ) );
 
         useCommand.execute( SYSTEM_DB_NAME );
 

--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellPlainIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellPlainIntegrationTest.java
@@ -29,7 +29,7 @@ public class CypherShellPlainIntegrationTest {
     public void setUp() throws Exception {
         linePrinter.clear();
         shell = new CypherShell(linePrinter, new PrettyConfig(Format.PLAIN, true, 1000), false);
-        shell.connect(new ConnectionConfig("bolt://", "localhost", 7687, "neo4j", "neo", true, ABSENT_DB_NAME));
+        shell.connect(new ConnectionConfig("bolt://", "localhost", 7687, "neo4j", "neo", false, ABSENT_DB_NAME));
     }
 
     @After

--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellVerboseIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellVerboseIntegrationTest.java
@@ -39,7 +39,7 @@ public class CypherShellVerboseIntegrationTest {
         commitCommand = new Commit(shell);
         beginCommand = new Begin(shell);
 
-        shell.connect(new ConnectionConfig("bolt://", "localhost", 7687, "neo4j", "neo", true, ABSENT_DB_NAME));
+        shell.connect(new ConnectionConfig("bolt://", "localhost", 7687, "neo4j", "neo", false, ABSENT_DB_NAME));
     }
 
     @After
@@ -73,7 +73,7 @@ public class CypherShellVerboseIntegrationTest {
         thrown.expect(CommandException.class);
         thrown.expectMessage("Already connected");
 
-        ConnectionConfig config = new ConnectionConfig("bolt://", "localhost", 7687, "neo4j", "neo", true, ABSENT_DB_NAME);
+        ConnectionConfig config = new ConnectionConfig("bolt://", "localhost", 7687, "neo4j", "neo", false, ABSENT_DB_NAME);
         assertTrue("Shell should already be connected", shell.isConnected());
         shell.connect(config);
     }

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgHelper.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgHelper.java
@@ -139,7 +139,7 @@ public class CliArgHelper {
                 .help("whether the connection to Neo4j should be encrypted; must be consistent with Neo4j's " +
                         "configuration")
                 .type(new BooleanArgumentType())
-                .setDefault(true);
+                .setDefault(false);
         connGroup.addArgument("-d", "--database")
                 .help("database to connect to. Can also be specified using environment variable " + ConnectionConfig.DATABASE_ENV_VAR)
                 .setDefault("");

--- a/cypher-shell/src/test/java/org/neo4j/shell/cli/CliArgHelperTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/cli/CliArgHelperTest.java
@@ -170,8 +170,8 @@ public class CliArgHelperTest {
     }
 
     @Test
-    public void defaultsEncryptionToTrue() {
-        assertEquals(true, CliArgHelper.parse().getEncryption());
+    public void defaultsEncryptionToFalse() {
+        assertEquals(false, CliArgHelper.parse().getEncryption());
     }
 
     @Test


### PR DESCRIPTION
This mirrors the Neo4j 4.0 default which is changed to having encryption turned off by default.

[cl]: Encryption is turned off by default, which mirrors the same change in the Neo4j server. Encryption is turned on via the command line argument ´--encryption true´, like before.