### PR TITLE
Update to Java Driver 4.0.0-betaXX

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ ext {
     argparse4jVersion = '0.7.0'
     junitVersion = '4.12'
     evaluatorVersion = '3.5.4'
-    neo4jJavaDriverVersion = '2.0.0-alpha03'
+    neo4jJavaDriverVersion = '4.0.0-beta01'
     findbugsVersion = '3.0.0'
     jansiVersion = '1.13'
     jlineVersion = '2.14.6'

--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ ext {
     argparse4jVersion = '0.7.0'
     junitVersion = '4.12'
     evaluatorVersion = '3.5.4'
-    neo4jJavaDriverVersion = '4.0.0-beta01'
+    neo4jJavaDriverVersion = '4.0-SNAPSHOT'
     findbugsVersion = '3.0.0'
     jansiVersion = '1.13'
     jlineVersion = '2.14.6'

--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellIntegrationTest.java
@@ -1,11 +1,11 @@
 package org.neo4j.shell.commands;
 
+import static org.neo4j.shell.DatabaseManager.*;
+
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.shell.ConnectionConfig;
 import org.neo4j.shell.CypherShell;
 import org.neo4j.shell.exception.CommandException;
-
-import static org.neo4j.driver.internal.messaging.request.MultiDatabaseUtil.ABSENT_DB_NAME;
 
 abstract class CypherShellIntegrationTest
 {

--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellMultiDatabaseIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellMultiDatabaseIntegrationTest.java
@@ -20,9 +20,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
-import static org.neo4j.driver.internal.messaging.request.MultiDatabaseUtil.ABSENT_DB_NAME;
-import static org.neo4j.shell.DatabaseManager.DEFAULT_DEFAULT_DB_NAME;
-import static org.neo4j.shell.DatabaseManager.SYSTEM_DB_NAME;
+import static org.neo4j.shell.DatabaseManager.*;
 import static org.neo4j.shell.Versions.majorVersion;
 
 public class CypherShellMultiDatabaseIntegrationTest

--- a/cypher-shell/src/main/java/org/neo4j/shell/DatabaseManager.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/DatabaseManager.java
@@ -7,7 +7,7 @@ import org.neo4j.shell.exception.CommandException;
  */
 public interface DatabaseManager
 {
-    String ABSENT_DB_NAME = "";
+    String ABSENT_DB_NAME = "neo4j"; // TODO After beta02, "" and literal null are no longer valid database names.
     String SYSTEM_DB_NAME = "system";
     String DEFAULT_DEFAULT_DB_NAME = "neo4j";
 

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgs.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgs.java
@@ -4,10 +4,9 @@ import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import org.neo4j.shell.DatabaseManager;
 import org.neo4j.shell.ParameterMap;
 import org.neo4j.shell.ShellParameterMap;
-
-import static org.neo4j.driver.internal.messaging.request.MultiDatabaseUtil.ABSENT_DB_NAME;
 
 public class CliArgs {
     private static final String DEFAULT_SCHEME = "bolt://";
@@ -20,7 +19,7 @@ public class CliArgs {
     private int port = DEFAULT_PORT;
     private String username = "";
     private String password = "";
-    private String databaseName = ABSENT_DB_NAME;
+    private String databaseName = DatabaseManager.ABSENT_DB_NAME;
     private FailBehavior failBehavior = FailBehavior.FAIL_FAST;
     private Format format = Format.AUTO;
     @SuppressWarnings( "OptionalUsedAsFieldOrParameterType" )

--- a/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
@@ -12,7 +12,7 @@ import javax.annotation.Nullable;
 import org.neo4j.driver.*;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.exceptions.SessionExpiredException;
-import org.neo4j.driver.internal.Bookmark;
+import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.summary.DatabaseInfo;
 import org.neo4j.shell.ConnectionConfig;
 import org.neo4j.shell.Connector;

--- a/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
@@ -9,19 +9,10 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import org.neo4j.driver.AccessMode;
-import org.neo4j.driver.AuthToken;
-import org.neo4j.driver.AuthTokens;
-import org.neo4j.driver.Config;
-import org.neo4j.driver.Driver;
-import org.neo4j.driver.GraphDatabase;
-import org.neo4j.driver.Session;
-import org.neo4j.driver.Statement;
-import org.neo4j.driver.StatementResult;
-import org.neo4j.driver.Transaction;
+import org.neo4j.driver.*;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.exceptions.SessionExpiredException;
-import org.neo4j.driver.internal.SessionConfig;
+import org.neo4j.driver.internal.Bookmark;
 import org.neo4j.driver.summary.DatabaseInfo;
 import org.neo4j.shell.ConnectionConfig;
 import org.neo4j.shell.Connector;
@@ -184,7 +175,7 @@ public class BoltStateHandler implements TransactionHandler, Connector, Database
         if ( session != null && keepBookmark )
         {
             // Save the last bookmark and close the session
-            final String bookmark = session.lastBookmark();
+            final Bookmark bookmark = session.lastBookmark();
             session.close();
             builder.withBookmarks( bookmark );
         }
@@ -312,13 +303,13 @@ public class BoltStateHandler implements TransactionHandler, Connector, Database
     }
 
     private Driver getDriver(@Nonnull ConnectionConfig connectionConfig, @Nullable AuthToken authToken) {
-        Config.ConfigBuilder configBuilder = Config.build().withLogging(NullLogging.NULL_LOGGING);
+        Config.ConfigBuilder configBuilder = Config.builder().withLogging(NullLogging.NULL_LOGGING);
         if (connectionConfig.encryption()) {
             configBuilder = configBuilder.withEncryption();
         } else {
             configBuilder = configBuilder.withoutEncryption();
         }
-        return driverProvider.apply(connectionConfig.driverUrl(), authToken, configBuilder.toConfig());
+        return driverProvider.apply(connectionConfig.driverUrl(), authToken, configBuilder.build());
     }
 
     private Optional<List<BoltResult>> captureResults(@Nonnull List<Statement> transactionStatements) {

--- a/cypher-shell/src/test/java/org/neo4j/shell/ConnectionConfigTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/ConnectionConfigTest.java
@@ -8,7 +8,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
-import static org.neo4j.driver.internal.messaging.request.MultiDatabaseUtil.ABSENT_DB_NAME;
+import static org.neo4j.shell.DatabaseManager.*;
 
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
 

--- a/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertFalse;
 import static org.mockito.Matchers.anyMap;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
-import static org.neo4j.driver.internal.messaging.request.MultiDatabaseUtil.ABSENT_DB_NAME;
+import static org.neo4j.shell.DatabaseManager.*;
 
 @SuppressWarnings("OptionalGetWithoutIsPresent")
 public class CypherShellTest {

--- a/cypher-shell/src/test/java/org/neo4j/shell/state/BoltStateHandlerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/state/BoltStateHandlerTest.java
@@ -403,7 +403,7 @@ public class BoltStateHandlerTest {
         BoltStateHandler handler = new BoltStateHandler(provider, false);
         ConnectionConfig config = new ConnectionConfig("bolt://", "", -1, "", "", false, ABSENT_DB_NAME);
         handler.connect(config);
-        assertEquals(Config.EncryptionLevel.NONE, provider.config.encryptionLevel());
+        assertFalse(provider.config.encrypted());
     }
 
     @Test
@@ -412,7 +412,7 @@ public class BoltStateHandlerTest {
         BoltStateHandler handler = new BoltStateHandler(provider, false);
         ConnectionConfig config = new ConnectionConfig("bolt://", "", -1, "", "", true, ABSENT_DB_NAME);
         handler.connect(config);
-        assertEquals(Config.EncryptionLevel.REQUIRED, provider.config.encryptionLevel());
+        assertTrue(provider.config.encrypted());
     }
 
     private Driver stubResultSummaryInAnOpenSession(StatementResult resultMock, Session sessionMock, String version) {

--- a/cypher-shell/src/test/java/org/neo4j/shell/test/bolt/FakeDriver.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/test/bolt/FakeDriver.java
@@ -42,6 +42,10 @@ public class FakeDriver implements Driver {
         return null;
     }
 
+    @Override public boolean isMetricsEnabled() {
+        return false;
+    }
+
     @Override
     public RxSession rxSession()
     {

--- a/cypher-shell/src/test/java/org/neo4j/shell/test/bolt/FakeDriver.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/test/bolt/FakeDriver.java
@@ -3,9 +3,9 @@ package org.neo4j.shell.test.bolt;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Metrics;
 import org.neo4j.driver.Session;
+import org.neo4j.driver.SessionConfig;
 import org.neo4j.driver.async.AsyncSession;
 import org.neo4j.driver.exceptions.Neo4jException;
-import org.neo4j.driver.internal.SessionConfig;
 import org.neo4j.driver.reactive.RxSession;
 import org.neo4j.driver.types.TypeSystem;
 

--- a/cypher-shell/src/test/java/org/neo4j/shell/test/bolt/FakeSession.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/test/bolt/FakeSession.java
@@ -1,6 +1,7 @@
 package org.neo4j.shell.test.bolt;
 
 import org.neo4j.driver.*;
+import org.neo4j.driver.internal.Bookmark;
 import org.neo4j.driver.types.TypeSystem;
 
 import java.util.Map;
@@ -63,7 +64,7 @@ public class FakeSession implements Session {
     }
 
     @Override
-    public String lastBookmark() {
+    public Bookmark lastBookmark() {
         return null;
     }
 

--- a/cypher-shell/src/test/java/org/neo4j/shell/test/bolt/FakeSession.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/test/bolt/FakeSession.java
@@ -1,7 +1,7 @@
 package org.neo4j.shell.test.bolt;
 
 import org.neo4j.driver.*;
-import org.neo4j.driver.internal.Bookmark;
+import org.neo4j.driver.Bookmark;
 import org.neo4j.driver.types.TypeSystem;
 
 import java.util.Map;


### PR DESCRIPTION
This PR contains 2 commits.

The first one updates to 4.0.0-beta02, mainly fixing package names and imports, but also
* Adapting to the new `Bookmark` api
* Changing the assertions regarding encryption.
* Minor API changes

The 2nd one updates to the current driver snapshot and is kinda bigger change.
The latest driver doesn't support `null` or the empty string as database name and doesn't have a constant of `ABSENT_DB_NAME`. I set this fix to `neo4j`, as I didn't want to mess with the logic cypher shell has in place.

Feel. free to pick any commit or both, but please be aware that this is currently untested. I compiled my fork and actually used it, but didn't run the test.