### PR TITLE
Fix getting server version and database name on failure

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/util/Versions.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/util/Versions.java
@@ -26,6 +26,9 @@ public final class Versions {
         if (version == null) {
             throw new AssertionError("null is not a valid version string");
         }
+        if (version.isEmpty()) {
+            return new Version(0, 0, 0);
+        }
         //remove -alpha, and -beta etc
         int offset = version.indexOf("-");
         if (offset > 0) {

--- a/cypher-shell/src/test/java/org/neo4j/shell/util/VersionsTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/util/VersionsTest.java
@@ -1,0 +1,34 @@
+package org.neo4j.shell.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class VersionsTest
+{
+    @Test
+    public void shouldWorkForEmptyString() throws Exception {
+        assertEquals(0, Versions.version("").compareTo(Versions.version("0.0.0")));
+        assertEquals(0, Versions.majorVersion(""));
+        assertEquals(0, Versions.minorVersion(""));
+        assertEquals(0, Versions.patch(""));
+    }
+
+    @Test
+    public void shouldWorkForReleaseVersion() throws Exception {
+        String versionString = "3.4.5";
+        assertEquals(0, Versions.version(versionString).compareTo(Versions.version("3.4.5")));
+        assertEquals(3, Versions.majorVersion(versionString));
+        assertEquals(4, Versions.minorVersion(versionString));
+        assertEquals(5, Versions.patch(versionString));
+    }
+
+    @Test
+    public void shouldWorkForPreReleaseVersion() throws Exception {
+        String versionString = "3.4.55-beta99";
+        assertEquals(0, Versions.version(versionString).compareTo(Versions.version("3.4.55")));
+        assertEquals(3, Versions.majorVersion(versionString));
+        assertEquals(4, Versions.minorVersion(versionString));
+        assertEquals(55, Versions.patch(versionString));
+    }
+}


### PR DESCRIPTION
When the ping query fails, e.g. on credentials expired exception,
we still need to get the server version.

- Add handling of empty version string