### PR TITLE
Change formatting ResultTables with long values

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/TableOutputFormatter.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/TableOutputFormatter.java
@@ -54,7 +54,7 @@ public class TableOutputFormatter implements OutputFormatter {
                                          LinePrinter output) {
 
         List<Record> topRecords = take(records, numSampleRows);
-        int[] columnSizes = calculateColumnSizes(columns, topRecords);
+        int[] columnSizes = calculateColumnSizes(columns, topRecords, records.hasNext());
 
         int totalWidth = 1;
         for (int columnSize : columnSizes) {
@@ -83,14 +83,21 @@ public class TableOutputFormatter implements OutputFormatter {
         return numberOfRows;
     }
 
-    private int[] calculateColumnSizes(@Nonnull String[] columns, @Nonnull List<Record> data) {
+    /**
+     * Calculate the size of the columns for table formatting
+     * @param columns the column names
+     * @param data (sample) data
+     * @param moreDataAfterSamples if there is more data that should be written into the table after `data`
+     * @return the column sizes
+     */
+    private int[] calculateColumnSizes(@Nonnull String[] columns, @Nonnull List<Record> data, boolean moreDataAfterSamples) {
         int[] columnSizes = new int[columns.length];
         for (int i = 0; i < columns.length; i++) {
             columnSizes[i] = columns[i].length();
         }
         for (Record record : data) {
             for (int i = 0; i < columns.length; i++) {
-                int len = columnLengthForValue(record.get(i));
+                int len = columnLengthForValue(record.get(i), moreDataAfterSamples);
                 if (columnSizes[i] < len) {
                     columnSizes[i] = len;
                 }
@@ -101,9 +108,13 @@ public class TableOutputFormatter implements OutputFormatter {
 
     /**
      * The length of a column, where Numbers are always getting enough space to fit the highest number possible.
+     *
+     * @param value the value to calculate the length for
+     * @param moreDataAfterSamples if there is more data that should be written into the table after `data`
+     * @return the column size for this value.
      */
-    private int columnLengthForValue(Value value) {
-        if (value instanceof NumberValueAdapter ) {
+    private int columnLengthForValue(Value value, boolean moreDataAfterSamples) {
+        if (value instanceof NumberValueAdapter && moreDataAfterSamples) {
             return 19; // The number of digits of Long.Max
         } else {
             return formatValue(value).length();

--- a/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/TableOutputFormatter.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/TableOutputFormatter.java
@@ -1,14 +1,21 @@
 package org.neo4j.shell.prettyprint;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import org.neo4j.driver.internal.InternalRecord;
+import org.neo4j.driver.internal.value.NumberValueAdapter;
 import org.neo4j.driver.v1.Record;
 import org.neo4j.driver.v1.Value;
 import org.neo4j.driver.v1.summary.ResultSummary;
 import org.neo4j.shell.state.BoltResult;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.util.*;
 
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -55,7 +62,7 @@ public class TableOutputFormatter implements OutputFormatter {
         }
 
         StringBuilder builder = new StringBuilder(totalWidth);
-        String headerLine = formatRow(builder, columnSizes, columns);
+        String headerLine = formatRow(builder, columnSizes, columns, new boolean[columnSizes.length]);
         int lineWidth = totalWidth - 2;
         String dashes = "+" + OutputFormatter.repeat('-', lineWidth) + "+";
 
@@ -83,7 +90,7 @@ public class TableOutputFormatter implements OutputFormatter {
         }
         for (Record record : data) {
             for (int i = 0; i < columns.length; i++) {
-                int len = formatValue(record.get(i)).length();
+                int len = columnLengthForValue(record.get(i));
                 if (columnSizes[i] < len) {
                     columnSizes[i] = len;
                 }
@@ -92,9 +99,20 @@ public class TableOutputFormatter implements OutputFormatter {
         return columnSizes;
     }
 
+    /**
+     * The length of a column, where Numbers are always getting enough space to fit the highest number possible.
+     */
+    private int columnLengthForValue(Value value) {
+        if (value instanceof NumberValueAdapter ) {
+            return 19; // The number of digits of Long.Max
+        } else {
+            return formatValue(value).length();
+        }
+    }
+
     private String formatRecord(StringBuilder sb, int[] columnSizes, Record record) {
         sb.setLength(0);
-        return formatRow(sb, columnSizes, formatValues(record));
+        return formatRow(sb, columnSizes, formatValues(record), new boolean[columnSizes.length]);
     }
 
     private String[] formatValues(Record record) {
@@ -105,8 +123,21 @@ public class TableOutputFormatter implements OutputFormatter {
         return row;
     }
 
-    private String formatRow(StringBuilder sb, int[] columnSizes, String[] row) {
-        sb.append("|");
+    /**
+     * Format one row of data.
+     *
+     * @param sb the StringBuilder to use
+     * @param columnSizes the size of all columns
+     * @param row the data
+     * @param continuation for each column whether it holds the remainder of data that did not fit in the column
+     * @return the String result
+     */
+    private String formatRow(StringBuilder sb, int[] columnSizes, String[] row, boolean[] continuation) {
+        if (!continuation[0]) {
+            sb.append("|");
+        } else {
+            sb.append("\\");
+        }
         boolean remainder = false;
         for (int i = 0; i < row.length; i++) {
             sb.append(" ");
@@ -117,6 +148,7 @@ public class TableOutputFormatter implements OutputFormatter {
                     if (wrap) {
                         sb.append(txt, 0, length);
                         row[i] = txt.substring(length);
+                        continuation[i] = true;
                         remainder = true;
                     } else {
                         sb.append(txt, 0, length - 1);
@@ -129,11 +161,15 @@ public class TableOutputFormatter implements OutputFormatter {
             } else {
                 sb.append(OutputFormatter.repeat(' ', length));
             }
-            sb.append(" |");
+            if (i == row.length -1 || !continuation[i+1]) {
+                sb.append(" |");
+            } else {
+                sb.append(" \\");
+            }
         }
         if (wrap && remainder) {
             sb.append(OutputFormatter.NEWLINE);
-            formatRow(sb, columnSizes, row);
+            formatRow(sb, columnSizes, row, continuation);
         }
         return sb.toString();
     }

--- a/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/TableOutputFormatterTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/TableOutputFormatterTest.java
@@ -105,11 +105,11 @@ public class TableOutputFormatterTest {
 
         // THEN
         assertThat(actual, startsWith(String.join(NEWLINE,
-                                         "+-----------------------------------------------------------------------------------+",
-                                         "| Plan      | Statement   | Version | Planner | Runtime       | Time                |",
-                                         "+-----------------------------------------------------------------------------------+",
-                                         "| \"EXPLAIN\" | \"READ_ONLY\" | \"3.1\"   | \"COST\"  | \"INTERPRETED\" | 12                  |",
-                                          "+-----------------------------------------------------------------------------------+",
+                                         "+--------------------------------------------------------------------+",
+                                         "| Plan      | Statement   | Version | Planner | Runtime       | Time |",
+                                         "+--------------------------------------------------------------------+",
+                                         "| \"EXPLAIN\" | \"READ_ONLY\" | \"3.1\"   | \"COST\"  | \"INTERPRETED\" | 12   |",
+                                          "+--------------------------------------------------------------------+",
                                          NEWLINE)));
     }
 
@@ -303,19 +303,33 @@ public class TableOutputFormatterTest {
         // WHEN
         String table = formatResult(result);
         // THEN
-        assertThat(table, containsString("| c1  | c2                  |"));
-        assertThat(table, containsString("| \"a\" | 42                  |"));
+        assertThat(table, containsString("| c1  | c2 |"));
+        assertThat(table, containsString("| \"a\" | 42 |"));
     }
 
     @Test
-    public void twoRows() {
+    public void twoRowsWithNumbersAllSampled() {
         // GIVEN
         StatementResult result = mockResult(asList("c1", "c2"), "a", 42, "b", 43);
         // WHEN
         String table = formatResult(result);
         // THEN
-        assertThat(table, containsString("| \"a\" | 42                  |"));
-        assertThat(table, containsString("| \"b\" | 43                  |"));
+        assertThat(table, containsString("| \"a\" | 42 |"));
+        assertThat(table, containsString("| \"b\" | 43 |"));
+    }
+
+    @Test
+    public void fiveRowsWithNumbersNotAllSampled() {
+        // GIVEN
+        StatementResult result = mockResult(asList("c1", "c2"), "a", 42, "b", 43, "c", 44, "d", 45, "e", 46);
+        // WHEN
+        String table = formatResult(result);
+        // THEN
+        assertThat(table, containsString("| \"a\" | 42 |"));
+        assertThat(table, containsString("| \"b\" | 43 |"));
+        assertThat(table, containsString("| \"c\" | 44 |"));
+        assertThat(table, containsString("| \"d\" | 45 |"));
+        assertThat(table, containsString("| \"e\" | 46 |"));
     }
 
     @Test

--- a/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/TableOutputFormatterTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/prettyprint/TableOutputFormatterTest.java
@@ -2,9 +2,31 @@ package org.neo4j.shell.prettyprint;
 
 import org.hamcrest.CoreMatchers;
 import org.junit.Test;
-import org.neo4j.driver.internal.*;
-import org.neo4j.driver.internal.value.*;
-import org.neo4j.driver.v1.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.neo4j.driver.internal.InternalIsoDuration;
+import org.neo4j.driver.internal.InternalNode;
+import org.neo4j.driver.internal.InternalPath;
+import org.neo4j.driver.internal.InternalPoint2D;
+import org.neo4j.driver.internal.InternalPoint3D;
+import org.neo4j.driver.internal.InternalRecord;
+import org.neo4j.driver.internal.InternalRelationship;
+import org.neo4j.driver.internal.value.DurationValue;
+import org.neo4j.driver.internal.value.NodeValue;
+import org.neo4j.driver.internal.value.PathValue;
+import org.neo4j.driver.internal.value.PointValue;
+import org.neo4j.driver.internal.value.RelationshipValue;
+import org.neo4j.driver.v1.Record;
+import org.neo4j.driver.v1.Statement;
+import org.neo4j.driver.v1.StatementResult;
+import org.neo4j.driver.v1.Value;
+import org.neo4j.driver.v1.Values;
 import org.neo4j.driver.v1.summary.ProfiledPlan;
 import org.neo4j.driver.v1.summary.ResultSummary;
 import org.neo4j.driver.v1.summary.StatementType;
@@ -14,8 +36,6 @@ import org.neo4j.driver.v1.types.Relationship;
 import org.neo4j.shell.cli.Format;
 import org.neo4j.shell.state.BoltResult;
 import org.neo4j.shell.state.ListBoltResult;
-
-import java.util.*;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonMap;
@@ -85,11 +105,11 @@ public class TableOutputFormatterTest {
 
         // THEN
         assertThat(actual, startsWith(String.join(NEWLINE,
-                                         "+--------------------------------------------------------------------+",
-                                         "| Plan      | Statement   | Version | Planner | Runtime       | Time |",
-                                         "+--------------------------------------------------------------------+",
-                                         "| \"EXPLAIN\" | \"READ_ONLY\" | \"3.1\"   | \"COST\"  | \"INTERPRETED\" | 12   |",
-                                          "+--------------------------------------------------------------------+",
+                                         "+-----------------------------------------------------------------------------------+",
+                                         "| Plan      | Statement   | Version | Planner | Runtime       | Time                |",
+                                         "+-----------------------------------------------------------------------------------+",
+                                         "| \"EXPLAIN\" | \"READ_ONLY\" | \"3.1\"   | \"COST\"  | \"INTERPRETED\" | 12                  |",
+                                          "+-----------------------------------------------------------------------------------+",
                                          NEWLINE)));
     }
 
@@ -283,8 +303,8 @@ public class TableOutputFormatterTest {
         // WHEN
         String table = formatResult(result);
         // THEN
-        assertThat(table, containsString("| c1  | c2 |"));
-        assertThat(table, containsString("| \"a\" | 42 |"));
+        assertThat(table, containsString("| c1  | c2                  |"));
+        assertThat(table, containsString("| \"a\" | 42                  |"));
     }
 
     @Test
@@ -294,12 +314,12 @@ public class TableOutputFormatterTest {
         // WHEN
         String table = formatResult(result);
         // THEN
-        assertThat(table, containsString("| \"a\" | 42 |"));
-        assertThat(table, containsString("| \"b\" | 43 |"));
+        assertThat(table, containsString("| \"a\" | 42                  |"));
+        assertThat(table, containsString("| \"b\" | 43                  |"));
     }
 
     @Test
-    public void wrapContent()
+    public void wrapStringContent()
     {
         // GIVEN
         StatementResult result = mockResult( asList( "c1"), "a", "bb","ccc","dddd","eeeee" );
@@ -315,12 +335,71 @@ public class TableOutputFormatterTest {
                 "| \"a\"  |",
                 "| \"bb\" |",
                 "| \"ccc |",
-                "| \"    |",
+                "\\ \"    |",
                 "| \"ddd |",
-                "| d\"   |",
+                "\\ d\"   |",
                 "| \"eee |",
-                "| ee\"  |",
+                "\\ ee\"  |",
                 "+------+",
+                NEWLINE)));
+    }
+
+    @Test
+    public void wrapStringContentWithTwoColumns()
+    {
+        // GIVEN
+        StatementResult result = mockResult( asList( "c1", "c2" ), "a", "b",
+                                             "aa", "bb",
+                                             "aaa", "b",
+                                             "a", "bbb",
+                                             "aaaa", "bb",
+                                             "aa", "bbbb",
+                                             "aaaaa", "bbbbb" );
+        // WHEN
+        ToStringLinePrinter printer = new ToStringLinePrinter();
+        new TableOutputFormatter(true, 2).formatAndCount(new ListBoltResult(result.list(), result.summary()), printer);
+        String table = printer.result();
+        // THEN
+        assertThat(table, is(String.join(NEWLINE,
+                "+-------------+",
+                "| c1   | c2   |",
+                "+-------------+",
+                "| \"a\"  | \"b\"  |",
+                "| \"aa\" | \"bb\" |",
+                "| \"aaa | \"b\"  |",
+                "\\ \"    |      |",
+                "| \"a\"  | \"bbb |",
+                "|      \\ \"    |",
+                "| \"aaa | \"bb\" |",
+                "\\ a\"   |      |",
+                "| \"aa\" | \"bbb |",
+                "|      \\ b\"   |",
+                "| \"aaa | \"bbb |",
+                "\\ aa\"  \\ bb\"  |",
+                "+-------------+",
+                NEWLINE)));
+    }
+
+    @Test
+    public void wrapNumberContentWithLongSize()
+    {
+        // GIVEN
+        StatementResult result = mockResult( asList( "c1"), 345, 12, 978623, 132456798, 9223372036854775807L );
+        // WHEN
+        ToStringLinePrinter printer = new ToStringLinePrinter();
+        new TableOutputFormatter(true, 2).formatAndCount(new ListBoltResult(result.list(), result.summary()), printer);
+        String table = printer.result();
+        // THEN
+        assertThat(table, is(String.join(NEWLINE,
+                "+---------------------+",
+                 "| c1                  |",
+                 "+---------------------+",
+                 "| 345                 |",
+                 "| 12                  |",
+                 "| 978623              |",
+                 "| 132456798           |",
+                 "| 9223372036854775807 |",
+                 "+---------------------+",
                 NEWLINE)));
     }
 


### PR DESCRIPTION
* For numbers, always reserve 19 digits (length of Long.Max)
* For other types, change the borders of the table when values overflow
  into the next row.