### PR TITLE
Fix connection when default database is unavailable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ ext {
     argparse4jVersion = '0.7.0'
     junitVersion = '4.12'
     evaluatorVersion = '3.5.4'
-    neo4jJavaDriverVersion = '4.0.0-rc1'
+    neo4jJavaDriverVersion = '4.0.0-rc2'
     findbugsVersion = '3.0.0'
     jansiVersion = '1.13'
     jlineVersion = '2.14.6'

--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/MainIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/MainIntegrationTest.java
@@ -14,6 +14,7 @@ import java.nio.ByteBuffer;
 
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.exceptions.ServiceUnavailableException;
+import org.neo4j.driver.exceptions.TransientException;
 import org.neo4j.shell.cli.CliArgs;
 import org.neo4j.shell.commands.CommandHelper;
 import org.neo4j.shell.exception.CommandException;
@@ -27,9 +28,11 @@ import org.neo4j.shell.prettyprint.ToStringLinePrinter;
 import static java.lang.String.format;
 import static org.hamcrest.CoreMatchers.isA;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -100,6 +103,20 @@ public class MainIntegrationTest
                 }
             }
         }
+    }
+
+    private void ensureDefaultDatabaseStarted() throws Exception {
+        CypherShell shellToUse = shell;
+        if (!shellToUse.isConnected()) {
+            CliArgs cliArgs = new CliArgs();
+            cliArgs.setUsername("neo4j", "");
+            cliArgs.setPassword("neo", "");
+            cliArgs.setDatabase("system");
+            ShellAndConnection sac = getShell(cliArgs);
+            main.connectMaybeInteractively(sac.shell, sac.connectionConfig, true, false);
+            shellToUse = sac.shell;
+        }
+        shellToUse.execute("START DATABASE " + DatabaseManager.DEFAULT_DEFAULT_DB_NAME);
     }
 
     @Test
@@ -239,7 +256,7 @@ public class MainIntegrationTest
         ConnectionConfig connectionConfig = sac.connectionConfig;
 
         exception.expect( ServiceUnavailableException.class );
-        exception.expectMessage( "Unable to connect to database, ensure the database is running and that there is a working network connection to it" );
+        // The error message here may be subject to change and is not stable across versions so let us not assert on it
         main.connectMaybeInteractively( shell, connectionConfig, true, true );
     }
 
@@ -372,6 +389,97 @@ public class MainIntegrationTest
         exception.expectMessage( "Cannot find file: 'what.cypher'" );
         exception.expectCause( isA( FileNotFoundException.class ) );
         shell.execute( ":source what.cypher" );
+    }
+
+    @Test
+    public void doesNotStartWhenDefaultDatabaseUnavailableIfInteractive() throws Exception {
+        shell.setCommandHelper(new CommandHelper(mock(Logger.class), Historian.empty, shell));
+        inputBuffer.put(String.format("neo4j%nneo%n").getBytes());
+
+        assertEquals("", connectionConfig.username());
+        assertEquals("", connectionConfig.password());
+
+        // when
+        main.connectMaybeInteractively(shell, connectionConfig, true, true);
+
+        // Multiple databases are only available from 4.0
+        assumeTrue( majorVersion( shell.getServerVersion() ) >= 4 );
+
+        // then
+        // should be connected
+        assertTrue(shell.isConnected());
+        // should have prompted and set the username and password
+        String expectedLoginOutput = format( "username: neo4j%npassword: ***%n" );
+        assertEquals(expectedLoginOutput, baos.toString());
+        assertEquals("neo4j", connectionConfig.username());
+        assertEquals("neo", connectionConfig.password());
+
+        // Stop the default database
+        shell.execute(":use " + DatabaseManager.SYSTEM_DB_NAME);
+        shell.execute("STOP DATABASE " + DatabaseManager.DEFAULT_DEFAULT_DB_NAME);
+
+        try {
+            shell.disconnect();
+
+            // Should get exception that database is unavailable when trying to connect
+            exception.expect(TransientException.class);
+            exception.expectMessage("Database 'neo4j' is unavailable");
+            main.connectMaybeInteractively(shell, connectionConfig, true, true);
+
+            // then
+            assertFalse(shell.isConnected());
+        } finally {
+            // Start the default database again
+            ensureDefaultDatabaseStarted();
+        }
+    }
+
+    @Test
+    public void startsAgainstSystemDatabaseWhenDefaultDatabaseUnavailableIfInteractive() throws Exception {
+        shell.setCommandHelper(new CommandHelper(mock(Logger.class), Historian.empty, shell));
+
+        assertEquals("", connectionConfig.username());
+        assertEquals("", connectionConfig.password());
+
+        // when
+        main.connectMaybeInteractively(shell, connectionConfig, true, true);
+
+        // Multiple databases are only available from 4.0
+        assumeTrue( majorVersion( shell.getServerVersion() ) >= 4 );
+
+        // then
+        // should be connected
+        assertTrue(shell.isConnected());
+        // should have prompted and set the username and password
+        String expectedLoginOutput = format( "username: neo4j%npassword: ***%n" );
+        assertEquals(expectedLoginOutput, baos.toString());
+        assertEquals("neo4j", connectionConfig.username());
+        assertEquals("neo", connectionConfig.password());
+
+        // Stop the default database
+        shell.execute(":use " + DatabaseManager.SYSTEM_DB_NAME);
+        shell.execute("STOP DATABASE " + DatabaseManager.DEFAULT_DEFAULT_DB_NAME);
+
+        try {
+            shell.disconnect();
+
+            // Connect to system database
+            CliArgs cliArgs = new CliArgs();
+            cliArgs.setUsername("neo4j", "");
+            cliArgs.setPassword("neo", "");
+            cliArgs.setDatabase("system");
+            ShellAndConnection sac = getShell(cliArgs);
+            // Use the new shell and connection config from here on
+            shell = sac.shell;
+            connectionConfig = sac.connectionConfig;
+            main.connectMaybeInteractively(shell, connectionConfig, true, false);
+
+            // then
+            assertTrue(shell.isConnected());
+        } finally {
+            // Start the default database again
+            ensureDefaultDatabaseStarted();
+        }
     }
 
     private String executeFileNonInteractively(String filename) throws Exception {

--- a/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/CypherShell.java
@@ -177,7 +177,7 @@ public class CypherShell implements StatementExecuter, Connector, TransactionHan
         return boltStateHandler.isTransactionOpen();
     }
 
-    void setCommandHelper(@Nonnull CommandHelper commandHelper) {
+    public void setCommandHelper(@Nonnull CommandHelper commandHelper) {
         this.commandHelper = commandHelper;
     }
 

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/InteractiveShellRunner.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/InteractiveShellRunner.java
@@ -166,14 +166,11 @@ public class InteractiveShellRunner implements ShellRunner, SignalHandler {
         }
 
         String databaseName = databaseManager.getActualDatabaseAsReportedByServer();
-        if (databaseName == null) {
+        if (databaseName == null || ABSENT_DB_NAME.equals(databaseName)) {
             // We have failed to get a successful response from the connection ping query
             // Build the prompt from the db name as set by the user + a suffix indicating that we are in a disconnected state
             String dbNameSetByUser = databaseManager.getActiveDatabaseAsSetByUser();
             databaseName = ABSENT_DB_NAME.equals(dbNameSetByUser)? UNRESOLVED_DEFAULT_DB_PROPMPT_TEXT : dbNameSetByUser;
-        } else if (ABSENT_DB_NAME.equals(databaseName)) {
-            // The driver did not give us a database name in the response from the connection ping query
-            databaseName = UNRESOLVED_DEFAULT_DB_PROPMPT_TEXT;
         }
 
         String errorSuffix = getErrorPrompt(executer.lastNeo4jErrorCode());

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/InteractiveShellRunner.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/InteractiveShellRunner.java
@@ -39,8 +39,8 @@ public class InteractiveShellRunner implements ShellRunner, SignalHandler {
     private final static String TRANSACTION_PROMPT = "# ";
     private final static String USERNAME_DB_DELIMITER = "@";
     private final static int ONELINE_PROMPT_MAX_LENGTH = 50;
-    private static final String UNRESOLVED_DEFAULT_DB_PROPMPT_TEXT = "<default_database>";
-    private static final String DATABASE_UNAVAILABLE_ERROR_PROMPT_TEXT = "[UNAVAILABLE]";
+    static final String UNRESOLVED_DEFAULT_DB_PROPMPT_TEXT = "<default_database>";
+    static final String DATABASE_UNAVAILABLE_ERROR_PROMPT_TEXT = "[UNAVAILABLE]";
 
     // Need to know if we are currently executing when catch Ctrl-C, needs to be atomic due to
     // being called from different thread

--- a/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
@@ -174,9 +174,6 @@ public class BoltStateHandler implements TransactionHandler, Connector, Database
     }
 
     private void reconnect(boolean keepBookmark) {
-        // This will already throw an exception if there is no connectivity
-        driver.verifyConnectivity();
-
         SessionConfig.Builder builder = SessionConfig.builder();
         builder.withDefaultAccessMode(AccessMode.WRITE);
         if (!ABSENT_DB_NAME.equals(activeDatabaseNameAsSetByUser)) {
@@ -267,9 +264,6 @@ public class BoltStateHandler implements TransactionHandler, Connector, Database
 
         try {
             driver = getDriver(connectionConfig, authToken);
-
-            // This will already throw an exception if there is no connectivity
-            driver.verifyConnectivity();
 
             SessionConfig.Builder builder = SessionConfig.builder()
                     .withDefaultAccessMode(AccessMode.WRITE)

--- a/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
@@ -83,7 +83,7 @@ public class BoltStateHandler implements TransactionHandler, Connector, Database
                 try {
                     reconnect(true);
                 }
-                catch (ClientException e2) {
+                catch (Exception e2) {
                     e.addSuppressed(e2);
                 }
             }

--- a/cypher-shell/src/test/java/org/neo4j/shell/OfflineTestShell.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/OfflineTestShell.java
@@ -1,6 +1,5 @@
 package org.neo4j.shell;
 
-
 import org.neo4j.shell.log.Logger;
 import org.neo4j.shell.prettyprint.PrettyPrinter;
 import org.neo4j.shell.state.BoltStateHandler;
@@ -12,7 +11,7 @@ import org.neo4j.shell.state.BoltStateHandler;
  */
 public class OfflineTestShell extends CypherShell {
 
-    OfflineTestShell( Logger logger, BoltStateHandler boltStateHandler, PrettyPrinter prettyPrinter ) {
+    public OfflineTestShell(Logger logger, BoltStateHandler boltStateHandler, PrettyPrinter prettyPrinter) {
         super(logger, boltStateHandler, prettyPrinter, new ShellParameterMap());
     }
 

--- a/cypher-shell/src/test/java/org/neo4j/shell/test/bolt/FakeDriver.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/test/bolt/FakeDriver.java
@@ -11,6 +11,8 @@ import org.neo4j.driver.types.TypeSystem;
 
 import java.util.concurrent.CompletionStage;
 
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
 public class FakeDriver implements Driver {
     @Override
     public boolean isEncrypted() {
@@ -78,5 +80,17 @@ public class FakeDriver implements Driver {
     @Override
     public CompletionStage<Void> verifyConnectivityAsync() {
         return null;
+    }
+
+    @Override
+    public boolean supportsMultiDb()
+    {
+        return true;
+    }
+
+    @Override
+    public CompletionStage<Boolean> supportsMultiDbAsync()
+    {
+        return completedFuture(true);
     }
 }


### PR DESCRIPTION
We should be able to connect to another database or system database
even when the default database is stopped.

So we no longer use the Java driver verifyConnectivity() method
since that is hard-wired to check connectivity toward the default
database only.

Also adapt to that the DatabaseUnavailable error message could be
masked by the driver. Treat any ServiceUnavailable the same in
interactive mode.