### PR TITLE
Change query to execute against system to ping for version

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
@@ -193,7 +193,7 @@ public class BoltStateHandler implements TransactionHandler, Connector, Database
 
         session = driver.session(builder.build());
 
-        String query = activeDatabaseNameAsSetByUser.compareToIgnoreCase(SYSTEM_DB_NAME) == 0 ? "SHOW DEFAULT DATABASE" : "RETURN 1";
+        String query = activeDatabaseNameAsSetByUser.compareToIgnoreCase(SYSTEM_DB_NAME) == 0 ? "CALL dbms.showCurrentUser()" : "RETURN 1";
 
         resetActualDbName(); // Set this to null first in case run throws an exception
         Result run = session.run(query);


### PR DESCRIPTION
`SHOW DEFAULT DATABASE` requires the user to have a password that hasn't expired.
Changing to use a procedure that doesn't require that.

4.1 version of https://github.com/neo4j/cypher-shell/pull/185