### PR TITLE
Remove some transitive dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ ext {
 
     argparse4jVersion = '0.7.0'
     junitVersion = '4.12'
-    evaluatorVersion = '4.0.0'
+    evaluatorVersion = '3.5.14'
     neo4jJavaDriverVersion = '4.0.0'
     findbugsVersion = '3.0.0'
     jansiVersion = '1.13'

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ ext {
 
     argparse4jVersion = '0.7.0'
     junitVersion = '4.12'
-    evaluatorVersion = '3.5.4'
+    evaluatorVersion = '4.0.0'
     neo4jJavaDriverVersion = '4.0.0'
     findbugsVersion = '3.0.0'
     jansiVersion = '1.13'

--- a/cypher-shell/build.gradle
+++ b/cypher-shell/build.gradle
@@ -37,7 +37,23 @@ distributions {
 
 dependencies {
     compile "net.sourceforge.argparse4j:argparse4j:$argparse4jVersion"
-    compile "org.neo4j:neo4j-cypher-expression-evaluator:$evaluatorVersion"
+    compile("org.neo4j:neo4j-cypher-expression-evaluator:$evaluatorVersion") {
+        exclude(group: 'org.neo4j', module: 'neo4j-index')
+        exclude(group: 'org.neo4j', module: 'neo4j-fulltext-index')
+        exclude(group: 'org.neo4j', module: 'neo4j-ssl')
+        exclude(group: 'org.neo4j', module: 'neo4j-graph-algo')
+        exclude(group: 'org.neo4j', module: 'neo4j-id-generator')
+        exclude(group: 'org.neo4j', module: 'neo4j-io')
+        exclude(group: 'org.neo4j', module: 'neo4j-label-index')
+        exclude(group: 'org.neo4j', module: 'neo4j-storage-engine-api')
+        exclude(group: 'org.neo4j', module: 'neo4j-spatial-index')
+        exclude(group: 'org.neo4j', module: 'neo4j-wal')
+        exclude(group: 'org.neo4j', module: 'neo4j-native')
+        exclude(group: 'org.neo4j', module: 'neo4j-logging')
+        exclude(group: 'org.neo4j', module: 'neo4j-procedure-api')
+        exclude(group: 'org.eclipse.collections')
+        exclude(group: 'org.jctools')
+    }
     compile "org.neo4j.driver:neo4j-java-driver:$neo4jJavaDriverVersion"
     compileOnly "com.google.code.findbugs:annotations:$findbugsVersion"
     compile "org.fusesource.jansi:jansi:$jansiVersion"

--- a/cypher-shell/build.gradle
+++ b/cypher-shell/build.gradle
@@ -38,21 +38,24 @@ distributions {
 dependencies {
     compile "net.sourceforge.argparse4j:argparse4j:$argparse4jVersion"
     compile("org.neo4j:neo4j-cypher-expression-evaluator:$evaluatorVersion") {
+        exclude(group: 'org.apache.lucene')
         exclude(group: 'org.neo4j', module: 'neo4j-index')
-        exclude(group: 'org.neo4j', module: 'neo4j-fulltext-index')
+        exclude(group: 'org.neo4j', module: 'neo4j-lucene-upgrade')
         exclude(group: 'org.neo4j', module: 'neo4j-ssl')
         exclude(group: 'org.neo4j', module: 'neo4j-graph-algo')
-        exclude(group: 'org.neo4j', module: 'neo4j-id-generator')
         exclude(group: 'org.neo4j', module: 'neo4j-io')
-        exclude(group: 'org.neo4j', module: 'neo4j-label-index')
-        exclude(group: 'org.neo4j', module: 'neo4j-storage-engine-api')
+        exclude(group: 'org.neo4j', module: 'neo4j-csv')
+        exclude(group: 'org.neo4j', module: 'neo4j-configuration')
+        exclude(group: 'org.neo4j', module: 'neo4j-collections')
+        exclude(group: 'org.neo4j', module: 'neo4j-diagnostics')
+        exclude(group: 'org.neo4j', module: 'neo4j-resource')
+        exclude(group: 'org.neo4j', module: 'neo4j-annotation-processors')
         exclude(group: 'org.neo4j', module: 'neo4j-spatial-index')
-        exclude(group: 'org.neo4j', module: 'neo4j-wal')
         exclude(group: 'org.neo4j', module: 'neo4j-native')
         exclude(group: 'org.neo4j', module: 'neo4j-logging')
         exclude(group: 'org.neo4j', module: 'neo4j-procedure-api')
+        exclude(group: 'org.neo4j', module: 'neo4j-kernel-api')
         exclude(group: 'org.eclipse.collections')
-        exclude(group: 'org.jctools')
     }
     compile "org.neo4j.driver:neo4j-java-driver:$neo4jJavaDriverVersion"
     compileOnly "com.google.code.findbugs:annotations:$findbugsVersion"


### PR DESCRIPTION
The evaluator pulls in all of the kernel dependencies, this is an attempt to reduce the set.
The proper solution should be to not depend on the kernel, but that is larger refactoring.