### PR TITLE
Use db.indexes instead of showCurrentUser as ping

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
@@ -190,7 +190,7 @@ public class BoltStateHandler implements TransactionHandler, Connector, Database
 
         session = driver.session(builder.build());
 
-        String query = activeDatabaseNameAsSetByUser.compareToIgnoreCase(SYSTEM_DB_NAME) == 0 ? "CALL dbms.showCurrentUser()" : "RETURN 1";
+        String query = activeDatabaseNameAsSetByUser.compareToIgnoreCase(SYSTEM_DB_NAME) == 0 ? "CALL db.indexes()" : "RETURN 1";
 
         resetActualDbName(); // Set this to null first in case run throws an exception
         Result run = session.run(query);


### PR DESCRIPTION
We still have no built-in mechanism for pinging the database, we were
using `dbms.showCurrentUser` (for system db) however this procedure is
not registered when auth is disabled so in those cases you get a

```
neo4j@neo4j> :use system
There is no procedure with the name dbms.showCurrentUser registered for this database instance. Please ensure you've spelled the procedure name correctly and that the procedure is properly deployed.
```

This PR changes to use `db.indexes` which is also what the browser use.

changelog: Fix issue with connecting to system db with auth disabled.