### PR TITLE
Execute statements interactively in cypher-shell when in transactions

### DIFF
--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellVerboseIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellVerboseIntegrationTest.java
@@ -134,23 +134,17 @@ public class CypherShellVerboseIntegrationTest extends CypherShellIntegrationTes
     public void commitScenario() throws CommandException {
         beginCommand.execute("");
         shell.execute("CREATE (:TestPerson {name: \"Joe Smith\"})");
-        assertThat(linePrinter.output(), equalTo(""));
-        // Here ^^ we assert that nothing is printed before commit on explicit transactions. This was
-        // existing behaviour on typing this comment, but it could we worth thinking that through if
-        // we change explicit transaction queries to stream results.
+        assertThat(linePrinter.output(), containsString("0 rows available after"));
 
+        linePrinter.clear();
         shell.execute("CREATE (:TestPerson {name: \"Jane Smith\"})");
-        assertThat(linePrinter.output(), equalTo(""));
+        assertThat(linePrinter.output(), containsString("0 rows available after"));
 
+        linePrinter.clear();
         shell.execute("MATCH (n:TestPerson) RETURN n ORDER BY n.name");
-        assertThat(linePrinter.output(), equalTo(""));
+        assertThat(linePrinter.output(), containsString("\n| (:TestPerson {name: \"Jane Smith\"}) |\n| (:TestPerson {name: \"Joe Smith\"})  |\n"));
 
         commitCommand.execute("");
-
-        //then
-        String result = linePrinter.output();
-        assertThat(result,
-                containsString("\n| (:TestPerson {name: \"Jane Smith\"}) |\n| (:TestPerson {name: \"Joe Smith\"})  |\n"));
     }
 
     @Test

--- a/cypher-shell/src/test/java/org/neo4j/shell/state/BoltStateHandlerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/state/BoltStateHandlerTest.java
@@ -7,8 +7,6 @@ import org.junit.rules.ExpectedException;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
-import java.util.Optional;
 
 import org.neo4j.driver.AuthToken;
 import org.neo4j.driver.Config;
@@ -17,6 +15,7 @@ import org.neo4j.driver.Query;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Result;
 import org.neo4j.driver.Session;
+import org.neo4j.driver.Transaction;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.exceptions.SessionExpiredException;
@@ -35,7 +34,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -140,11 +138,11 @@ public class BoltStateHandlerTest {
         boltStateHandler.connect();
         boltStateHandler.beginTransaction();
 
-        assertNotNull(boltStateHandler.getTransactionStatements());
+        assertTrue(boltStateHandler.isTransactionOpen());
 
         boltStateHandler.rollbackTransaction();
 
-        assertNull(boltStateHandler.getTransactionStatements());
+        assertFalse(boltStateHandler.isTransactionOpen());
     }
 
     @Test
@@ -174,11 +172,11 @@ public class BoltStateHandlerTest {
     public void closeTransactionAfterCommit() throws CommandException {
         boltStateHandler.connect();
         boltStateHandler.beginTransaction();
-        assertNotNull(boltStateHandler.getTransactionStatements());
+        assertTrue(boltStateHandler.isTransactionOpen());
 
         boltStateHandler.commitTransaction();
 
-        assertNull(boltStateHandler.getTransactionStatements());
+        assertFalse(boltStateHandler.isTransactionOpen());
     }
 
     @Test
@@ -206,57 +204,30 @@ public class BoltStateHandlerTest {
         boltStateHandler.connect();
 
         boltStateHandler.beginTransaction();
-        assertNotNull(boltStateHandler.getTransactionStatements());
+        assertTrue(boltStateHandler.isTransactionOpen());
     }
 
     @Test
-    public void commitPurgesTheTransactionStatementsAndCollectsResults() throws CommandException {
+    public void whenInTransactionHandlerLetsTransactionDoTheWork() throws CommandException {
+        Transaction transactionMock = mock(Transaction.class);
         Session sessionMock = mock(Session.class);
+        when(sessionMock.beginTransaction()).thenReturn(transactionMock);
         Driver driverMock = stubResultSummaryInAnOpenSession(mock(Result.class), sessionMock, "neo4j-version");
 
-        Record record1 = mock(Record.class);
-        Record record2 = mock(Record.class);
-        Record record3 = mock(Record.class);
-        Value val1 = mock(Value.class);
-        Value val2 = mock(Value.class);
-        Value str1Val = mock(Value.class);
-        Value str2Val = mock(Value.class);
+        Result result = mock(Result.class);
 
-        BoltResult boltResult1 = new ListBoltResult(asList(record1, record2), mock(ResultSummary.class));
-        BoltResult boltResult2 = new ListBoltResult(asList(record3), mock(ResultSummary.class));
-
-        when(str1Val.toString()).thenReturn("str1");
-        when(str2Val.toString()).thenReturn("str2");
-        when(val1.toString()).thenReturn("1");
-        when(val2.toString()).thenReturn("2");
-
-        when(record1.get(0)).thenReturn(val1);
-        when(record2.get(0)).thenReturn(val2);
-
-        when(record3.get(0)).thenReturn(str1Val);
-        when(record3.get(1)).thenReturn(str2Val);
-        when(sessionMock.writeTransaction(anyObject())).thenReturn(asList(boltResult1, boltResult2));
+        when(transactionMock.run((Query)anyObject())).thenReturn(result);
 
         OfflineBoltStateHandler boltStateHandler = new OfflineBoltStateHandler(driverMock);
         boltStateHandler.connect();
         boltStateHandler.beginTransaction();
-        boltStateHandler.runCypher("UNWIND [1,2] as num RETURN *", Collections.emptyMap());
-        boltStateHandler.runCypher("RETURN \"str1\", \"str2\"", Collections.emptyMap());
+        BoltResult boltResult = boltStateHandler.runCypher("UNWIND [1,2] as num RETURN *", Collections.emptyMap()).get();
+        assertEquals(result, boltResult.iterate());
 
-        Optional<List<BoltResult>> boltResultOptional = boltStateHandler.commitTransaction();
-        List<BoltResult> boltResults = boltResultOptional.get();
-        Record actualRecord1 = boltResults.get(0).getRecords().get(0);
-        Record actualRecord2 = boltResults.get(0).getRecords().get(1);
+        boltStateHandler.commitTransaction();
 
-        Record actualRecord3 = boltResults.get(1).getRecords().get(0);
+        assertFalse(boltStateHandler.isTransactionOpen());
 
-        assertNull(boltStateHandler.getTransactionStatements());
-
-        assertEquals("1", actualRecord1.get(0).toString());
-        assertEquals("2", actualRecord2.get(0).toString());
-
-        assertEquals("str1", actualRecord3.get(0).toString());
-        assertEquals("str2", actualRecord3.get(1).toString());
     }
 
     @Test
@@ -282,7 +253,7 @@ public class BoltStateHandlerTest {
         boltStateHandler.connect();
         boltStateHandler.beginTransaction();
 
-        assertNotNull("Expected a transaction", boltStateHandler.getTransactionStatements());
+        assertTrue("Expected a transaction", boltStateHandler.isTransactionOpen());
     }
 
     @Test
@@ -344,7 +315,7 @@ public class BoltStateHandlerTest {
     public void shouldExecuteInSessionByDefault() throws CommandException {
         boltStateHandler.connect();
 
-        assertNull("Did not expect a transaction", boltStateHandler.getTransactionStatements());
+        assertFalse("Did not expect a transaction", boltStateHandler.isTransactionOpen());
     }
 
     @Test
@@ -377,7 +348,6 @@ public class BoltStateHandlerTest {
 
         // then
         verify(sessionMock).reset();
-        assertNull(boltStateHandler.getTransactionStatements());
     }
 
     @Test

--- a/cypher-shell/src/test/java/org/neo4j/shell/test/bolt/FakeSession.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/test/bolt/FakeSession.java
@@ -20,12 +20,12 @@ public class FakeSession implements Session {
 
     @Override
     public Transaction beginTransaction() {
-        return null;
+        return new FakeTransaction();
     }
 
     @Override
     public Transaction beginTransaction(TransactionConfig config) {
-        return null;
+        return new FakeTransaction();
     }
 
     @Override

--- a/cypher-shell/src/test/java/org/neo4j/shell/test/bolt/FakeTransaction.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/test/bolt/FakeTransaction.java
@@ -1,0 +1,56 @@
+package org.neo4j.shell.test.bolt;
+
+import org.neo4j.driver.Query;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Result;
+import org.neo4j.driver.Transaction;
+import org.neo4j.driver.Value;
+
+import java.util.Map;
+
+public class FakeTransaction implements Transaction {
+    @Override
+    public void commit() {
+
+    }
+
+    @Override
+    public void rollback() {
+
+    }
+
+    @Override
+    public boolean isOpen() {
+        return true;
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public Result run(String query, Value parameters) {
+        return null;
+    }
+
+    @Override
+    public Result run(String query, Map<String, Object> parameters) {
+        return null;
+    }
+
+    @Override
+    public Result run(String query, Record parameters) {
+        return null;
+    }
+
+    @Override
+    public Result run(String query) {
+        return null;
+    }
+
+    @Override
+    public Result run(Query query) {
+        return null;
+    }
+}


### PR DESCRIPTION
As in PostgreSQL, it is nice to be able to check the results of your work in a transaction, so you can choose whether to rollback or commit.