### PR TITLE
Automatically fall back to bolt protocol

### DIFF
--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellProtocolIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellProtocolIntegrationTest.java
@@ -1,0 +1,24 @@
+package org.neo4j.shell.commands;
+
+import org.junit.Test;
+
+import org.neo4j.shell.ConnectionConfig;
+import org.neo4j.shell.CypherShell;
+import org.neo4j.shell.ShellParameterMap;
+import org.neo4j.shell.StringLinePrinter;
+import org.neo4j.shell.cli.Format;
+import org.neo4j.shell.prettyprint.PrettyConfig;
+import static org.junit.Assert.assertTrue;
+
+import static org.neo4j.shell.DatabaseManager.ABSENT_DB_NAME;
+
+public class CypherShellProtocolIntegrationTest{
+
+    @Test
+    public void shouldConnectWithNeo4jProtocol() throws Exception {
+        CypherShell shell = new CypherShell( new StringLinePrinter(), new PrettyConfig( Format.PLAIN, true, 1000), false, new ShellParameterMap());
+        // This should work even on older databases without the neo4j protocol, by falling back to bolt
+        shell.connect( new ConnectionConfig( "neo4j://", "localhost", 7687, "neo4j", "neo", false, ABSENT_DB_NAME ) );
+        assertTrue(shell.isConnected());
+    }
+}

--- a/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
@@ -26,6 +26,7 @@ import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.exceptions.SessionExpiredException;
+import org.neo4j.driver.internal.DriverFactory;
 import org.neo4j.driver.summary.DatabaseInfo;
 import org.neo4j.driver.summary.ResultSummary;
 import org.neo4j.shell.ConnectionConfig;
@@ -156,9 +157,25 @@ public class BoltStateHandler implements TransactionHandler, Connector, Database
         final AuthToken authToken = AuthTokens.basic(connectionConfig.username(), connectionConfig.password());
 
         try {
-            setActiveDatabase(connectionConfig.database());
-            driver = getDriver(connectionConfig, authToken);
-            reconnect();
+            try {
+                setActiveDatabase(connectionConfig.database());
+                driver = getDriver(connectionConfig, authToken);
+                reconnect();
+            } catch (org.neo4j.driver.exceptions.ServiceUnavailableException e) {
+                if (!connectionConfig.scheme().equals(DriverFactory.BOLT_ROUTING_URI_SCHEME + "://")) {
+                    throw e;
+                }
+                connectionConfig = new ConnectionConfig(
+                    DriverFactory.BOLT_URI_SCHEME + "://",
+                    connectionConfig.host(),
+                    connectionConfig.port(),
+                    connectionConfig.username(),
+                    connectionConfig.password(),
+                    connectionConfig.encryption(),
+                    connectionConfig.database());
+                driver = getDriver(connectionConfig, authToken);
+                reconnect();
+            }
         } catch (Throwable t) {
             try {
                 silentDisconnect();


### PR DESCRIPTION
It seems that cypher-shell changed the default protocol, this means that one has to add `-a localhost:7687` to get cypher-shell to speak to older databases.

I don't see any particular reason that cypher-shell shouldn't automatically fall back to the older protocol.