### PR TITLE
Rename DEFAULT_ to ABSENT_

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgs.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgs.java
@@ -10,14 +10,14 @@ import org.neo4j.shell.ShellParameterMap;
 import static org.neo4j.shell.DatabaseManager.ABSENT_DB_NAME;
 
 public class CliArgs {
-    private static final String DEFAULT_SCHEME = "bolt://";
-    private static final String DEFAULT_HOST = "localhost";
-    private static final int DEFAULT_PORT = 7687;
+    private static final String ABSENT_SCHEME = "bolt://";
+    private static final String ABSENT_HOST = "localhost";
+    private static final int ABSENT_PORT = 7687;
     static final int DEFAULT_NUM_SAMPLE_ROWS = 1000;
 
-    private String scheme = DEFAULT_SCHEME;
-    private String host = DEFAULT_HOST;
-    private int port = DEFAULT_PORT;
+    private String scheme = ABSENT_SCHEME;
+    private String host = ABSENT_HOST;
+    private int port = ABSENT_PORT;
     private String username = "";
     private String password = "";
     private String databaseName = ABSENT_DB_NAME;


### PR DESCRIPTION
While you might think that these are in fact defaults, they are not.

If you do not ask for an address/port, you get the default connection url.
That url is set in `CliArgHelper.setupParser` to `neo4j://localhost:7687`
https://github.com/neo4j/cypher-shell/blob/290c6de4d9194329b16efcc045ddcd4670307340/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgHelper.java#L156

a url that is significantly different from `bolt://localhost:7687`.

---
This made understanding #201 very confusing. Especially all mentions of `DEFAULT_SCHEME` and the fact that the vast majority of the tests are for `bolt:` 