### PR TITLE
Use the neo4j protocol as the default for tests as well.

### DIFF
--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/MainIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/MainIntegrationTest.java
@@ -470,6 +470,7 @@ public class MainIntegrationTest
 
             // Should get exception that database is unavailable when trying to connect
             main.connectMaybeInteractively(shell, connectionConfig, true, true);
+            fail("No exception thrown");
         } catch(TransientException|ServiceUnavailableException e) {
             expectDatabaseUnavailable(e, "neo4j");
         } finally {
@@ -556,6 +557,7 @@ public class MainIntegrationTest
         try {
             // Should get exception that database is unavailable when trying to connect
             shell.execute(":use " + DatabaseManager.DEFAULT_DEFAULT_DB_NAME);
+            fail("No exception thrown");
         } catch(TransientException|ServiceUnavailableException e) {
             expectDatabaseUnavailable(e, "neo4j");
         } finally {
@@ -594,6 +596,7 @@ public class MainIntegrationTest
         try {
             // Should get exception that database is unavailable when trying to connect
             shell.execute(":use");
+            fail("No exception thrown");
         } catch(TransientException|ServiceUnavailableException e) {
             expectDatabaseUnavailable(e, "neo4j");
         } finally {

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgHelper.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgHelper.java
@@ -82,7 +82,7 @@ public class CliArgHelper {
         cliArgs.setHost(addressMatcher.group("host"), "localhost");
         // Safe, regex only matches integers
         String portString = addressMatcher.group("port");
-        cliArgs.setPort(portString == null ? 7687 : Integer.parseInt(portString));
+        cliArgs.setPort(portString == null ? CliArgs.DEFAULT_PORT : Integer.parseInt(portString));
         // Also parse username and password from address if available
         cliArgs.setUsername(addressMatcher.group("username"), "");
         cliArgs.setPassword(addressMatcher.group("password"), "");
@@ -153,7 +153,7 @@ public class CliArgHelper {
         ArgumentGroup connGroup = parser.addArgumentGroup("connection arguments");
         connGroup.addArgument("-a", "--address")
                 .help("address and port to connect to")
-                .setDefault("neo4j://localhost:7687");
+                .setDefault(String.format("%s%s:%d", CliArgs.DEFAULT_SCHEME, CliArgs.DEFAULT_HOST, CliArgs.DEFAULT_PORT));
         connGroup.addArgument("-u", "--username")
                 .setDefault("")
                 .help("username to connect as. Can also be specified using environment variable " + ConnectionConfig.USERNAME_ENV_VAR);

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgs.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgs.java
@@ -10,9 +10,9 @@ import org.neo4j.shell.ShellParameterMap;
 import static org.neo4j.shell.DatabaseManager.ABSENT_DB_NAME;
 
 public class CliArgs {
-    private static final String DEFAULT_SCHEME = "bolt://";
-    private static final String DEFAULT_HOST = "localhost";
-    private static final int DEFAULT_PORT = 7687;
+    static final String DEFAULT_SCHEME = "neo4j://";
+    static final String DEFAULT_HOST = "localhost";
+    static final int DEFAULT_PORT = 7687;
     static final int DEFAULT_NUM_SAMPLE_ROWS = 1000;
 
     private String scheme = DEFAULT_SCHEME;

--- a/cypher-shell/src/main/java/org/neo4j/shell/log/AnsiLogger.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/log/AnsiLogger.java
@@ -115,7 +115,7 @@ public class AnsiLogger implements Logger {
      * Formatting for Bolt exceptions.
      */
     @Nonnull
-    String getFormattedMessage(@Nonnull final Throwable e) {
+    public String getFormattedMessage(@Nonnull final Throwable e) {
         AnsiFormattedText msg = AnsiFormattedText.s().colorRed();
 
         if (isDebugEnabled()) {

--- a/cypher-shell/src/test/java/org/neo4j/shell/cli/CliArgHelperTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/cli/CliArgHelperTest.java
@@ -12,8 +12,8 @@ import java.util.ArrayList;
 import java.util.Optional;
 
 import static java.util.Arrays.asList;
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -150,8 +150,19 @@ public class CliArgHelperTest {
         assertNotNull(cliArgs);
         assertEquals("alice", cliArgs.getUsername());
         assertEquals("foo", cliArgs.getPassword());
+        assertEquals("bolt+routing://", cliArgs.getScheme());
         assertEquals("bar", cliArgs.getHost());
         assertEquals(69, cliArgs.getPort());
+    }
+
+    @Test
+    public void defaultAddress()
+    {
+        CliArgs cliArgs = CliArgHelper.parse();
+        assertNotNull( cliArgs );
+        assertEquals( CliArgs.DEFAULT_SCHEME, cliArgs.getScheme() );
+        assertEquals( CliArgs.DEFAULT_HOST, cliArgs.getHost() );
+        assertEquals( CliArgs.DEFAULT_PORT, cliArgs.getPort() );
     }
 
     @Test


### PR DESCRIPTION
In production `neo4j://` was the default protocol, but in integration-tests we used `bolt://` by default instead. This aligns the tests with the production default.