### PR TITLE
Show memory in Profile.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,4 +77,5 @@ ext {
     mockitoVersion = '1.9.5'
     systemRulesVersion = '1.19.0'
     commonsIoVersion = '2.6'
+    hamcrestVersion = '2.0.0.0'
 }

--- a/cypher-shell/build.gradle
+++ b/cypher-shell/build.gradle
@@ -67,5 +67,6 @@ dependencies {
     testCompile "junit:junit:$junitVersion"
     testCompile "org.mockito:mockito-core:$mockitoVersion"
     testCompile "com.github.stefanbirkner:system-rules:$systemRulesVersion"
+    testCompile "org.hamcrest:java-hamcrest:$hamcrestVersion"
     testCompileOnly "com.google.code.findbugs:annotations:$findbugsVersion"
 }

--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellPlainIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellPlainIntegrationTest.java
@@ -16,10 +16,10 @@ import org.neo4j.shell.prettyprint.PrettyConfig;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assume.assumeTrue;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.junit.Assume.assumeThat;
 import static org.neo4j.shell.prettyprint.OutputFormatter.NEWLINE;
-import static org.neo4j.shell.util.Versions.majorVersion;
-import static org.neo4j.shell.util.Versions.minorVersion;
+import static org.neo4j.shell.util.Versions.version;
 
 public class CypherShellPlainIntegrationTest extends CypherShellIntegrationTest {
     @Rule
@@ -75,8 +75,7 @@ public class CypherShellPlainIntegrationTest extends CypherShellIntegrationTest 
 
         String serverVersion = shell.getServerVersion();
         // Memory profile are only available from 4.1
-        assumeTrue( majorVersion( serverVersion ) >= 4);
-        assumeTrue( minorVersion( serverVersion ) >= 1);
+        assumeThat( version(serverVersion), greaterThanOrEqualTo(version("4.1")));
 
         //when
         shell.execute("CYPHER RUNTIME=INTERPRETED PROFILE RETURN null");

--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellPlainIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellPlainIntegrationTest.java
@@ -16,8 +16,10 @@ import org.neo4j.shell.prettyprint.PrettyConfig;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 import static org.neo4j.shell.prettyprint.OutputFormatter.NEWLINE;
+import static org.neo4j.shell.util.Versions.majorVersion;
+import static org.neo4j.shell.util.Versions.minorVersion;
 
 public class CypherShellPlainIntegrationTest extends CypherShellIntegrationTest {
     @Rule
@@ -65,6 +67,24 @@ public class CypherShellPlainIntegrationTest extends CypherShellIntegrationTest 
         assertThat(actual, containsString("Rows: 1"));
         assertThat(actual, containsString("null"));
         assertThat(actual, containsString("NULL"));
+    }
+
+    @Test
+    public void cypherWithProfileWithMemory() throws CommandException {
+        // given
+
+        String serverVersion = shell.getServerVersion();
+        // Memory profile are only available from 4.1
+        assumeTrue( majorVersion( serverVersion ) >= 4);
+        assumeTrue( minorVersion( serverVersion ) >= 1);
+
+        //when
+        shell.execute("CYPHER RUNTIME=INTERPRETED PROFILE RETURN null");
+
+        //then
+        String actual = linePrinter.output();
+        System.out.println(actual);
+        assertThat(actual, containsString("Memory (Bytes): 0"));
     }
 
     @Test

--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellVerboseIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellVerboseIntegrationTest.java
@@ -223,6 +223,24 @@ public class CypherShellVerboseIntegrationTest extends CypherShellIntegrationTes
     }
 
     @Test
+    public void cypherWithProfileWithMemory() throws CommandException {
+        // given
+
+        String serverVersion = shell.getServerVersion();
+        // Memory profile are only available from 4.1
+        assumeTrue( majorVersion( serverVersion ) >= 4);
+        assumeTrue( minorVersion( serverVersion ) >= 1);
+
+        //when
+        shell.execute("CYPHER RUNTIME=INTERPRETED PROFILE WITH 1 AS x RETURN DISTINCT x");
+
+        //then
+        String actual = linePrinter.output();
+        assertThat(actual, containsString("| Plan      | Statement   | Version      | Planner | Runtime       | Time | DbHits | Rows | Memory (Bytes) |")); // First table
+        assertThat(actual, containsString("| Operator        | Estimated Rows | Rows | DB Hits | Cache H/M | Memory (Bytes) | Identifiers |")); // Second table
+    }
+
+    @Test
     public void shouldShowTheNumberOfRows() throws CommandException {
         //when
         shell.execute("UNWIND [1,2,3] AS row RETURN row");

--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellVerboseIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellVerboseIntegrationTest.java
@@ -18,11 +18,13 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeThat;
 import static org.junit.Assume.assumeTrue;
 import static org.neo4j.shell.util.Versions.majorVersion;
-import static org.neo4j.shell.util.Versions.minorVersion;
+import static org.neo4j.shell.util.Versions.version;
 
 public class CypherShellVerboseIntegrationTest extends CypherShellIntegrationTest {
     @Rule
@@ -192,7 +194,7 @@ public class CypherShellVerboseIntegrationTest extends CypherShellIntegrationTes
     public void cypherWithOrder() throws CommandException {
         // given
         String serverVersion = shell.getServerVersion();
-        assumeTrue(minorVersion(serverVersion) == 6 || majorVersion(serverVersion) == 4);
+        assumeThat( version(serverVersion), greaterThanOrEqualTo(version("3.6")));
 
         shell.execute( "CREATE INDEX ON :Person(age)" );
         shell.execute( "CALL db.awaitIndexes()" );
@@ -228,8 +230,7 @@ public class CypherShellVerboseIntegrationTest extends CypherShellIntegrationTes
 
         String serverVersion = shell.getServerVersion();
         // Memory profile are only available from 4.1
-        assumeTrue( majorVersion( serverVersion ) >= 4);
-        assumeTrue( minorVersion( serverVersion ) >= 1);
+        assumeThat( version(serverVersion), greaterThanOrEqualTo(version("4.1")));
 
         //when
         shell.execute("CYPHER RUNTIME=INTERPRETED PROFILE WITH 1 AS x RETURN DISTINCT x");

--- a/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/OutputFormatter.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/OutputFormatter.java
@@ -204,15 +204,17 @@ public interface OutputFormatter {
         result.put("Plan", Values.value(summary.hasProfile() ? "PROFILE" : "EXPLAIN"));
         result.put("Statement", Values.value(summary.queryType().name()));
         Map<String, Value> arguments = plan.arguments();
-        Value defaultValue = Values.value("");
+        Value emptyString = Values.value("");
+        Value questionMark = Values.value("?");
 
         for (String key : INFO_SUMMARY) {
-            Value value = arguments.getOrDefault(key, arguments.getOrDefault(key.toLowerCase(), defaultValue));
+            Value value = arguments.getOrDefault(key, arguments.getOrDefault(key.toLowerCase(), emptyString));
             result.put(key, value);
         }
         result.put("Time", Values.value(summary.resultAvailableAfter(MILLISECONDS)+summary.resultConsumedAfter(MILLISECONDS)));
         if ( summary.hasProfile() ) result.put( "DbHits", Values.value( collectHits( summary.profile() ) ) );
         if (summary.hasProfile()) result.put("Rows", Values.value( summary.profile().records() ));
+        if (summary.hasProfile()) result.put("Memory (Bytes)", arguments.getOrDefault("GlobalMemory", questionMark));
         return result;
     }
 

--- a/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/TablePlanFormatter.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/prettyprint/TablePlanFormatter.java
@@ -37,16 +37,17 @@ class TablePlanFormatter {
     private static final String PAGE_CACHE = "Cache H/M";
     private static final String TIME = "Time (ms)";
     private static final String ORDER = "Ordered by";
+    private static final String MEMORY = "Memory (Bytes)";
     private static final String IDENTIFIERS = "Identifiers";
     private static final String OTHER = "Other";
     private static final String SEPARATOR = ", ";
     private static final Pattern DEDUP_PATTERN = Pattern.compile("\\s*(\\S+)@\\d+");
 
-    private static final List<String> HEADERS = asList(OPERATOR, ESTIMATED_ROWS, ROWS, HITS, PAGE_CACHE, TIME, IDENTIFIERS, ORDER, OTHER);
+    private static final List<String> HEADERS = asList(OPERATOR, ESTIMATED_ROWS, ROWS, HITS, PAGE_CACHE, TIME, MEMORY, IDENTIFIERS, ORDER, OTHER);
 
     private static final Set<String> IGNORED_ARGUMENTS = new LinkedHashSet<>(
             asList( "Rows", "DbHits", "EstimatedRows", "planner", "planner-impl", "planner-version", "version", "runtime", "runtime-impl", "runtime-version",
-                    "time", "source-code", "PageCacheMisses", "PageCacheHits", "PageCacheHitRatio", "Order" ) );
+                    "time", "source-code", "PageCacheMisses", "PageCacheHits", "PageCacheHitRatio", "Order", "Memory", "GlobalMemory" ) );
     public static final Value ZERO_VALUE = Values.value(0);
 
     private int width(@Nonnull String header, @Nonnull Map<String, Integer> columns) {
@@ -207,6 +208,8 @@ class TablePlanFormatter {
                     return mapping(TIME, new Right(String.format("%.3f", value.asLong() / 1000000.0d)), columns);
                 case "Order":
                     return mapping( ORDER, new Left( String.format( "%s", value.asString() ) ), columns );
+                case "Memory":
+                    return mapping( MEMORY, new Right( String.format( "%s", value.asNumber().toString() ) ), columns );
                 default:
                     return Optional.empty();
             }


### PR DESCRIPTION
cl:
When running a Cypher query with "PROFILE", a new column "Memory (Bytes)" informs about the maximum amount of memory that this operator allocated during the execution of the query. Given values are estimates.