### PR TITLE
Fix bug when running non-interactively and password change required

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/Main.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/Main.java
@@ -22,6 +22,7 @@ import org.neo4j.shell.prettyprint.PrettyConfig;
 
 import static org.neo4j.shell.ShellRunner.isInputInteractive;
 import static org.neo4j.shell.ShellRunner.isOutputInteractive;
+import static org.neo4j.shell.util.Versions.isPasswordChangeRequiredException;
 
 public class Main {
     static final String NEO_CLIENT_ERROR_SECURITY_UNAUTHORIZED = "Neo.ClientError.Security.Unauthorized";
@@ -172,7 +173,7 @@ public class Main {
                 promptForUsernameAndPassword(connectionConfig, outputInteractive);
                 didPrompt = true;
             } catch (Neo4jException e) {
-                if (passwordChangeRequiredException(e)) {
+                if (isPasswordChangeRequiredException(e)) {
                     promptForPasswordChange(connectionConfig, outputInteractive);
                     shell.changePassword(connectionConfig);
                     didPrompt = true;
@@ -181,10 +182,6 @@ public class Main {
                 }
             }
         }
-    }
-
-    private boolean passwordChangeRequiredException(Neo4jException e) {
-        return "Neo.ClientError.Security.CredentialsExpired".equalsIgnoreCase(e.code());
     }
 
     private void promptForUsernameAndPassword(ConnectionConfig connectionConfig, boolean outputInteractive) throws Exception {

--- a/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
@@ -221,11 +221,12 @@ public class BoltStateHandler implements TransactionHandler, Connector, Database
         session = driver.session( builder.build() );
 
         resetActualDbName(); // Set this to null first in case run throws an exception
-        wrap(command).apply();
+        connect(command);
     }
 
-    private ThrowingAction<CommandException> wrap(ThrowingAction<CommandException> command) {
-        return command == null ? getPing() : () ->
+    private void connect( ThrowingAction<CommandException> command) throws CommandException
+    {
+        ThrowingAction<CommandException> toCall = command == null ? getPing() : () ->
         {
             try
             {
@@ -242,6 +243,9 @@ public class BoltStateHandler implements TransactionHandler, Connector, Database
                 throw e;
             }
         };
+
+        //execute
+        toCall.apply();
     }
 
     private ThrowingAction<CommandException> getPing() {

--- a/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
@@ -25,6 +25,7 @@ import org.neo4j.driver.Transaction;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.Values;
 import org.neo4j.driver.exceptions.ClientException;
+import org.neo4j.driver.exceptions.Neo4jException;
 import org.neo4j.driver.exceptions.SessionExpiredException;
 import org.neo4j.driver.internal.Scheme;
 import org.neo4j.driver.summary.DatabaseInfo;
@@ -38,6 +39,7 @@ import org.neo4j.shell.TriFunction;
 import org.neo4j.shell.exception.CommandException;
 import org.neo4j.shell.log.NullLogging;
 
+import static org.neo4j.shell.util.Versions.isPasswordChangeRequiredException;
 import static org.neo4j.shell.util.Versions.majorVersion;
 
 /**
@@ -218,10 +220,28 @@ public class BoltStateHandler implements TransactionHandler, Connector, Database
 
         session = driver.session( builder.build() );
 
-        ThrowingAction<CommandException> action = command != null ? command : getPing();
-
         resetActualDbName(); // Set this to null first in case run throws an exception
-        action.apply();
+        wrap(command).apply();
+    }
+
+    private ThrowingAction<CommandException> wrap(ThrowingAction<CommandException> command) {
+        return command == null ? getPing() : () ->
+        {
+            try
+            {
+                command.apply();
+            }
+            catch ( Neo4jException e )
+            {
+                //If we need to update password we need to call the apply
+                //to set the server version and such.
+                if (isPasswordChangeRequiredException( e ))
+                {
+                    getPing().apply();
+                }
+                throw e;
+            }
+        };
     }
 
     private ThrowingAction<CommandException> getPing() {
@@ -401,6 +421,7 @@ public class BoltStateHandler implements TransactionHandler, Connector, Database
     public void disconnect() {
          reset();
          silentDisconnect();
+         version = null;
     }
 
     List<Query> getTransactionStatements() {

--- a/cypher-shell/src/main/java/org/neo4j/shell/util/Versions.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/util/Versions.java
@@ -1,5 +1,7 @@
 package org.neo4j.shell.util;
 
+import org.neo4j.driver.exceptions.Neo4jException;
+
 import static java.lang.Integer.parseInt;
 import static java.lang.String.format;
 
@@ -46,5 +48,9 @@ public final class Versions {
                 throw new AssertionError(
                         format("%s is not a proper version string, it should be of the form X.Y.Z ", version));
         }
+    }
+
+    public static boolean isPasswordChangeRequiredException( Neo4jException e) {
+        return "Neo.ClientError.Security.CredentialsExpired".equalsIgnoreCase(e.code());
     }
 }


### PR DESCRIPTION
In the situation when running non-interactively without when a password change
was required, such as running the following on a vanilla db

```
cypher-shell -u neo4j -p neo4j "RETURN 1"
```

the user was first prompted for a password but then failed with the error

>This procedure is no longer available, use: 'ALTER CURRENT USER SET PASSWORD'

This was due to a recent change how we handle interactive commands, what happens
is we never run the `ping` so we never get a chance to set the `version` field
in `BoltStateHandler` which in turn messes up the updating of the password since
it thinks we are communicating with an older db.