### PR TITLE
Support +ssc and +s protocols

### DIFF
--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellIntegrationTest.java
@@ -1,8 +1,8 @@
 package org.neo4j.shell.commands;
 
-import org.neo4j.driver.exceptions.ServiceUnavailableException;
 import org.neo4j.shell.ConnectionConfig;
 import org.neo4j.shell.CypherShell;
+import org.neo4j.shell.cli.Encryption;
 import org.neo4j.shell.exception.CommandException;
 
 import static org.neo4j.shell.DatabaseManager.ABSENT_DB_NAME;
@@ -12,15 +12,6 @@ abstract class CypherShellIntegrationTest
     CypherShell shell;
 
     void connect(String password) throws CommandException {
-        // Try with encryption off first, which is the default for 4.X
-        try
-        {
-            shell.connect( new ConnectionConfig( "bolt://", "localhost", 7687, "neo4j", password, false, ABSENT_DB_NAME ) );
-        }
-        catch ( ServiceUnavailableException e )
-        {
-            // This means we are probably in 3.X, let's retry with encryption on
-            shell.connect( new ConnectionConfig( "bolt://", "localhost", 7687, "neo4j", password, true, ABSENT_DB_NAME ) );
-        }
+        shell.connect( new ConnectionConfig( "bolt://", "localhost", 7687, "neo4j", password, Encryption.DEFAULT, ABSENT_DB_NAME ) );
     }
 }

--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellMultiDatabaseIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellMultiDatabaseIntegrationTest.java
@@ -11,6 +11,7 @@ import org.neo4j.shell.ConnectionConfig;
 import org.neo4j.shell.CypherShell;
 import org.neo4j.shell.ShellParameterMap;
 import org.neo4j.shell.StringLinePrinter;
+import org.neo4j.shell.cli.Encryption;
 import org.neo4j.shell.cli.Format;
 import org.neo4j.shell.exception.CommandException;
 import org.neo4j.shell.prettyprint.PrettyConfig;
@@ -45,7 +46,7 @@ public class CypherShellMultiDatabaseIntegrationTest
         beginCommand = new Begin( shell );
         rollbackCommand = new Rollback( shell );
 
-        shell.connect( new ConnectionConfig( "bolt://", "localhost", 7687, "neo4j", "neo", false, ABSENT_DB_NAME ) );
+        shell.connect( new ConnectionConfig( "bolt://", "localhost", 7687, "neo4j", "neo", Encryption.DEFAULT, ABSENT_DB_NAME ) );
 
         // Multiple databases are only available from 4.0
         assumeTrue( majorVersion( shell.getServerVersion() ) >= 4 );
@@ -137,7 +138,7 @@ public class CypherShellMultiDatabaseIntegrationTest
     {
         shell = new CypherShell( linePrinter, new PrettyConfig( Format.PLAIN, true, 1000 ), true, new ShellParameterMap() );
         useCommand = new Use( shell );
-        shell.connect( new ConnectionConfig( "bolt://", "localhost", 7687, "neo4j", "neo", false, ABSENT_DB_NAME ) );
+        shell.connect( new ConnectionConfig( "bolt://", "localhost", 7687, "neo4j", "neo", Encryption.DEFAULT, ABSENT_DB_NAME ) );
 
         useCommand.execute( SYSTEM_DB_NAME );
 

--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellProtocolIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellProtocolIntegrationTest.java
@@ -6,19 +6,57 @@ import org.neo4j.shell.ConnectionConfig;
 import org.neo4j.shell.CypherShell;
 import org.neo4j.shell.ShellParameterMap;
 import org.neo4j.shell.StringLinePrinter;
+import org.neo4j.shell.cli.Encryption;
 import org.neo4j.shell.cli.Format;
 import org.neo4j.shell.prettyprint.PrettyConfig;
-import static org.junit.Assert.assertTrue;
 
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 import static org.neo4j.shell.DatabaseManager.ABSENT_DB_NAME;
+import static org.neo4j.shell.util.Versions.majorVersion;
 
 public class CypherShellProtocolIntegrationTest{
+
+    @Test
+    public void shouldConnectWithBoltProtocol() throws Exception {
+        CypherShell shell = new CypherShell( new StringLinePrinter(), new PrettyConfig( Format.PLAIN, true, 1000), false, new ShellParameterMap());
+        shell.connect( new ConnectionConfig( "bolt://", "localhost", 7687, "neo4j", "neo", Encryption.DEFAULT, ABSENT_DB_NAME ) );
+        assertTrue(shell.isConnected());
+    }
 
     @Test
     public void shouldConnectWithNeo4jProtocol() throws Exception {
         CypherShell shell = new CypherShell( new StringLinePrinter(), new PrettyConfig( Format.PLAIN, true, 1000), false, new ShellParameterMap());
         // This should work even on older databases without the neo4j protocol, by falling back to bolt
-        shell.connect( new ConnectionConfig( "neo4j://", "localhost", 7687, "neo4j", "neo", false, ABSENT_DB_NAME ) );
+        shell.connect( new ConnectionConfig( "neo4j://", "localhost", 7687, "neo4j", "neo", Encryption.DEFAULT, ABSENT_DB_NAME ) );
         assertTrue(shell.isConnected());
+    }
+
+    @Test
+    public void shouldConnectWithBoltSSCProtocol() throws Exception {
+        CypherShell shell = new CypherShell( new StringLinePrinter(), new PrettyConfig( Format.PLAIN, true, 1000), false, new ShellParameterMap());
+        // Given 3.X series, where SSC are the default. Hard to test in 4.0 sadly.
+        onlyIn3x(shell);
+        shell.connect( new ConnectionConfig( "bolt+ssc://", "localhost", 7687, "neo4j", "neo", Encryption.DEFAULT, ABSENT_DB_NAME ) );
+        assertTrue(shell.isConnected());
+    }
+
+    @Test
+    public void shouldConnectWithNeo4jSSCProtocol() throws Exception {
+        CypherShell shell = new CypherShell( new StringLinePrinter(), new PrettyConfig( Format.PLAIN, true, 1000), false, new ShellParameterMap());
+        // Given 3.X series, where SSC are the default. Hard to test in 4.0 sadly.
+        onlyIn3x(shell);
+        // This should work by falling back to bolt+ssc
+        shell.connect( new ConnectionConfig( "neo4j+ssc://", "localhost", 7687, "neo4j", "neo", Encryption.DEFAULT, ABSENT_DB_NAME ) );
+        assertTrue(shell.isConnected());
+    }
+
+    // Here should be tests for "neo4j+s" and "bolt+s", but we don't have the infrastructure for those.
+
+    private void onlyIn3x(CypherShell shell) throws Exception {
+        // Default connection settings
+        shell.connect( new ConnectionConfig( "bolt://", "localhost", 7687, "neo4j", "neo", Encryption.DEFAULT, ABSENT_DB_NAME ) );
+        assumeTrue( majorVersion( shell.getServerVersion() ) < 4 );
+        shell.disconnect();
     }
 }

--- a/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellProtocolIntegrationTest.java
+++ b/cypher-shell/src/integration-test/java/org/neo4j/shell/commands/CypherShellProtocolIntegrationTest.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 import static org.neo4j.shell.DatabaseManager.ABSENT_DB_NAME;
 import static org.neo4j.shell.util.Versions.majorVersion;
+import static org.neo4j.shell.util.Versions.minorVersion;
 
 public class CypherShellProtocolIntegrationTest{
 
@@ -35,8 +36,8 @@ public class CypherShellProtocolIntegrationTest{
     @Test
     public void shouldConnectWithBoltSSCProtocol() throws Exception {
         CypherShell shell = new CypherShell( new StringLinePrinter(), new PrettyConfig( Format.PLAIN, true, 1000), false, new ShellParameterMap());
-        // Given 3.X series, where SSC are the default. Hard to test in 4.0 sadly.
-        onlyIn3x(shell);
+        // Given 3.X series where X > 1, where SSC are the default. Hard to test in 4.0 sadly.
+        onlyIn3_2to3_6( shell);
         shell.connect( new ConnectionConfig( "bolt+ssc://", "localhost", 7687, "neo4j", "neo", Encryption.DEFAULT, ABSENT_DB_NAME ) );
         assertTrue(shell.isConnected());
     }
@@ -44,8 +45,8 @@ public class CypherShellProtocolIntegrationTest{
     @Test
     public void shouldConnectWithNeo4jSSCProtocol() throws Exception {
         CypherShell shell = new CypherShell( new StringLinePrinter(), new PrettyConfig( Format.PLAIN, true, 1000), false, new ShellParameterMap());
-        // Given 3.X series, where SSC are the default. Hard to test in 4.0 sadly.
-        onlyIn3x(shell);
+        // Given 3.X series where X > 1, where SSC are the default. Hard to test in 4.0 sadly.
+        onlyIn3_2to3_6( shell);
         // This should work by falling back to bolt+ssc
         shell.connect( new ConnectionConfig( "neo4j+ssc://", "localhost", 7687, "neo4j", "neo", Encryption.DEFAULT, ABSENT_DB_NAME ) );
         assertTrue(shell.isConnected());
@@ -53,10 +54,11 @@ public class CypherShellProtocolIntegrationTest{
 
     // Here should be tests for "neo4j+s" and "bolt+s", but we don't have the infrastructure for those.
 
-    private void onlyIn3x(CypherShell shell) throws Exception {
+    private void onlyIn3_2to3_6( CypherShell shell) throws Exception {
         // Default connection settings
         shell.connect( new ConnectionConfig( "bolt://", "localhost", 7687, "neo4j", "neo", Encryption.DEFAULT, ABSENT_DB_NAME ) );
-        assumeTrue( majorVersion( shell.getServerVersion() ) < 4 );
+        assumeTrue( majorVersion( shell.getServerVersion() ) == 3 );
+        assumeTrue( minorVersion( shell.getServerVersion() )  > 1 );
         shell.disconnect();
     }
 }

--- a/cypher-shell/src/main/java/org/neo4j/shell/ConnectionConfig.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/ConnectionConfig.java
@@ -2,6 +2,8 @@ package org.neo4j.shell;
 
 import javax.annotation.Nonnull;
 
+import org.neo4j.shell.cli.Encryption;
+
 public class ConnectionConfig {
     public static final String USERNAME_ENV_VAR = "NEO4J_USERNAME";
     public static final String PASSWORD_ENV_VAR = "NEO4J_PASSWORD";
@@ -10,7 +12,7 @@ public class ConnectionConfig {
     private final String scheme;
     private final String host;
     private final int port;
-    private final boolean encryption;
+    private final Encryption encryption;
     private String username;
     private String password;
     private String newPassword;
@@ -21,7 +23,7 @@ public class ConnectionConfig {
                             int port,
                             @Nonnull String username,
                             @Nonnull String password,
-                            boolean encryption,
+                            Encryption encryption,
                             @Nonnull String database) {
         this.host = host;
         this.port = port;
@@ -78,7 +80,7 @@ public class ConnectionConfig {
     }
 
     @Nonnull
-    public boolean encryption() {
+    public Encryption encryption() {
         return encryption;
     }
 

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgHelper.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgHelper.java
@@ -96,7 +96,7 @@ public class CliArgHelper {
         if (!pass.isEmpty()) {
             cliArgs.setPassword(pass, cliArgs.getPassword());
         }
-        cliArgs.setEncryption(ns.getBoolean("encryption"));
+        cliArgs.setEncryption(Encryption.parse(ns.get("encryption")));
         cliArgs.setDatabase(ns.getString("database"));
         cliArgs.setInputFilename(ns.getString( "file" )  );
 
@@ -161,10 +161,15 @@ public class CliArgHelper {
                 .setDefault("")
                 .help("password to connect with. Can also be specified using environment variable " + ConnectionConfig.PASSWORD_ENV_VAR);
         connGroup.addArgument("--encryption")
-                .help("whether the connection to Neo4j should be encrypted; must be consistent with Neo4j's " +
-                        "configuration")
-                .type(new BooleanArgumentType())
-                .setDefault(false);
+                .help("whether the connection to Neo4j should be encrypted. This must be consistent with Neo4j's " +
+                      "configuration. If choosing " + Encryption.DEFAULT.name().toLowerCase() +
+                      " the encryption setting is deduced from the specified address. " +
+                      "For example the 'neo4j+ssc' protocol would use encryption.")
+                 .choices(new CollectionArgumentChoice<>(
+                         Encryption.TRUE.name().toLowerCase(),
+                         Encryption.FALSE.name().toLowerCase(),
+                         Encryption.DEFAULT.name().toLowerCase()))
+                 .setDefault(Encryption.DEFAULT.name().toLowerCase());
         connGroup.addArgument("-d", "--database")
                 .help("database to connect to. Can also be specified using environment variable " + ConnectionConfig.DATABASE_ENV_VAR)
                 .setDefault("");

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgHelper.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgHelper.java
@@ -162,8 +162,8 @@ public class CliArgHelper {
                 .help("password to connect with. Can also be specified using environment variable " + ConnectionConfig.PASSWORD_ENV_VAR);
         connGroup.addArgument("--encryption")
                 .help("whether the connection to Neo4j should be encrypted. This must be consistent with Neo4j's " +
-                      "configuration. If choosing " + Encryption.DEFAULT.name().toLowerCase() +
-                      " the encryption setting is deduced from the specified address. " +
+                      "configuration. If choosing '" + Encryption.DEFAULT.name().toLowerCase() +
+                      "' the encryption setting is deduced from the specified address. " +
                       "For example the 'neo4j+ssc' protocol would use encryption.")
                  .choices(new CollectionArgumentChoice<>(
                          Encryption.TRUE.name().toLowerCase(),

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgs.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgs.java
@@ -25,7 +25,7 @@ public class CliArgs {
     private Format format = Format.AUTO;
     @SuppressWarnings( "OptionalUsedAsFieldOrParameterType" )
     private Optional<String> cypher = Optional.empty();
-    private boolean encryption;
+    private Encryption encryption = Encryption.DEFAULT;
     private boolean debugMode;
     private boolean nonInteractive = false;
     private boolean version = false;
@@ -101,7 +101,7 @@ public class CliArgs {
     /**
      * Set whether the connection should be encrypted
      */
-    public void setEncryption(boolean encryption) {
+    public void setEncryption(Encryption encryption) {
         this.encryption = encryption;
     }
 
@@ -171,7 +171,7 @@ public class CliArgs {
         return format;
     }
 
-    public boolean getEncryption() {
+    public Encryption getEncryption() {
         return encryption;
     }
 

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/Encryption.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/Encryption.java
@@ -1,0 +1,20 @@
+package org.neo4j.shell.cli;
+
+import javax.annotation.Nonnull;
+
+public enum Encryption
+{
+    TRUE,
+    FALSE,
+    DEFAULT;
+
+    public static Encryption parse( @Nonnull String format) {
+        if (format.equalsIgnoreCase(TRUE.name())) {
+            return TRUE;
+        } else if (format.equalsIgnoreCase( FALSE.name() )) {
+            return FALSE;
+        } else {
+            return DEFAULT;
+        }
+    }
+}

--- a/cypher-shell/src/test/java/org/neo4j/shell/ConnectionConfigTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/ConnectionConfigTest.java
@@ -2,15 +2,14 @@ package org.neo4j.shell;
 
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+
+import org.neo4j.shell.cli.Encryption;
 import org.neo4j.shell.log.Logger;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.neo4j.shell.DatabaseManager.ABSENT_DB_NAME;
-
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
 
 public class ConnectionConfigTest {
 
@@ -20,7 +19,7 @@ public class ConnectionConfigTest {
 
     private Logger logger = mock(Logger.class);
     private ConnectionConfig config = new ConnectionConfig("bolt://", "localhost", 1, "bob",
-            "pass", false, "db");
+                                                           "pass", Encryption.DEFAULT, "db");
 
 
     @Test
@@ -47,7 +46,7 @@ public class ConnectionConfigTest {
     public void usernameDefaultsToEnvironmentVar() {
         environmentVariables.set(ConnectionConfig.USERNAME_ENV_VAR, "alice");
         ConnectionConfig configWithEmptyParams = new ConnectionConfig("bolt://", "localhost", 1, "",
-                                                                      "", false, ABSENT_DB_NAME);
+                                                                      "", Encryption.DEFAULT, ABSENT_DB_NAME);
         assertEquals("alice", configWithEmptyParams.username());
     }
 
@@ -60,7 +59,7 @@ public class ConnectionConfigTest {
     public void passwordDefaultsToEnvironmentVar() {
         environmentVariables.set(ConnectionConfig.PASSWORD_ENV_VAR, "ssap");
         ConnectionConfig configWithEmptyParams = new ConnectionConfig("bolt://", "localhost", 1, "",
-                                                                      "", false, ABSENT_DB_NAME);
+                                                                      "", Encryption.DEFAULT, ABSENT_DB_NAME);
         assertEquals("ssap", configWithEmptyParams.password());
     }
 
@@ -73,7 +72,7 @@ public class ConnectionConfigTest {
     public void databaseDefaultsToEnvironmentVar() {
         environmentVariables.set(ConnectionConfig.DATABASE_ENV_VAR, "funnyDB");
         ConnectionConfig configWithEmptyParams = new ConnectionConfig("bolt://", "localhost", 1, "",
-                                                                      "", false, ABSENT_DB_NAME);
+                                                                      "", Encryption.DEFAULT, ABSENT_DB_NAME);
         assertEquals("funnyDB", configWithEmptyParams.database());
     }
     @Test
@@ -83,7 +82,8 @@ public class ConnectionConfigTest {
 
     @Test
     public void encryption() {
-        assertTrue(new ConnectionConfig("bolt://", "", -1, "", "", true, ABSENT_DB_NAME).encryption());
-        assertFalse(new ConnectionConfig("bolt://", "", -1, "", "", false, ABSENT_DB_NAME).encryption());
+        assertEquals(Encryption.DEFAULT, new ConnectionConfig("bolt://", "", -1, "", "", Encryption.DEFAULT, ABSENT_DB_NAME).encryption());
+        assertEquals(Encryption.TRUE, new ConnectionConfig("bolt://", "", -1, "", "", Encryption.TRUE, ABSENT_DB_NAME).encryption());
+        assertEquals(Encryption.FALSE, new ConnectionConfig("bolt://", "", -1, "", "", Encryption.FALSE, ABSENT_DB_NAME).encryption());
     }
 }

--- a/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/CypherShellTest.java
@@ -13,6 +13,7 @@ import org.neo4j.driver.Record;
 import org.neo4j.driver.Session;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.summary.ResultSummary;
+import org.neo4j.shell.cli.Encryption;
 import org.neo4j.shell.commands.CommandExecutable;
 import org.neo4j.shell.commands.CommandHelper;
 import org.neo4j.shell.exception.CommandException;
@@ -62,7 +63,7 @@ public class CypherShellTest {
 
     @Test
     public void verifyDelegationOfConnectionMethods() throws CommandException {
-        ConnectionConfig cc = new ConnectionConfig("bolt://", "", 1, "", "", false, ABSENT_DB_NAME);
+        ConnectionConfig cc = new ConnectionConfig("bolt://", "", 1, "", "", Encryption.DEFAULT, ABSENT_DB_NAME);
         CypherShell shell = new CypherShell(logger, mockedBoltStateHandler, mockedPrettyPrinter, new ShellParameterMap());
 
         shell.connect(cc);

--- a/cypher-shell/src/test/java/org/neo4j/shell/MainTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/MainTest.java
@@ -16,6 +16,7 @@ import org.neo4j.driver.exceptions.AuthenticationException;
 import org.neo4j.driver.exceptions.Neo4jException;
 import org.neo4j.driver.exceptions.SecurityException;
 import org.neo4j.shell.cli.CliArgs;
+import org.neo4j.shell.cli.Encryption;
 import org.neo4j.shell.system.Utils;
 
 import static org.junit.Assert.assertEquals;
@@ -275,7 +276,7 @@ public class MainTest {
     @Test
     public void promptsForNewPasswordIfPasswordChangeRequired() throws Exception {
         // Use a real ConnectionConfig instead of the mock in this test
-        ConnectionConfig connectionConfig = new ConnectionConfig("", "", 0, "", "", false, "");
+        ConnectionConfig connectionConfig = new ConnectionConfig("", "", 0, "", "", Encryption.DEFAULT, "");
         doThrow(authException).doThrow(passwordChangeRequiredException).doNothing().when(shell).connect(connectionConfig, null);
 
         String inputString = "bob\nsecret\nnewsecret\n";
@@ -300,7 +301,7 @@ public class MainTest {
     @Test
     public void promptsForNewPasswordIfPasswordChangeRequiredCannotBeEmpty() throws Exception {
         // Use a real ConnectionConfig instead of the mock in this test
-        ConnectionConfig connectionConfig = new ConnectionConfig("", "", 0, "", "", false, "");
+        ConnectionConfig connectionConfig = new ConnectionConfig("", "", 0, "", "", Encryption.DEFAULT, "");
         doThrow(authException).doThrow(passwordChangeRequiredException).doNothing().when(shell).connect(connectionConfig, null);
 
         String inputString = "bob\nsecret\n\nnewsecret\n";

--- a/cypher-shell/src/test/java/org/neo4j/shell/cli/CliArgHelperTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/cli/CliArgHelperTest.java
@@ -196,6 +196,13 @@ public class CliArgHelperTest {
     }
 
     @Test
+    public void shouldNotAcceptInvalidEncryption() throws Exception  {
+        thrown.expect( ArgumentParserException.class );
+        thrown.expectMessage( containsString("argument --encryption: invalid choice: 'bugaluga' (choose from {true,false,default})"));
+        CliArgHelper.parseAndThrow("--encryption", "bugaluga");
+    }
+
+    @Test
     public void shouldParseSingleIntegerArgWithAddition() {
         CliArgs cliArgs = CliArgHelper.parse( "-P", "foo=>3+5" );
         assertNotNull( cliArgs );

--- a/cypher-shell/src/test/java/org/neo4j/shell/cli/CliArgHelperTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/cli/CliArgHelperTest.java
@@ -12,8 +12,8 @@ import java.util.ArrayList;
 import java.util.Optional;
 
 import static java.util.Arrays.asList;
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -185,14 +185,14 @@ public class CliArgHelperTest {
     }
 
     @Test
-    public void defaultsEncryptionToFalse() {
-        assertEquals(false, CliArgHelper.parse().getEncryption());
+    public void defaultsEncryptionToDefault() {
+        assertEquals(Encryption.DEFAULT, CliArgHelper.parse().getEncryption());
     }
 
     @Test
     public void allowsEncryptionToBeTurnedOnOrOff() {
-        assertEquals(true, CliArgHelper.parse("--encryption", "true").getEncryption());
-        assertEquals(false, CliArgHelper.parse("--encryption", "false").getEncryption());
+        assertEquals(Encryption.TRUE, CliArgHelper.parse("--encryption", "true").getEncryption());
+        assertEquals(Encryption.FALSE, CliArgHelper.parse("--encryption", "false").getEncryption());
     }
 
     @Test

--- a/cypher-shell/src/test/java/org/neo4j/shell/state/BoltStateHandlerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/state/BoltStateHandlerTest.java
@@ -20,12 +20,12 @@ import org.neo4j.driver.Session;
 import org.neo4j.driver.Value;
 import org.neo4j.driver.exceptions.ClientException;
 import org.neo4j.driver.exceptions.SessionExpiredException;
-import org.neo4j.driver.internal.DriverFactory;
 import org.neo4j.driver.summary.DatabaseInfo;
 import org.neo4j.driver.summary.ResultSummary;
 import org.neo4j.driver.summary.ServerInfo;
 import org.neo4j.shell.ConnectionConfig;
 import org.neo4j.shell.TriFunction;
+import org.neo4j.shell.cli.Encryption;
 import org.neo4j.shell.exception.CommandException;
 import org.neo4j.shell.log.Logger;
 import org.neo4j.shell.test.bolt.FakeDriver;
@@ -81,7 +81,7 @@ public class BoltStateHandlerTest {
             }
         };
         BoltStateHandler handler = new BoltStateHandler(provider, false);
-        ConnectionConfig config = new ConnectionConfig("bolt://", "", -1, "", "", false, ABSENT_DB_NAME);
+        ConnectionConfig config = new ConnectionConfig("bolt://", "", -1, "", "", Encryption.DEFAULT, ABSENT_DB_NAME);
         handler.connect(config);
 
         assertEquals("", handler.getServerVersion());
@@ -92,7 +92,7 @@ public class BoltStateHandlerTest {
         Driver driverMock = stubResultSummaryInAnOpenSession(mock(Result.class), mock(Session.class), "Neo4j/9.4.1-ALPHA");
 
         BoltStateHandler handler = new BoltStateHandler((s, authToken, config) -> driverMock, false);
-        ConnectionConfig config = new ConnectionConfig("bolt://", "", -1, "", "", false, ABSENT_DB_NAME);
+        ConnectionConfig config = new ConnectionConfig("bolt://", "", -1, "", "", Encryption.DEFAULT, ABSENT_DB_NAME);
         handler.connect(config);
 
         assertEquals("9.4.1-ALPHA", handler.getServerVersion());
@@ -104,7 +104,7 @@ public class BoltStateHandlerTest {
                 stubResultSummaryInAnOpenSession(mock(Result.class), mock(Session.class), "Neo4j/9.4.1-ALPHA", "my_default_db");
 
         BoltStateHandler handler = new BoltStateHandler((s, authToken, config) -> driverMock, false);
-        ConnectionConfig config = new ConnectionConfig("bolt://", "", -1, "", "", false, ABSENT_DB_NAME);
+        ConnectionConfig config = new ConnectionConfig("bolt://", "", -1, "", "", Encryption.DEFAULT, ABSENT_DB_NAME);
         handler.connect(config);
 
         assertEquals("my_default_db", handler.getActualDatabaseAsReportedByServer());
@@ -124,7 +124,7 @@ public class BoltStateHandlerTest {
                 .thenReturn(resultMock);
 
         BoltStateHandler handler = new BoltStateHandler((s, authToken, config) -> driverMock, false);
-        ConnectionConfig config = new ConnectionConfig("bolt://", "", -1, "", "", false, ABSENT_DB_NAME);
+        ConnectionConfig config = new ConnectionConfig("bolt://", "", -1, "", "", Encryption.DEFAULT, ABSENT_DB_NAME);
         handler.connect(config);
 
         try {
@@ -403,7 +403,7 @@ public class BoltStateHandlerTest {
     public void turnOffEncryptionIfRequested() throws CommandException {
         RecordingDriverProvider provider = new RecordingDriverProvider();
         BoltStateHandler handler = new BoltStateHandler(provider, false);
-        ConnectionConfig config = new ConnectionConfig("bolt://", "", -1, "", "", false, ABSENT_DB_NAME);
+        ConnectionConfig config = new ConnectionConfig("bolt://", "", -1, "", "", Encryption.DEFAULT, ABSENT_DB_NAME);
         handler.connect(config);
         assertFalse(provider.config.encrypted());
     }
@@ -412,7 +412,7 @@ public class BoltStateHandlerTest {
     public void turnOnEncryptionIfRequested() throws CommandException {
         RecordingDriverProvider provider = new RecordingDriverProvider();
         BoltStateHandler handler = new BoltStateHandler(provider, false);
-        ConnectionConfig config = new ConnectionConfig("bolt://", "", -1, "", "", true, ABSENT_DB_NAME);
+        ConnectionConfig config = new ConnectionConfig("bolt://", "", -1, "", "", Encryption.TRUE, ABSENT_DB_NAME);
         handler.connect(config);
         assertTrue(provider.config.encrypted());
     }
@@ -432,10 +432,52 @@ public class BoltStateHandlerTest {
             }
         };
         BoltStateHandler handler = new BoltStateHandler(provider, false);
-        ConnectionConfig config = new ConnectionConfig("neo4j://", "", -1, "", "", false, ABSENT_DB_NAME);
+        ConnectionConfig config = new ConnectionConfig("neo4j://", "", -1, "", "", Encryption.DEFAULT, ABSENT_DB_NAME);
         handler.connect(config);
 
         assertEquals("bolt", uriScheme[0]);
+    }
+
+    @Test
+    public void fallbackToBoltSSC() throws CommandException {
+        final String[] uriScheme = new String[1];
+        RecordingDriverProvider provider = new RecordingDriverProvider() {
+            @Override
+            public Driver apply(String uri, AuthToken authToken, Config config) {
+                uriScheme[0] = uri.substring(0, uri.indexOf(':'));
+                if (uriScheme[0].equals("neo4j+ssc")) {
+                    throw new org.neo4j.driver.exceptions.ServiceUnavailableException("Please fall back");
+                }
+                super.apply(uri, authToken, config);
+                return new FakeDriver();
+            }
+        };
+        BoltStateHandler handler = new BoltStateHandler(provider, false);
+        ConnectionConfig config = new ConnectionConfig("neo4j+ssc://", "", -1, "", "", Encryption.DEFAULT, ABSENT_DB_NAME);
+        handler.connect(config);
+
+        assertEquals("bolt+ssc", uriScheme[0]);
+    }
+
+    @Test
+    public void fallbackToBoltS() throws CommandException {
+        final String[] uriScheme = new String[1];
+        RecordingDriverProvider provider = new RecordingDriverProvider() {
+            @Override
+            public Driver apply(String uri, AuthToken authToken, Config config) {
+                uriScheme[0] = uri.substring(0, uri.indexOf(':'));
+                if (uriScheme[0].equals("neo4j+s")) {
+                    throw new org.neo4j.driver.exceptions.ServiceUnavailableException("Please fall back");
+                }
+                super.apply(uri, authToken, config);
+                return new FakeDriver();
+            }
+        };
+        BoltStateHandler handler = new BoltStateHandler(provider, false);
+        ConnectionConfig config = new ConnectionConfig("neo4j+s://", "", -1, "", "", Encryption.DEFAULT, ABSENT_DB_NAME);
+        handler.connect(config);
+
+        assertEquals("bolt+s", uriScheme[0]);
     }
 
     private Driver stubResultSummaryInAnOpenSession(Result resultMock, Session sessionMock, String version) {
@@ -471,7 +513,7 @@ public class BoltStateHandlerTest {
         }
 
         public void connect() throws CommandException {
-            connect(new ConnectionConfig("bolt://", "", 1, "", "", false, ABSENT_DB_NAME));
+            connect(new ConnectionConfig("bolt://", "", 1, "", "", Encryption.DEFAULT, ABSENT_DB_NAME));
         }
     }
 


### PR DESCRIPTION
This is achieved by not specifying an encryption setting in the driver,
if none has been explicitly set in Cypher Sell. The Driver would otherwise
throw an exception if +ssc or +s protocols are combined with manual set
encryption on or off.

cl:
This adds support for neo4j+s, neo4j+ssc, bolt+s, and bolt+ssc.