### PR TITLE
Provide USER_AGENT when connecting

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/state/BoltStateHandler.java
@@ -35,6 +35,7 @@ import org.neo4j.shell.Connector;
 import org.neo4j.shell.DatabaseManager;
 import org.neo4j.shell.TransactionHandler;
 import org.neo4j.shell.TriFunction;
+import org.neo4j.shell.build.Build;
 import org.neo4j.shell.exception.CommandException;
 import org.neo4j.shell.log.NullLogging;
 
@@ -46,6 +47,7 @@ import static org.neo4j.shell.util.Versions.majorVersion;
  */
 public class BoltStateHandler implements TransactionHandler, Connector, DatabaseManager {
     private final TriFunction<String, AuthToken, Config, Driver> driverProvider;
+    private static final String USER_AGENT = "neo4j-cypher-shell/v" + Build.version();
     protected Driver driver;
     Session session;
     private String version;
@@ -486,7 +488,9 @@ public class BoltStateHandler implements TransactionHandler, Connector, Database
     }
 
     private Driver getDriver(@Nonnull ConnectionConfig connectionConfig, @Nullable AuthToken authToken) {
-        Config.ConfigBuilder configBuilder = Config.builder().withLogging(NullLogging.NULL_LOGGING);
+        Config.ConfigBuilder configBuilder = Config.builder()
+                                                   .withLogging(NullLogging.NULL_LOGGING)
+                                                   .withUserAgent( USER_AGENT );
         switch(connectionConfig.encryption())
         {
         case TRUE:

--- a/cypher-shell/src/test/java/org/neo4j/shell/state/BoltStateHandlerTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/state/BoltStateHandlerTest.java
@@ -587,6 +587,21 @@ public class BoltStateHandlerTest {
         assertEquals("bolt+s", uriScheme[0]);
     }
 
+    @Test
+    public void provideUserAgentstring() throws CommandException {
+        RecordingDriverProvider provider = new RecordingDriverProvider() {
+            @Override
+            public Driver apply(String uri, AuthToken authToken, Config config) {
+                super.apply(uri, authToken, config);
+                return new FakeDriver();
+            }
+        };
+        BoltStateHandler handler = new BoltStateHandler(provider, false);
+        handler.connect(config);
+
+        assertTrue(provider.config.userAgent().startsWith( "neo4j-cypher-shell/v4.1" ));
+    }
+
     private Driver stubResultSummaryInAnOpenSession(Result resultMock, Session sessionMock, String version) {
         return stubResultSummaryInAnOpenSession(resultMock, sessionMock, version, DEFAULT_DEFAULT_DB_NAME);
     }


### PR DESCRIPTION
When connecting with bolt shell will use the user agen string `neo4j-cypher-shell/vX.X.X`