### PR TITLE
Fix issues with non-interactive mode prompting for new passwords

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/Main.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/Main.java
@@ -104,14 +104,18 @@ public class Main {
             if ( cliArgs.getCypher().isPresent() )
             {
                 // Can only prompt for password if input has not been redirected
-                connectMaybeInteractively( shell, connectionConfig, isInputInteractive(), isOutputInteractive(),
+                connectMaybeInteractively( shell, connectionConfig,
+                        !cliArgs.getNonInteractive() && isInputInteractive(),
+                        !cliArgs.getNonInteractive() && isOutputInteractive(),
                         () -> shell.execute( cliArgs.getCypher().get() ) );
                 return EXIT_SUCCESS;
             }
             else
             {
                 // Can only prompt for password if input has not been redirected
-                connectMaybeInteractively( shell, connectionConfig, isInputInteractive(), isOutputInteractive());
+                connectMaybeInteractively( shell, connectionConfig,
+                        !cliArgs.getNonInteractive() && isInputInteractive(),
+                        !cliArgs.getNonInteractive() && isOutputInteractive());
                 // Construct shellrunner after connecting, due to interrupt handling
                 ShellRunner shellRunner = ShellRunner.getShellRunner( cliArgs, shell, logger, connectionConfig );
                 CommandHelper commandHelper = new CommandHelper( logger, shellRunner.getHistorian(), shell );
@@ -173,7 +177,7 @@ public class Main {
                 promptForUsernameAndPassword(connectionConfig, outputInteractive);
                 didPrompt = true;
             } catch (Neo4jException e) {
-                if (isPasswordChangeRequiredException(e)) {
+                if (inputInteractive && isPasswordChangeRequiredException(e)) {
                     promptForPasswordChange(connectionConfig, outputInteractive);
                     shell.changePassword(connectionConfig);
                     didPrompt = true;

--- a/cypher-shell/src/test/java/org/neo4j/shell/MainTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/MainTest.java
@@ -63,7 +63,7 @@ public class MainTest {
         thrown.expectMessage("No text could be read, exiting");
 
         Main main = new Main(inputStream, out);
-        main.connectMaybeInteractively(shell, connectionConfig, true, true);
+        main.connectMaybeInteractively(shell, connectionConfig, true, true, true);
         verify(shell, times(1)).connect(connectionConfig, null);
     }
 
@@ -75,7 +75,7 @@ public class MainTest {
         thrown.expectMessage("bla");
 
         Main main = new Main(mock(InputStream.class), out);
-        main.connectMaybeInteractively(shell, connectionConfig, true, true);
+        main.connectMaybeInteractively(shell, connectionConfig, true, true, true);
         verify(shell, times(1)).connect(connectionConfig, null);
     }
 
@@ -90,7 +90,7 @@ public class MainTest {
         PrintStream ps = new PrintStream(baos);
 
         Main main = new Main(inputStream, ps);
-        main.connectMaybeInteractively(shell, connectionConfig, true, true);
+        main.connectMaybeInteractively(shell, connectionConfig, true, true, true);
 
         String out = new String(baos.toByteArray(), StandardCharsets.UTF_8);
 
@@ -124,7 +124,7 @@ public class MainTest {
 
         try {
             Main main = new Main();
-            main.connectMaybeInteractively(shell, connectionConfig, true, false);
+            main.connectMaybeInteractively(shell, connectionConfig, true, false, true);
 
             String out = new String(baos.toByteArray(), StandardCharsets.UTF_8);
 
@@ -151,7 +151,7 @@ public class MainTest {
         Main main = new Main(inputStream, ps);
 
         try {
-            main.connectMaybeInteractively(shell, connectionConfig, false, true);
+            main.connectMaybeInteractively(shell, connectionConfig, false, true, true);
             fail("Expected auth exception");
         } catch (AuthenticationException e) {
             verify(shell, times(1)).connect(connectionConfig, null);
@@ -170,7 +170,7 @@ public class MainTest {
         PrintStream ps = new PrintStream(baos);
 
         Main main = new Main(inputStream, ps);
-        main.connectMaybeInteractively(shell, connectionConfig, true, true);
+        main.connectMaybeInteractively(shell, connectionConfig, true, true, true);
 
         String out = new String(baos.toByteArray(), StandardCharsets.UTF_8);
 
@@ -203,7 +203,7 @@ public class MainTest {
 
         try {
             Main main = new Main();
-            main.connectMaybeInteractively(shell, connectionConfig, true, false);
+            main.connectMaybeInteractively(shell, connectionConfig, true, false, true);
 
             String out = new String(baos.toByteArray(), StandardCharsets.UTF_8);
 
@@ -227,7 +227,7 @@ public class MainTest {
         PrintStream ps = new PrintStream(baos);
 
         Main main = new Main(inputStream, ps);
-        main.connectMaybeInteractively(shell, connectionConfig, true, true);
+        main.connectMaybeInteractively(shell, connectionConfig, true, true, true);
 
         String out = new String(baos.toByteArray(), StandardCharsets.UTF_8);
 
@@ -260,7 +260,7 @@ public class MainTest {
 
         try {
             Main main = new Main();
-            main.connectMaybeInteractively(shell, connectionConfig, true, false);
+            main.connectMaybeInteractively(shell, connectionConfig, true, false, true);
 
             String out = new String(baos.toByteArray(), StandardCharsets.UTF_8);
 
@@ -286,7 +286,7 @@ public class MainTest {
         PrintStream ps = new PrintStream(baos);
 
         Main main = new Main(inputStream, ps);
-        main.connectMaybeInteractively(shell, connectionConfig, true, true);
+        main.connectMaybeInteractively(shell, connectionConfig, true, true, true);
 
         String out = new String(baos.toByteArray(), StandardCharsets.UTF_8);
 
@@ -311,7 +311,7 @@ public class MainTest {
         PrintStream ps = new PrintStream(baos);
 
         Main main = new Main(inputStream, ps);
-        main.connectMaybeInteractively(shell, connectionConfig, true, true);
+        main.connectMaybeInteractively(shell, connectionConfig, true, true, true);
 
         String out = new String(baos.toByteArray(), StandardCharsets.UTF_8);
 
@@ -334,7 +334,7 @@ public class MainTest {
         PrintStream ps = new PrintStream(baos);
 
         Main main = new Main(inputStream, ps);
-        main.connectMaybeInteractively(shell, connectionConfig, true, true);
+        main.connectMaybeInteractively(shell, connectionConfig, true, true, true);
 
         String out = new String(baos.toByteArray(), StandardCharsets.UTF_8);
 
@@ -358,7 +358,7 @@ public class MainTest {
         Main main = new Main(inputStream, ps);
 
         try {
-            main.connectMaybeInteractively(shell, connectionConfig, true, true);
+            main.connectMaybeInteractively(shell, connectionConfig, true, true, true);
             fail("Expected an exception");
         } catch (Neo4jException e) {
             assertEquals(authException.code(), e.code());
@@ -377,7 +377,7 @@ public class MainTest {
         PrintStream ps = new PrintStream(baos);
 
         Main main = new Main(inputStream, ps);
-        main.connectMaybeInteractively(shell, connectionConfig, true, true);
+        main.connectMaybeInteractively(shell, connectionConfig, true, true, true);
 
         String out = new String(baos.toByteArray(), StandardCharsets.UTF_8);
 
@@ -410,7 +410,7 @@ public class MainTest {
 
         try {
             Main main = new Main();
-            main.connectMaybeInteractively(shell, connectionConfig, true, false);
+            main.connectMaybeInteractively(shell, connectionConfig, true, false, true);
 
             String out = new String(baos.toByteArray(), StandardCharsets.UTF_8);
 


### PR DESCRIPTION
I found that if a 4.0/4.1 user had their account set to requiring a password change (for instance, after a fresh install), cypher-shell would still prompt for the new password when using `--non-interactive`.

This prevents safe usage via shell scripts, Ansible, etc. that will never send a newline to stdin causing the cypher-shell program to never exit.