### PR TITLE
Update java driver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ ext {
     argparse4jVersion = '0.7.0'
     junitVersion = '4.12'
     evaluatorVersion = '3.5.14'
-    neo4jJavaDriverVersion = '4.0.1'
+    neo4jJavaDriverVersion = '4.1.1'
     findbugsVersion = '3.0.0'
     jansiVersion = '1.13'
     jlineVersion = '2.14.6'


### PR DESCRIPTION
In 4.1 we are using driver 4.1 but in 4.2 we were using (an old) 4.0
driver. That feels wrong. Should there be a 4.2 driver?