### PR TITLE
Support host:port without scheme

### DIFF
--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgHelper.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgHelper.java
@@ -25,6 +25,7 @@ import org.neo4j.shell.ConnectionConfig;
 import org.neo4j.shell.ParameterMap;
 
 import static java.lang.String.format;
+import static org.neo4j.shell.cli.CliArgs.DEFAULT_SCHEME;
 import static org.neo4j.shell.cli.FailBehavior.FAIL_AT_END;
 import static org.neo4j.shell.cli.FailBehavior.FAIL_FAST;
 
@@ -152,6 +153,12 @@ public class CliArgHelper {
     {
         try
         {
+            String[] schemeSplit = address.split( "://" );
+            if ( schemeSplit.length == 1 )
+            {
+                // URI can't parse addresses without scheme, prepend fake "bolt://" to reuse the parsing facility
+                address = DEFAULT_SCHEME + "://" + address;
+            }
             return new URI( address );
         }
         catch ( URISyntaxException e )

--- a/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgs.java
+++ b/cypher-shell/src/main/java/org/neo4j/shell/cli/CliArgs.java
@@ -10,7 +10,7 @@ import org.neo4j.shell.ShellParameterMap;
 import static org.neo4j.shell.DatabaseManager.ABSENT_DB_NAME;
 
 public class CliArgs {
-    private static final String DEFAULT_SCHEME = "bolt";
+    static final String DEFAULT_SCHEME = "bolt";
     private static final String DEFAULT_HOST = "localhost";
     private static final int DEFAULT_PORT = 7687;
     static final int DEFAULT_NUM_SAMPLE_ROWS = 1000;

--- a/cypher-shell/src/test/java/org/neo4j/shell/cli/CliArgHelperTest.java
+++ b/cypher-shell/src/test/java/org/neo4j/shell/cli/CliArgHelperTest.java
@@ -155,6 +155,16 @@ public class CliArgHelperTest {
     }
 
     @Test
+    public void parseWithoutProtocol() {
+        CliArgs cliArgs = CliArgHelper.parse("--address", "localhost:10000");
+        assertNotNull(cliArgs);
+        assertNotNull(cliArgs);
+        assertEquals("bolt", cliArgs.getScheme());
+        assertEquals("localhost", cliArgs.getHost());
+        assertEquals(10000, cliArgs.getPort());
+    }
+
+    @Test
     public void parseAddressWithRoutingContext() {
         CliArgs cliArgs = CliArgHelper.parse("--address", "neo4j://localhost:7697?policy=one");
         assertNotNull(cliArgs);


### PR DESCRIPTION
We recently removed the homegrown big REGEX that handled parsing URIs,
however in the process we stopped supporting URIs like
`--address=localhost:10000`, where we provide a port but don't
 provide the scheme.