### PR TITLE
Prepare packaging for move to mono repo

### DIFF
--- a/packaging/bin/build-deb-package
+++ b/packaging/bin/build-deb-package
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -eu
+# build-deb-package:
+# Build Debian package for Neo4j Cypher Shell from jar distribution
+
+if [ $# -ne 4 ]
+then
+  echo "Usage: ${0} <jar-distribution-dir> <version> <distribution> <output-dir>"
+  exit 1
+fi
+
+jar_dist_dir=${1}
+version=${2}
+distribution=${3}
+output_dir=${4}
+deb_build_dir=${output_dir}/debian/cypher-shell-${version}
+
+echo "Building DEB package"
+echo "Output directory: ${output_dir}"
+echo "Version: ${version}"
+echo "Distribution: ${distribution}"
+echo "Jar distribution directory: ${jar_dist_dir}"
+
+mkdir -p ${deb_build_dir}/debian/
+mkdir -p ${deb_build_dir}/cypher-shell/build/install/cypher-shell/
+
+cp ${jar_dist_dir}/cypher-shell ${deb_build_dir}/cypher-shell/build/install/cypher-shell/cypher-shell
+cp ${jar_dist_dir}/cypher-shell.jar ${deb_build_dir}/cypher-shell/build/install/cypher-shell/cypher-shell.jar
+
+cp packaging/debian/cypher-shell.install ${deb_build_dir}/debian/cypher-shell.install
+cp packaging/debian/rules ${deb_build_dir}/debian/rules
+cp packaging/debian/compat ${deb_build_dir}/debian/compat
+cp packaging/debian/copyright ${deb_build_dir}/debian/copyright
+cp packaging/debian/control ${deb_build_dir}/debian/control
+cp packaging/debian/cypher-shell.manpages ${deb_build_dir}/debian/cypher-shell.manpages
+cp cypher-shell.1.md ${deb_build_dir}/cypher-shell.1.md
+
+VERSION=${version} DISTRIBUTION=${distribution} DATE=`date -R` envsubst '${VERSION} ${DISTRIBUTION} ${DATE}' < packaging/debian/changelog > ${deb_build_dir}/debian/changelog
+
+( cd ${deb_build_dir} && debuild -A -uc -us )
+cp ${output_dir}/debian/cypher-shell_4.1.0_all.deb ${output_dir}/cypher-shell_4.1.0_all.deb

--- a/packaging/bin/build-rpm-package
+++ b/packaging/bin/build-rpm-package
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -eu
+# build-rpm-package:
+# Build RPM package for Neo4j Cypher Shell from jar distribution
+
+if [ $# -ne 4 ]
+then
+  echo "Usage: ${0} <jar-distribution-dir> <version> <release> <output-dir>"
+  exit 1
+fi
+
+# We use realpath because rpmbuild gets confused otherwi
+jar_dist_dir=$(realpath ${1})
+version=${2}
+release=${3}
+output_dir=$(realpath ${4})
+cypher_shell_project_dir=$(realpath "$(dirname "$(dirname "$(dirname "$0")")")")
+spec_file_output=${output_dir}/rpm/SPECS/cypher-shell.spec
+
+echo "Building RPM package"
+echo "Version: ${version}"
+echo "Release: ${release}"
+echo "Output directory: ${output_dir}"
+echo "Jar distribution directory: ${jar_dist_dir}"
+
+mkdir -p ${output_dir}/rpm/SPECS/
+mkdir -p ${output_dir}/rpm/BUILD/cypher-shell/build/install/cypher-shell/
+mkdir -p ${output_dir}/rpm/BUILD/manpages
+
+VERSION=${version} RELEASE=${release} DATE=`date -R` envsubst '${VERSION} ${RELEASE}' < packaging/rpm/cypher-shell.spec > ${spec_file_output}
+
+cp ${jar_dist_dir}/cypher-shell ${output_dir}/rpm/BUILD/cypher-shell/build/install/cypher-shell/cypher-shell
+cp ${jar_dist_dir}/cypher-shell.bat ${output_dir}/rpm/BUILD/cypher-shell/build/install/cypher-shell/cypher-shell.bat
+cp ${jar_dist_dir}/cypher-shell.jar ${output_dir}/rpm/BUILD/cypher-shell/build/install/cypher-shell/cypher-shell.jar
+
+pandoc -s -o ${output_dir}/rpm/BUILD/manpages/cypher-shell.1 ${cypher_shell_project_dir}/cypher-shell.1.md
+gzip ${output_dir}/rpm/BUILD/manpages/*
+
+rpmbuild --define "_topdir ${output_dir}/rpm" -bb --clean ${spec_file_output}
+cp ${output_dir}/rpm/RPMS/noarch/cypher-shell-${version}-${release}.noarch.rpm ${output_dir}/cypher-shell-${version}-${release}.noarch.rpm

--- a/packaging/rpm/cypher-shell.spec
+++ b/packaging/rpm/cypher-shell.spec
@@ -24,9 +24,15 @@ of Neo4j.
 #make clean build
 
 %install
-rm -rf ${RPM_BUILD_ROOT}
-# Calls make with correct DESTDIR
-%make_install prefix=/usr
+rm -rf ${buildroot}
+
+mkdir -p %{buildroot}/%{_bindir}
+mkdir -p %{buildroot}/%{_datadir}/cypher-shell/lib
+mkdir -p %{buildroot}/%{_mandir}/man1
+
+install -m 0755 cypher-shell/build/install/cypher-shell/cypher-shell %{buildroot}/%{_bindir}
+install -m 0755 cypher-shell/build/install/cypher-shell/cypher-shell.jar %{buildroot}/%{_datadir}/cypher-shell/lib
+install -m 0644 manpages/* %{buildroot}/%{_mandir}/man1
 
 %clean
 rm -rf ${RPM_BUILD_ROOT}
@@ -35,4 +41,4 @@ rm -rf ${RPM_BUILD_ROOT}
 %defattr(-,root,root)
 %{_bindir}/cypher-shell
 %{_datadir}/cypher-shell
-%doc %{_mandir}/man1/cypher-shell.1.gz
+%doc %{_mandir}/man1/*

--- a/packaging/test/debian/Dockerfile
+++ b/packaging/test/debian/Dockerfile
@@ -1,9 +1,12 @@
-FROM debian:stretch
+FROM debian:stretch-backports
 ENV DEBIAN_FRONTEND noninteractive
 
 COPY ${DEBFILE} /tmp/
 
 RUN apt-get update -qq && \
+    # Because of a bug we need to install java before cypher-shell
+    # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=924897
+    apt-get install -y openjdk-11-jre-headless && \
     apt-get install -y --no-install-recommends /tmp/${DEBFILE}
 
 ENTRYPOINT ["/usr/bin/cypher-shell"]


### PR DESCRIPTION
- Start to align packaging to the way it is organised for the database (see https://github.com/neo-technology/neo4j/tree/4.3/private/new-packaging) to make the move to mono repo easier.
- Fix build failure in `make debian-test`.
- Fix missing man pages in rpm build.

## Tests

- Successful run of `make rpm-test`
- Successful run of `make debian-test`
- Running `man cypher-shell` from both the deb and rpm installations.