### PR TITLE
fixed URL pointing to private repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Contains Cypher Shell 1.1. __PLEASE NOTE!__ newer versions have moved to https://github.com/neo-technology/neo4j/tree/4.3/public/community/cypher-shell.
+Contains Cypher Shell 1.1. __PLEASE NOTE!__ newer versions have moved to https://github.com/neo4j/neo4j/tree/4.3/community/cypher-shell.
 
 ## How to build
 


### PR DESCRIPTION
repo's main README.md starts with :

> Contains Cypher Shell 1.1. PLEASE NOTE! newer versions have moved to https://github.com/neo-technology/neo4j/tree/4.3/public/community/cypher-shell.

... which is a private repository. It should point to the public repo : https://github.com/neo4j/neo4j/tree/4.3/community/cypher-shell